### PR TITLE
fix: replace uuid import with crypto.randomUUID in shared/observabili…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,6 @@
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
     "vaul": "^1.1.2",
     "xlsx": "^0.18.5",
     "zod": "^3.24.1"

--- a/shared/observability/trace.ts
+++ b/shared/observability/trace.ts
@@ -1,11 +1,9 @@
-import { v4 as uuidv4 } from 'uuid';
-
 let currentCorrelationId: string | null = null;
 
 export class TraceContext {
     static getCorrelationId(): string {
         if (!currentCorrelationId) {
-            currentCorrelationId = uuidv4() as string;
+            currentCorrelationId = crypto.randomUUID();
         }
         return currentCorrelationId!;
     }


### PR DESCRIPTION
…ty/trace.ts

Removes the uuid package dependency from shared code. crypto.randomUUID() is available in Node 14.17+ and all modern browsers.

## What does this PR do?
<!-- One paragraph max. Link to issue if applicable. -->


## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — refactor / cleanup / tooling
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only

## Packages affected
- [ ] `backend`
- [ ] `frontend`
- [ ] `admin-frontend`
- [ ] `shared`

## Test plan
<!-- How was this tested? Unit tests / manual steps / N/A -->


## Checklist
- [ ] `npm run type-check` passes locally
- [ ] `npm test` passes locally (backend)
- [ ] No `.env` or secret values committed
- [ ] No new `console.log` in `src/` (use `logger`)
