### PR TITLE
fix: typography, audit hardening, auth, error handling — 7-session batch

### DIFF
--- a/backend/src/controllers/ad/adMutationController.ts
+++ b/backend/src/controllers/ad/adMutationController.ts
@@ -144,13 +144,7 @@ export const deleteAd = async (req: Request, res: Response, next: NextFunction) 
             return sendClientError(req, res, 404, 'Ad not found', 'NOT_FOUND');
         }
 
-        const response = respond<ApiResponse<null>>({
-            success: true,
-            data: null,
-            message: 'Ad deleted successfully'
-        });
-
-        res.json(response);
+        res.status(204).end();
     } catch (error: unknown) {
         next(error);
     }

--- a/backend/src/controllers/auth/authController.ts
+++ b/backend/src/controllers/auth/authController.ts
@@ -6,7 +6,6 @@ import { verifyToken } from '../../utils/auth';
 import { respond, sendSuccessResponse } from '../../utils/respond';
 import { sendErrorResponse } from '../../utils/errorResponse';
 import { SendOtpResult, VerifyOtpResult } from '../../services/AuthService';
-
 import { env } from '../../config/env';
 
 const getAuthCookieOptions = (maxAge: number) => ({
@@ -27,17 +26,20 @@ export class AuthController {
         });
     }
 
-    private static normalizePhone(phone: string): string {
-        const cleaned = phone.replace(/\D/g, '');
+    private static parsePhone(req: Request, res: Response, phone: string): string | null {
+        const cleaned = (phone || '').replace(/\D/g, '');
         if (cleaned.length === 10) return cleaned;
         if (cleaned.length === 12 && cleaned.startsWith('91')) return cleaned.slice(2);
-        return cleaned.slice(-10);
+        // Invalid length — reject with 400 instead of silently truncating
+        sendErrorResponse(req, res, 400, 'Invalid phone number. Must be a 10-digit Indian mobile number.');
+        return null;
     }
 
     static async login(req: Request, res: Response, next: NextFunction) {
         try {
             const { mobile } = req.body;
-            const normalizedPhone = AuthController.normalizePhone(mobile);
+            const normalizedPhone = AuthController.parsePhone(req, res, mobile);
+            if (!normalizedPhone) return;
             const result = await AuthService.sendLoginOtp(normalizedPhone);
 
             if (!result.success) {
@@ -54,7 +56,8 @@ export class AuthController {
     static async verify(req: Request, res: Response, next: NextFunction) {
         try {
             const { mobile, otp, name } = req.body;
-            const normalizedPhone = AuthController.normalizePhone(mobile);
+            const normalizedPhone = AuthController.parsePhone(req, res, mobile);
+            if (!normalizedPhone) return;
             const result = await AuthService.verifyLoginOtp(normalizedPhone, otp, name);
 
             if (!result.success) {
@@ -77,7 +80,8 @@ export class AuthController {
     static async cancelOtp(req: Request, res: Response, next: NextFunction) {
         try {
             const { mobile } = req.body;
-            const normalizedPhone = AuthController.normalizePhone(mobile);
+            const normalizedPhone = AuthController.parsePhone(req, res, mobile);
+            if (!normalizedPhone) return;
             const result = await AuthService.cancelOtpSession(normalizedPhone);
             return sendSuccessResponse(res, result);
         } catch (error: unknown) {

--- a/backend/src/controllers/business/businessMutationController.ts
+++ b/backend/src/controllers/business/businessMutationController.ts
@@ -113,6 +113,27 @@ export const updateBusiness = async (req: Request, res: Response) => {
             delete filteredUpdates.phone;
         }
 
+        // Validate coordinates if provided
+        if (filteredUpdates.location !== undefined) {
+            const loc = filteredUpdates.location as Record<string, unknown> | undefined;
+            if (loc && loc.coordinates !== undefined) {
+                const coords = loc.coordinates;
+                const isValidCoords =
+                    Array.isArray(coords) &&
+                    coords.length === 2 &&
+                    typeof coords[0] === 'number' &&
+                    typeof coords[1] === 'number' &&
+                    coords[0] >= -180 && coords[0] <= 180 &&
+                    coords[1] >= -90 && coords[1] <= 90;
+                if (!isValidCoords) {
+                    sendErrorResponse(req, res, 400, 'Invalid coordinates. Longitude must be -180 to 180 and latitude -90 to 90.', {
+                        code: 'INVALID_COORDINATES'
+                    });
+                    return;
+                }
+            }
+        }
+
         // Note: Sensitive status mutation checks moved to `businessService.ts`.
 
         const updated = await businessService.updateBusinessById(id, filteredUpdates);

--- a/backend/src/controllers/service/serviceMutationController.ts
+++ b/backend/src/controllers/service/serviceMutationController.ts
@@ -612,13 +612,7 @@ export const deleteService = async (req: Request, res: Response) => {
         // 🛡️ Soft Delete
         await (service as unknown as { softDelete: () => Promise<void> }).softDelete();
 
-        const response = respond<ApiResponse<null>>({
-            success: true,
-            data: null,
-            message: 'Service deleted'
-        });
-
-        res.json(response);
+        res.status(204).end();
     } catch (error) {
         logger.error('Delete Service Error:', error);
         sendErrorResponse(req, res, 500, 'Failed to delete service');

--- a/backend/src/controllers/sparePartListingController.ts
+++ b/backend/src/controllers/sparePartListingController.ts
@@ -172,6 +172,9 @@ export const getSparePartListings = async (req: Request, res: Response) => {
     try {
         const { categoryId, typeId, status, page, limit, cursor, search, locationId, lat, lng, radiusKm } = req.query;
 
+        const parsedPage = Math.min(Number(page) || 1, 1000);
+        const parsedLimit = Math.min(Number(limit) || 20, 100);
+
         // Redirect to unified AdQueryService
         const result = await adService.getAds(
             {
@@ -186,8 +189,8 @@ export const getSparePartListings = async (req: Request, res: Response) => {
                 ...(radiusKm ? { radiusKm: Number(radiusKm) } : {}),
             },
             {
-                page: Number(page) || 1,
-                limit: Number(limit) || 20,
+                page: parsedPage,
+                limit: parsedLimit,
                 cursor: cursor as string
             },
             { enforcePublicVisibility: true }
@@ -297,7 +300,7 @@ export const deleteSparePartListing = async (req: Request, res: Response) => {
         if (!listing) return;
 
         await listing.softDelete();
-        res.status(200).json({ success: true, data: null, message: 'Spare part listing deleted.' });
+        res.status(204).end();
     } catch (error) {
         sendContractErrorResponse(req, res, 500, 'Failed to delete spare part listing');
     }

--- a/backend/src/controllers/sparePartListingController.ts
+++ b/backend/src/controllers/sparePartListingController.ts
@@ -172,8 +172,10 @@ export const getSparePartListings = async (req: Request, res: Response) => {
     try {
         const { categoryId, typeId, status, page, limit, cursor, search, locationId, lat, lng, radiusKm } = req.query;
 
-        const parsedPage = Math.min(Number(page) || 1, 1000);
-        const parsedLimit = Math.min(Number(limit) || 20, 100);
+        const requestedPage = Number(page) || 1;
+        const requestedLimit = Number(limit) || 20;
+        const parsedPage = Math.min(requestedPage, 1000);
+        const parsedLimit = Math.min(requestedLimit, 100);
 
         // Redirect to unified AdQueryService
         const result = await adService.getAds(
@@ -201,8 +203,10 @@ export const getSparePartListings = async (req: Request, res: Response) => {
             data: result.data as Array<Record<string, unknown>>,
             pagination: {
                 ...result.pagination,
-                page: result.pagination.page || 1,
-                limit: result.pagination.limit || 20,
+                page: parsedPage,
+                limit: parsedLimit,
+                ...(parsedLimit !== requestedLimit ? { clampedLimit: true } : {}),
+                ...(parsedPage !== requestedPage ? { clampedPage: true } : {}),
             }
         }));
     } catch (error) {

--- a/backend/src/controllers/user/userMutationController.ts
+++ b/backend/src/controllers/user/userMutationController.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
 import User, { IUser } from '../../models/User';
 import Business from '../../models/Business';
+import AdModel from '../../models/Ad';
 import BlockedUser from '../../models/BlockedUser';
 import * as userService from '../../services/UserService';
 import {
@@ -224,9 +225,22 @@ export const deleteMe = async (
       reason: combinedReason,
     });
 
+    // Cascade soft-delete to all user-owned listings and business
+    const deletedAt = new Date();
+    await Promise.all([
+      AdModel.updateMany(
+        { sellerId: userId, isDeleted: { $ne: true } },
+        { $set: { isDeleted: true, deletedAt } }
+      ),
+      Business.updateMany(
+        { userId, isDeleted: { $ne: true } },
+        { $set: { isDeleted: true, deletedAt } }
+      ),
+    ]);
+
     AuthService.clearUserSession(res);
 
-    sendSuccessResponse(res, null, 'Account deleted');
+    res.status(204).end();
     return;
   } catch (err) {
     next(err);

--- a/backend/src/controllers/user/userQueryController.ts
+++ b/backend/src/controllers/user/userQueryController.ts
@@ -36,13 +36,13 @@ export const getMe = async (
       return;
     }
 
-    const [user, business] = await Promise.all([
-      User.findById(userId)
-        .select('-password -salt')
-        .lean(),
+    const user = await User.findById(userId)
+      .select('-password -salt')
+      .lean();
 
-      Business.findOne({ userId }).lean(),
-    ]);
+    const business = user?.businessId
+      ? await Business.findOne({ userId }).lean()
+      : null;
 
     if (!user) {
       sendErrorResponse(req, res, 404, 'User not found');

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -146,7 +146,7 @@ export const protect = async (
         cacheKey,
         JSON.stringify({ status: userStatus, tokenVersion: storedTokenVersion }),
         'EX',
-        300
+        60
       );
     }
 

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -126,10 +126,7 @@ const buildCreateListingIdempotencyGuard = (scope: string) => async (req: Reques
                 return res.status(existing.responseStatus || 200).json(existing.responseBody);
             }
 
-            const recentlyUpdated =
-                existing.updatedAt &&
-                now.getTime() - new Date(existing.updatedAt).getTime() <= PROCESSING_LOCK_MS;
-            if (recentlyUpdated) {
+            if (existing.status === 'processing') {
                 logger.warn('Idempotency request already in progress', {
                     requestId: req.requestId,
                     userId,
@@ -142,7 +139,7 @@ const buildCreateListingIdempotencyGuard = (scope: string) => async (req: Reques
                     res,
                     429,
                     'IDEMPOTENCY_IN_PROGRESS',
-                    'A request with this idempotency key is already being processed.',
+                    'A request with this idempotency key is already being processed. Please retry with exponential backoff.',
                     {
                         idempotencyKey: key,
                         conflictType: 'IDEMPOTENCY',

--- a/backend/src/routes/adRoutes.ts
+++ b/backend/src/routes/adRoutes.ts
@@ -76,6 +76,9 @@ router.get("/:id/phone", validateObjectId, searchLimiter, listingController.getL
 // Repost expired/rejected ad (no Layer 2 equivalent — keep here)
 router.post("/:id/repost", validateObjectId, protect, mutationLimiter, idempotencyMiddleware, adController.repostAd);
 
+// Update ad
+router.patch("/:id", validateObjectId, protect, mutationLimiter, validateRequest(AdPayloadSchema as unknown as ZodTypeAny), adController.updateAd);
+
 // Delete ad
 router.delete("/:id", validateObjectId, protect, idempotencyMiddleware, adController.deleteAd);
 

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -66,7 +66,7 @@ const upload = createUploadMiddleware({
     errorLabel: 'image type'
 });
 
-router.get('/me', protect, userController.getMe);
+router.get('/me', protect, searchLimiter, userController.getMe);
 router.get('/:id/profile', validateObjectId, searchLimiter, userController.getUserProfileById);
 router.post('/:id/block', protect, validateObjectId, mutationLimiter, userController.blockUser);
 router.delete('/:id/block', protect, validateObjectId, mutationLimiter, userController.unblockUser);

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -150,9 +150,14 @@ const dispatchOtpSms = async (mobile: string, otp: string): Promise<void> => {
     if (env.NODE_ENV === 'test') return;
 
     // Static OTP bypass: skip SMS dispatch when USE_DEFAULT_OTP is enabled
+    // Guard: never activate in production even if env var is accidentally set
     if (env.USE_DEFAULT_OTP) {
-        logger.info('Static OTP fallback active — skipping SMS dispatch', { phone: mobile.slice(-4) });
-        return;
+        if (env.NODE_ENV === 'production') {
+            logger.error('[SECURITY] USE_DEFAULT_OTP is set in production — bypass is DISABLED. Remove this env var immediately.');
+        } else {
+            logger.info('Static OTP fallback active — skipping SMS dispatch', { phone: mobile.slice(-4) });
+            return;
+        }
     }
 
     if (!env.MSG91_AUTH_KEY || !env.MSG91_SENDER_ID) {
@@ -289,9 +294,11 @@ export class AuthService {
         }
 
         if (otpRecord.expiresAt < now) {
-            // DEV GRACE: If using default OTP in dev, allow expired records to persist for manual testing
+            // DEV GRACE: If using default OTP in dev/test, allow expired records to persist for manual testing
+            // Never active in production even if env var is set
             const isDevDefaultOtp =
                 env.USE_DEFAULT_OTP &&
+                env.NODE_ENV !== 'production' &&
                 otp === env.DEV_STATIC_OTP;
 
             if (!isDevDefaultOtp) {

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
 
             <intent-filter>

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -27,6 +27,11 @@ const config: CapacitorConfig = {
     CapacitorCookies: {
       enabled: true,
     },
+    Keyboard: {
+      resize: "body",
+      style: "default",
+      resizeOnFullScreen: true,
+    },
   },
 };
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -118,6 +118,9 @@ const nextConfig = {
         optimizePackageImports: [
             'lucide-react',
             'framer-motion',
+            'recharts',
+            'socket.io-client',
+            'xlsx',
         ],
     },
     images: {

--- a/frontend/src/app/(private)/account/business/apply/page.tsx
+++ b/frontend/src/app/(private)/account/business/apply/page.tsx
@@ -66,7 +66,7 @@ export default function BusinessApplyPage() {
             <div className="flex min-h-screen items-center justify-center px-4">
                 <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
                     <h1 className="text-lg font-semibold text-foreground">Unable to verify business status</h1>
-                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                    <p className="mt-2 text-sm leading-6 text-foreground-tertiary">
                         {mapErrorToMessage(businessError, "We couldn't verify your current business status. Try again.")}
                     </p>
                     <Button className="mt-5 w-full" onClick={() => retryBusiness()}>

--- a/frontend/src/app/(private)/business/edit/page.tsx
+++ b/frontend/src/app/(private)/business/edit/page.tsx
@@ -47,7 +47,7 @@ export default function BusinessEditPage() {
             <div className="flex min-h-[60vh] items-center justify-center px-4">
                 <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
                     <h1 className="text-lg font-semibold text-foreground">Unable to load business profile</h1>
-                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                    <p className="mt-2 text-sm leading-6 text-foreground-tertiary">
                         {mapErrorToMessage(businessError, "We couldn't load your business profile. Try again.")}
                     </p>
                     <Button className="mt-5 w-full" onClick={() => retryBusiness()}>

--- a/frontend/src/app/(private)/notifications/page.tsx
+++ b/frontend/src/app/(private)/notifications/page.tsx
@@ -1,5 +1,267 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import {
+    Bell,
+    Check,
+    ChevronRight,
+    Inbox,
+    Megaphone,
+    MessageCircleMore,
+    ShoppingBag,
+    Sparkles,
+    Tag,
+    type LucideIcon,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import type { NotificationTypeValue } from "@shared/enums/notificationType";
+
+import { queryKeys, useNotificationsQuery } from "@/hooks/queries";
+import { notificationApi, type Notification } from "@/lib/api/user/notifications";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+type NotificationMeta = {
+    label: string;
+    icon: LucideIcon;
+    iconTone: string;
+    badgeTone: string;
+};
+
+const NOTIFICATION_META: Record<NotificationTypeValue, NotificationMeta> = {
+    SYSTEM: {
+        label: "System",
+        icon: Megaphone,
+        iconTone: "text-foreground-secondary",
+        badgeTone: "border-slate-200 bg-slate-100 text-foreground-secondary",
+    },
+    CHAT: {
+        label: "Message",
+        icon: MessageCircleMore,
+        iconTone: "text-sky-700",
+        badgeTone: "border-sky-200 bg-sky-100 text-sky-700",
+    },
+    SMART_ALERT: {
+        label: "Smart alert",
+        icon: Sparkles,
+        iconTone: "text-amber-700",
+        badgeTone: "border-amber-200 bg-amber-100 text-amber-700",
+    },
+    AD_STATUS: {
+        label: "Listing",
+        icon: Tag,
+        iconTone: "text-violet-700",
+        badgeTone: "border-violet-200 bg-violet-100 text-violet-700",
+    },
+    BUSINESS_STATUS: {
+        label: "Business",
+        icon: Check,
+        iconTone: "text-emerald-700",
+        badgeTone: "border-emerald-200 bg-emerald-100 text-emerald-700",
+    },
+    ORDER_UPDATE: {
+        label: "Order",
+        icon: ShoppingBag,
+        iconTone: "text-link-dark",
+        badgeTone: "border-blue-200 bg-blue-100 text-link-dark",
+    },
+    PRICE_DROP: {
+        label: "Price drop",
+        icon: Tag,
+        iconTone: "text-rose-700",
+        badgeTone: "border-rose-200 bg-rose-100 text-rose-700",
+    },
+};
+
+function NotificationRow({
+    notification,
+    onSelect,
+    isProcessing,
+}: {
+    notification: Notification;
+    onSelect: (notification: Notification) => void;
+    isProcessing: boolean;
+}) {
+    const meta = NOTIFICATION_META[notification.type];
+    const Icon = meta.icon;
+    const relativeTime = formatDistanceToNow(new Date(notification.createdAt), { addSuffix: true });
+
+    return (
+        <button
+            type="button"
+            className={cn(
+                "w-full rounded-2xl border px-4 py-4 text-left transition",
+                notification.isRead
+                    ? "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50"
+                    : "border-blue-100 bg-blue-50/70 hover:border-blue-200 hover:bg-blue-50"
+            )}
+            onClick={() => onSelect(notification)}
+            disabled={isProcessing}
+        >
+            <div className="flex gap-4">
+                <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-slate-200 bg-white">
+                    <Icon className={cn("h-5 w-5", meta.iconTone)} />
+                </div>
+
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={meta.badgeTone}>
+                            {meta.label}
+                        </Badge>
+                        {!notification.isRead ? (
+                            <Badge variant="outline" className="border-blue-200 bg-blue-50 text-link-dark">
+                                New
+                            </Badge>
+                        ) : null}
+                    </div>
+
+                    <p className={cn("mt-2 text-sm", notification.isRead ? "font-medium text-foreground-secondary" : "font-semibold text-foreground")}>
+                        {notification.title}
+                    </p>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-foreground-tertiary">{notification.message}</p>
+
+                    <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                        <span>{relativeTime}</span>
+                        {notification.actionUrl ? (
+                            <span className="inline-flex items-center gap-1 font-medium text-foreground-secondary">
+                                Open
+                                <ChevronRight className="h-3 w-3" />
+                            </span>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        </button>
+    );
+}
 
 export default function NotificationsPage() {
-    redirect("/");
+    const router = useRouter();
+    const queryClient = useQueryClient();
+
+    const { data, isLoading } = useNotificationsQuery({ limit: 50 });
+
+    const notifications = data?.notifications ?? [];
+    const unreadCount = data?.unreadCount ?? 0;
+
+    const syncCaches = (updater: (c: typeof data) => typeof data) => {
+        queryClient.setQueriesData<typeof data>(
+            { queryKey: queryKeys.notifications.all },
+            (current) => (current ? updater(current) : current)
+        );
+    };
+
+    const markReadMutation = useMutation({
+        mutationFn: (id: string) => notificationApi.markRead(id),
+        onSuccess: (_r, id) => {
+            const now = new Date().toISOString();
+            syncCaches((current) => ({
+                ...current!,
+                notifications: current!.notifications.map((n) =>
+                    n.id === id ? { ...n, isRead: true, readAt: now } : n
+                ),
+                unreadCount: Math.max(0, (current!.unreadCount ?? 0) - 1),
+            }));
+        },
+    });
+
+    const markAllReadMutation = useMutation({
+        mutationFn: () => notificationApi.markAllRead(),
+        onSuccess: () => {
+            const now = new Date().toISOString();
+            syncCaches((current) => ({
+                ...current!,
+                notifications: current!.notifications.map((n) => ({ ...n, isRead: true, readAt: n.readAt || now })),
+                unreadCount: 0,
+            }));
+        },
+    });
+
+    const handleSelect = async (notification: Notification) => {
+        if (!notification.isRead) {
+            try {
+                await markReadMutation.mutateAsync(notification.id);
+            } catch {
+                /* ignore */
+            }
+        }
+        if (!notification.actionUrl) return;
+        try {
+            const url = new URL(notification.actionUrl, window.location.origin);
+            if (url.origin === window.location.origin) {
+                router.push(`${url.pathname}${url.search}${url.hash}`);
+            } else {
+                window.location.assign(url.toString());
+            }
+        } catch {
+            router.push(notification.actionUrl);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-slate-50">
+            <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+                <div className="mb-6 flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white border border-slate-200 shadow-sm">
+                            <Bell className="h-5 w-5 text-foreground-secondary" />
+                        </div>
+                        <div>
+                            <h1 className="text-xl font-bold text-foreground">Notifications</h1>
+                            {unreadCount > 0 ? (
+                                <p className="text-sm text-muted-foreground">{unreadCount} unread</p>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">All caught up</p>
+                            )}
+                        </div>
+                    </div>
+                    {unreadCount > 0 ? (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="rounded-full px-4 text-xs font-medium"
+                            onClick={() => markAllReadMutation.mutate()}
+                            disabled={markAllReadMutation.isPending}
+                        >
+                            Mark all read
+                        </Button>
+                    ) : null}
+                </div>
+
+                {isLoading ? (
+                    <div className="space-y-3">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                            <div key={i} className="h-24 rounded-2xl bg-white border border-slate-200 animate-pulse" />
+                        ))}
+                    </div>
+                ) : notifications.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-200 bg-white px-6 py-16 text-center">
+                        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-50 border border-slate-200">
+                            <Inbox className="h-6 w-6 text-foreground-subtle" />
+                        </div>
+                        <div className="space-y-1">
+                            <p className="text-base font-semibold text-foreground">No notifications yet</p>
+                            <p className="text-sm leading-6 text-muted-foreground max-w-xs">
+                                Updates about your listings, orders, and messages will appear here.
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        {notifications.map((notification) => (
+                            <NotificationRow
+                                key={notification.id}
+                                notification={notification}
+                                onSelect={handleSelect}
+                                isProcessing={markReadMutation.isPending}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
 }

--- a/frontend/src/app/(public)/about/page.tsx
+++ b/frontend/src/app/(public)/about/page.tsx
@@ -20,7 +20,7 @@ export default function AboutPage() {
         <InfoPage title="About Esparex">
             <div className="space-y-6 not-prose">
                 <div>
-                    <h2 className="text-base font-bold text-slate-800 mb-2">Who We Are</h2>
+                    <h2 className="text-base font-bold text-foreground-secondary mb-2">Who We Are</h2>
                     <p className="text-sm text-muted-foreground leading-relaxed">
                         Esparex is India&apos;s leading marketplace dedicated to electronics spare parts and repair services.
                         We bridge the gap between device owners, technicians, and spare part suppliers ensuring quality,
@@ -36,19 +36,19 @@ export default function AboutPage() {
                 </div>
 
                 <div>
-                    <h2 className="text-base font-bold text-slate-800 mb-3">Why Choose Us?</h2>
+                    <h2 className="text-base font-bold text-foreground-secondary mb-3">Why Choose Us?</h2>
                     <div className="space-y-2.5">
                         <div className="flex items-start gap-3 p-3.5 rounded-xl bg-slate-50 border border-slate-100">
                             <div className="h-2 w-2 rounded-full bg-blue-500 mt-1.5 flex-shrink-0" />
-                            <p className="text-sm text-slate-600 leading-relaxed"><span className="font-semibold text-slate-800">Verified Sellers:</span> We vet our business partners to ensure quality parts.</p>
+                            <p className="text-sm text-foreground-tertiary leading-relaxed"><span className="font-semibold text-foreground-secondary">Verified Sellers:</span> We vet our business partners to ensure quality parts.</p>
                         </div>
                         <div className="flex items-start gap-3 p-3.5 rounded-xl bg-slate-50 border border-slate-100">
                             <div className="h-2 w-2 rounded-full bg-green-500 mt-1.5 flex-shrink-0" />
-                            <p className="text-sm text-slate-600 leading-relaxed"><span className="font-semibold text-slate-800">Technician Network:</span> Find trusted repair experts in your locality.</p>
+                            <p className="text-sm text-foreground-tertiary leading-relaxed"><span className="font-semibold text-foreground-secondary">Technician Network:</span> Find trusted repair experts in your locality.</p>
                         </div>
                         <div className="flex items-start gap-3 p-3.5 rounded-xl bg-slate-50 border border-slate-100">
                             <div className="h-2 w-2 rounded-full bg-violet-500 mt-1.5 flex-shrink-0" />
-                            <p className="text-sm text-slate-600 leading-relaxed"><span className="font-semibold text-slate-800">Transparent Pricing:</span> No hidden costs, direct deals between buyers and sellers.</p>
+                            <p className="text-sm text-foreground-tertiary leading-relaxed"><span className="font-semibold text-foreground-secondary">Transparent Pricing:</span> No hidden costs, direct deals between buyers and sellers.</p>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/app/(public)/how-it-works/page.tsx
+++ b/frontend/src/app/(public)/how-it-works/page.tsx
@@ -22,21 +22,21 @@ export default function HowItWorksPage() {
                 <div className="flex items-start gap-4 p-4 rounded-2xl bg-blue-50 border border-blue-100">
                     <div className="h-9 w-9 rounded-xl bg-blue-600 flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">1</div>
                     <div>
-                        <h3 className="font-bold text-slate-800 text-sm mb-1">For Buyers</h3>
+                        <h3 className="font-bold text-foreground-secondary text-sm mb-1">For Buyers</h3>
                         <p className="text-sm text-muted-foreground leading-relaxed">Browse thousands of spare parts and services. Use our advanced filters to find parts compatible with your specific device model. Contact sellers directly to negotiate and arrange pickup or delivery.</p>
                     </div>
                 </div>
                 <div className="flex items-start gap-4 p-4 rounded-2xl bg-green-50 border border-green-100">
                     <div className="h-9 w-9 rounded-xl bg-green-600 flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">2</div>
                     <div>
-                        <h3 className="font-bold text-slate-800 text-sm mb-1">For Sellers</h3>
+                        <h3 className="font-bold text-foreground-secondary text-sm mb-1">For Sellers</h3>
                         <p className="text-sm text-muted-foreground leading-relaxed">List your spare parts in minutes. Take clear photos, describe the condition, and set your price. Manage all your listings and offers from your dashboard.</p>
                     </div>
                 </div>
                 <div className="flex items-start gap-4 p-4 rounded-2xl bg-violet-50 border border-violet-100">
                     <div className="h-9 w-9 rounded-xl bg-violet-600 flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">3</div>
                     <div>
-                        <h3 className="font-bold text-slate-800 text-sm mb-1">For Service Providers</h3>
+                        <h3 className="font-bold text-foreground-secondary text-sm mb-1">For Service Providers</h3>
                         <p className="text-sm text-muted-foreground leading-relaxed">Register your repair shop to get discovered by local customers. Showcase your expertise and services offered.</p>
                     </div>
                 </div>

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -42,7 +42,7 @@ export default function Error({
                 <h2 className="text-4xl font-bold text-foreground mb-4">
                     Oops! Something Went Wrong
                 </h2>
-                <p className="text-xl text-slate-600 mb-8">
+                <p className="text-xl text-foreground-tertiary mb-8">
                     We encountered an unexpected error. Don't worry, our team has been notified and we're working on it.
                 </p>
 
@@ -64,7 +64,7 @@ export default function Error({
                 {/* What Happened */}
                 <div className="bg-white rounded-lg shadow-md p-6 mb-8">
                     <h3 className="text-lg font-semibold mb-4">What Happened?</h3>
-                    <p className="text-slate-700 mb-4">
+                    <p className="text-foreground-secondary mb-4">
                         The application encountered an unexpected error while processing your request.
                         This could be due to a temporary issue or a bug in our system.
                     </p>
@@ -87,14 +87,14 @@ export default function Error({
                     </button>
                     <Link
                         href="/"
-                        className="inline-flex items-center justify-center gap-2 bg-white hover:bg-gray-50 text-slate-800 px-8 py-3 rounded-lg transition-colors font-semibold border-2 border-gray-300"
+                        className="inline-flex items-center justify-center gap-2 bg-white hover:bg-gray-50 text-foreground-secondary px-8 py-3 rounded-lg transition-colors font-semibold border-2 border-gray-300"
                     >
                         <Home size={20} />
                         <span>Go to Homepage</span>
                     </Link>
                     <Link
                         href="/contact"
-                        className="inline-flex items-center justify-center gap-2 bg-gray-100 hover:bg-gray-200 text-slate-800 px-8 py-3 rounded-lg transition-colors font-semibold"
+                        className="inline-flex items-center justify-center gap-2 bg-gray-100 hover:bg-gray-200 text-foreground-secondary px-8 py-3 rounded-lg transition-colors font-semibold"
                     >
                         <Mail size={20} />
                         <span>Contact Support</span>

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -33,7 +33,7 @@ export default function GlobalError({
                         <h1 className="text-4xl font-bold text-foreground mb-4">
                             Critical Error
                         </h1>
-                        <p className="text-xl text-slate-600 mb-8">
+                        <p className="text-xl text-foreground-tertiary mb-8">
                             A critical error occurred. Please try refreshing the page.
                         </p>
 
@@ -48,7 +48,7 @@ export default function GlobalError({
                             </button>
                             <Link
                                 href="/"
-                                className="inline-flex items-center justify-center gap-2 bg-white hover:bg-gray-50 text-slate-800 px-8 py-3 rounded-lg transition-colors font-semibold border-2 border-gray-300"
+                                className="inline-flex items-center justify-center gap-2 bg-white hover:bg-gray-50 text-foreground-secondary px-8 py-3 rounded-lg transition-colors font-semibold border-2 border-gray-300"
                             >
                                 <Home size={20} />
                                 <span>Go to Homepage</span>
@@ -89,7 +89,7 @@ export default function GlobalError({
             color: #111827;
           }
 
-          .text-slate-600 {
+          .text-foreground-tertiary {
             color: #4b5563;
           }
 
@@ -97,7 +97,7 @@ export default function GlobalError({
             color: #6b7280;
           }
 
-          .text-slate-800 {
+          .text-foreground-secondary {
             color: #1f2937;
           }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,20 +5,21 @@ import { cookies } from 'next/headers';
 import '../styles/globals.css';
 import { RootClientShell } from '@/components/providers/RootClientShell';
 
+// Preload only the normal weight — italic is rarely needed on first paint
 const inter = localFont({
-    src: [
-        {
-            path: '../../public/fonts/Inter-VariableFont_opsz,wght.ttf',
-            style: 'normal',
-        },
-        {
-            path: '../../public/fonts/Inter-Italic-VariableFont_opsz,wght.ttf',
-            style: 'italic',
-        },
-    ],
+    src: '../../public/fonts/Inter-VariableFont_opsz,wght.ttf',
     variable: '--font-inter',
     display: 'swap',
     preload: true,
+    style: 'normal',
+});
+
+const interItalic = localFont({
+    src: '../../public/fonts/Inter-Italic-VariableFont_opsz,wght.ttf',
+    variable: '--font-inter-italic',
+    display: 'swap',
+    preload: false,
+    style: 'italic',
 });
 
 export const metadata: Metadata = {
@@ -55,7 +56,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
 
     return (
         <html lang="en">
-            <body className={`${inter.variable} ${inter.className}`}>
+            <body className={`${inter.variable} ${interItalic.variable} ${inter.className}`}>
                 <RootClientShell initialHasAuthCookie={initialHasAuthCookie}>{children}</RootClientShell>
             </body>
         </html>

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -12,7 +12,7 @@ export default function Loading() {
                 <h2 className="text-xl font-semibold text-foreground mb-2">
                     Loading...
                 </h2>
-                <p className="text-slate-600">
+                <p className="text-foreground-tertiary">
                     Please wait while we load your content
                 </p>
 

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -55,7 +55,7 @@ export default function NotFound() {
                         </Link>
                         <Link
                             href="/search"
-                            className="group flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-700 px-8 py-4 rounded-2xl transition-all border-2 border-slate-200 shadow-sm active:scale-95 font-bold"
+                            className="group flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-foreground-secondary px-8 py-4 rounded-2xl transition-all border-2 border-slate-200 shadow-sm active:scale-95 font-bold"
                         >
                             <Search size={20} className="text-green-600" />
                             <span>Search Marketplace</span>
@@ -73,7 +73,7 @@ export default function NotFound() {
                             <Link
                                 key={link.label}
                                 href={link.href}
-                                className="text-slate-400 hover:text-green-600 text-sm font-semibold transition-colors"
+                                className="text-foreground-subtle hover:text-green-600 text-sm font-semibold transition-colors"
                             >
                                 {link.label}
                             </Link>
@@ -82,10 +82,10 @@ export default function NotFound() {
                 </div>
 
                 {/* Footer Note */}
-                <div className="mt-8 text-center text-slate-400">
+                <div className="mt-8 text-center text-foreground-subtle">
                     <Link
                         href="/"
-                        className="inline-flex items-center gap-2 hover:text-slate-600 transition-colors text-sm font-medium"
+                        className="inline-flex items-center gap-2 hover:text-foreground-tertiary transition-colors text-sm font-medium"
                     >
                         <ArrowLeft size={16} />
                         <span>Return to Main View</span>

--- a/frontend/src/components/business/BusinessPublicProfile.tsx
+++ b/frontend/src/components/business/BusinessPublicProfile.tsx
@@ -184,16 +184,16 @@ export function BusinessPublicProfile({
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <div>
                   <h1 className="text-2xl md:text-3xl font-bold text-foreground">{business.name}</h1>
-                  {business.tagline && <p className="text-sm text-slate-400 mt-0.5">{business.tagline}</p>}
+                  {business.tagline && <p className="text-sm text-foreground-subtle mt-0.5">{business.tagline}</p>}
                 </div>
-                <Button variant="outline" size="sm" onClick={handleShare} className="h-11 rounded-xl border-slate-200 text-slate-600 text-xs w-fit">
+                <Button variant="outline" size="sm" onClick={handleShare} className="h-11 rounded-xl border-slate-200 text-foreground-tertiary text-xs w-fit">
                   <Share2 className="mr-1.5 h-3.5 w-3.5" />
                   {shareLabel}
                 </Button>
               </div>
 
               <div className="flex flex-wrap gap-1.5">
-                <Badge variant="secondary" className="rounded-lg bg-slate-100 text-slate-600 border-none text-xs">{primaryBusinessType}</Badge>
+                <Badge variant="secondary" className="rounded-lg bg-slate-100 text-foreground-tertiary border-none text-xs">{primaryBusinessType}</Badge>
                 {business.isVerified ? (
                   <Badge className="bg-blue-50 text-link-dark border-none rounded-lg text-xs">Verified Business</Badge>
                 ) : null}
@@ -202,8 +202,8 @@ export function BusinessPublicProfile({
               {business.rating ? (
                 <div className="flex items-center gap-1 text-sm text-muted-foreground">
                   <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-                  <span className="font-semibold text-slate-700">{business.rating.toFixed(1)}</span>
-                  <span className="text-slate-400">({business.totalReviews || 0} reviews)</span>
+                  <span className="font-semibold text-foreground-secondary">{business.rating.toFixed(1)}</span>
+                  <span className="text-foreground-subtle">({business.totalReviews || 0} reviews)</span>
                 </div>
               ) : null}
             </div>
@@ -215,13 +215,13 @@ export function BusinessPublicProfile({
       {business.description ? (
         <Card className="rounded-2xl border-slate-100 shadow-none">
           <CardHeader className="pb-2 pt-4 px-4 md:px-6">
-            <CardTitle className="text-sm font-bold text-slate-700 uppercase tracking-wide">About</CardTitle>
+            <CardTitle className="text-sm font-bold text-foreground-secondary uppercase tracking-wide">About</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 px-4 md:px-6 pb-4">
             <p className="leading-relaxed text-sm text-muted-foreground">{business.description}</p>
             {business.website ? (
               <div className="flex items-center gap-2">
-                <Globe className="h-3.5 w-3.5 text-slate-400 flex-shrink-0" />
+                <Globe className="h-3.5 w-3.5 text-foreground-subtle flex-shrink-0" />
                 <a href={business.website} target="_blank" rel="noopener noreferrer" className="text-sm text-link hover:underline truncate">
                   {business.website}
                 </a>
@@ -236,7 +236,7 @@ export function BusinessPublicProfile({
       {/* Contact */}
       <Card className="rounded-2xl border-slate-100 shadow-none">
         <CardHeader className="pb-2 pt-4 px-4 md:px-6">
-          <CardTitle className="text-sm font-bold text-slate-700 uppercase tracking-wide">Contact</CardTitle>
+          <CardTitle className="text-sm font-bold text-foreground-secondary uppercase tracking-wide">Contact</CardTitle>
         </CardHeader>
         <CardContent className="px-4 md:px-6 pb-4">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -246,8 +246,8 @@ export function BusinessPublicProfile({
                   <Phone className="h-4 w-4 text-link" />
                 </div>
                 <div>
-                  <p className="text-2xs text-slate-400 font-bold uppercase tracking-wide">Phone</p>
-                  <a href={`tel:${business.mobile}`} className="text-sm font-semibold text-slate-800 hover:text-link">
+                  <p className="text-2xs text-foreground-subtle font-bold uppercase tracking-wide">Phone</p>
+                  <a href={`tel:${business.mobile}`} className="text-sm font-semibold text-foreground-secondary hover:text-link">
                     {business.mobile}
                   </a>
                 </div>
@@ -259,8 +259,8 @@ export function BusinessPublicProfile({
                   <Phone className="h-4 w-4 text-green-600" />
                 </div>
                 <div>
-                  <p className="text-2xs text-slate-400 font-bold uppercase tracking-wide">WhatsApp</p>
-                  <a href={buildWhatsappHref(business.whatsappNumber)} target="_blank" rel="noopener noreferrer" className="text-sm font-semibold text-slate-800 hover:text-green-600">
+                  <p className="text-2xs text-foreground-subtle font-bold uppercase tracking-wide">WhatsApp</p>
+                  <a href={buildWhatsappHref(business.whatsappNumber)} target="_blank" rel="noopener noreferrer" className="text-sm font-semibold text-foreground-secondary hover:text-green-600">
                     {business.whatsappNumber}
                   </a>
                 </div>
@@ -272,8 +272,8 @@ export function BusinessPublicProfile({
                   <Mail className="h-4 w-4 text-red-500" />
                 </div>
                 <div>
-                  <p className="text-2xs text-slate-400 font-bold uppercase tracking-wide">Email</p>
-                  <a href={`mailto:${business.email}`} className="text-sm font-semibold text-slate-800 hover:text-red-600 truncate block">
+                  <p className="text-2xs text-foreground-subtle font-bold uppercase tracking-wide">Email</p>
+                  <a href={`mailto:${business.email}`} className="text-sm font-semibold text-foreground-secondary hover:text-red-600 truncate block">
                     {business.email}
                   </a>
                 </div>
@@ -286,8 +286,8 @@ export function BusinessPublicProfile({
       {/* Location */}
       <Card className="rounded-2xl border-slate-100 shadow-none">
         <CardHeader className="pb-2 pt-4 px-4 md:px-6">
-          <CardTitle className="text-sm font-bold text-slate-700 uppercase tracking-wide flex items-center gap-2">
-            <MapPin className="h-4 w-4 text-slate-400" />
+          <CardTitle className="text-sm font-bold text-foreground-secondary uppercase tracking-wide flex items-center gap-2">
+            <MapPin className="h-4 w-4 text-foreground-subtle" />
             Location
           </CardTitle>
         </CardHeader>
@@ -304,13 +304,13 @@ export function BusinessPublicProfile({
               <div className="h-12 w-12 rounded-2xl bg-blue-50 flex items-center justify-center">
                 <MapPin className="h-6 w-6 text-link" />
               </div>
-              <p className="text-sm font-semibold text-slate-700">
+              <p className="text-sm font-semibold text-foreground-secondary">
                 {mapData.addressQuery || "Address details are available above."}
               </p>
             </div>
             {mapData.externalUrl ? (
               <div className="flex items-center justify-between border-t border-slate-100 bg-white px-4 py-3">
-                <p className="text-xs text-slate-400">View on Google Maps</p>
+                <p className="text-xs text-foreground-subtle">View on Google Maps</p>
                 <a href={mapData.externalUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs font-semibold text-link hover:underline">
                   Open in Maps <ExternalLink className="h-3.5 w-3.5" />
                 </a>
@@ -331,7 +331,7 @@ export function BusinessPublicProfile({
                 className={`-mb-px flex min-h-[44px] items-center gap-1.5 border-b-2 px-3 py-2.5 text-sm font-semibold transition-colors whitespace-nowrap ${
                   activeTab === tab.key
                     ? "border-blue-600 text-link"
-                    : "border-transparent text-slate-400 hover:text-slate-600"
+                    : "border-transparent text-foreground-subtle hover:text-foreground-tertiary"
                 }`}
                 type="button"
               >
@@ -357,14 +357,14 @@ export function BusinessPublicProfile({
               })}
             </div>
           ) : (
-            <p className="py-10 text-center text-sm text-slate-400">
+            <p className="py-10 text-center text-sm text-foreground-subtle">
               No {activeTab === "ads" ? "listings" : activeTab === "services" ? "services" : "spare parts"} available.
             </p>
           )}
         </div>
       ) : (
         <Card className="rounded-2xl border-slate-100 shadow-none">
-          <CardContent className="py-12 text-center text-sm text-slate-400">
+          <CardContent className="py-12 text-center text-sm text-foreground-subtle">
             This business does not have any live public listings yet.
           </CardContent>
         </Card>

--- a/frontend/src/components/business/BusinessStatusBanner.tsx
+++ b/frontend/src/components/business/BusinessStatusBanner.tsx
@@ -55,7 +55,7 @@ export function BusinessStatusBanner({ status, rejectionReason, onAction }: Busi
                 </div>
                 <div className="flex-1 space-y-1">
                     <h3 className={`font-bold text-sm ${current.textColor}`}>{current.title}</h3>
-                    <p className="text-xs text-slate-600 leading-relaxed max-w-2xl">
+                    <p className="text-xs text-foreground-tertiary leading-relaxed max-w-2xl">
                         {current.description}
                     </p>
                 </div>

--- a/frontend/src/components/catalog/CatalogSlugPage.tsx
+++ b/frontend/src/components/catalog/CatalogSlugPage.tsx
@@ -87,16 +87,16 @@ export function CatalogSlugPage({
             <h1 className="text-4xl font-black tracking-tight text-foreground sm:text-5xl">
               {config.heading(record.name)}
             </h1>
-            <p className="text-base leading-7 text-slate-600 sm:text-lg">
+            <p className="text-base leading-7 text-foreground-tertiary sm:text-lg">
               {config.description(record.name, record.contextLabel)}
             </p>
             {record.contextLabel ? (
               <p className="text-sm font-medium text-muted-foreground">
-                Connected to <span className="text-slate-800">{record.contextLabel}</span>
+                Connected to <span className="text-foreground-secondary">{record.contextLabel}</span>
               </p>
             ) : null}
             <div className="flex flex-wrap items-center gap-3 pt-2">
-              <div className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700">
+              <div className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-foreground-secondary">
                 {total} live result{total === 1 ? "" : "s"}
               </div>
               <Button asChild className="rounded-full px-5">

--- a/frontend/src/components/chat/AccountMessagesWorkspace.tsx
+++ b/frontend/src/components/chat/AccountMessagesWorkspace.tsx
@@ -51,7 +51,7 @@ export function AccountMessagesWorkspace({
             <p className="text-sm font-semibold text-red-600">Unable to load this conversation right now.</p>
             <button
               type="button"
-              className="mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700"
+              className="mt-4 inline-flex min-h-11 items-center justify-center rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-foreground-secondary"
               onClick={() => {
                 router.refresh();
               }}

--- a/frontend/src/components/common/CookieConsentBanner.tsx
+++ b/frontend/src/components/common/CookieConsentBanner.tsx
@@ -50,7 +50,7 @@ export function CookieConsentBanner() {
                         <div className="h-9 w-9 rounded-xl bg-green-50 flex items-center justify-center shrink-0">
                             <ShieldCheck className="h-4 w-4 text-green-600" />
                         </div>
-                        <p className="text-sm text-slate-600 leading-relaxed">
+                        <p className="text-sm text-foreground-tertiary leading-relaxed">
                             We use essential cookies to keep you logged in and secure your account. Optional cookies help track ad view counts.{" "}
                             <Link
                                 href="/privacy"
@@ -68,7 +68,7 @@ export function CookieConsentBanner() {
                             variant="outline"
                             size="sm"
                             onClick={handleDecline}
-                            className="flex-1 sm:flex-none h-11 text-slate-600 border-slate-200 hover:bg-slate-50"
+                            className="flex-1 sm:flex-none h-11 text-foreground-tertiary border-slate-200 hover:bg-slate-50"
                         >
                             Decline Optional
                         </Button>

--- a/frontend/src/components/common/Footer.tsx
+++ b/frontend/src/components/common/Footer.tsx
@@ -88,7 +88,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
             compact
                 ? "inline-flex items-center text-sm transition-colors"
                 : "inline-flex min-h-10 items-center text-left text-sm transition-colors md:min-h-0",
-            isDark ? "hover:text-primary text-slate-400" : "hover:text-green-600 text-slate-600"
+            isDark ? "hover:text-primary text-foreground-subtle" : "hover:text-green-600 text-foreground-tertiary"
         );
 
         if (onNavigate) {
@@ -127,8 +127,8 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
                     const classes = cn(
                         "inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm transition-colors",
                         isDark
-                            ? "border-slate-800 bg-slate-900/70 text-slate-300 hover:border-primary/30 hover:text-white"
-                            : "border-slate-200 bg-white text-slate-600 hover:border-green-200 hover:text-green-700"
+                            ? "border-slate-800 bg-slate-900/70 text-foreground-subtle hover:border-primary/30 hover:text-white"
+                            : "border-slate-200 bg-white text-foreground-tertiary hover:border-green-200 hover:text-green-700"
                     );
 
                     if (href.startsWith("mailto:")) {
@@ -149,7 +149,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
                 })}
             </div>
             {!compact && (
-                <p className={cn("text-xs uppercase tracking-[0.2em] font-bold", isDark ? "text-slate-600" : "text-slate-400")}>
+                <p className={cn("text-xs uppercase tracking-[0.2em] font-bold", isDark ? "text-foreground-tertiary" : "text-foreground-subtle")}>
                     India's Leading Spare Parts Exchange
                 </p>
             )}
@@ -163,7 +163,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
                 hasMobileBottomNav
                     ? "pt-6 pb-[calc(6.75rem+env(safe-area-inset-bottom))] md:py-12"
                     : "py-6 md:py-12",
-                isDark ? "bg-slate-950 border-slate-900 text-slate-400" : "bg-slate-50 border-slate-200 text-slate-600",
+                isDark ? "bg-slate-950 border-slate-900 text-foreground-subtle" : "bg-slate-50 border-slate-200 text-foreground-tertiary",
                 className
             )}
         >
@@ -180,7 +180,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
                                     isDark ? "border-slate-800 bg-slate-900/60" : "border-slate-200 bg-white"
                                 )}
                             >
-                                <p className={cn("text-xs font-semibold uppercase tracking-[0.16em]", isDark ? "text-slate-300" : "text-muted-foreground")}>
+                                <p className={cn("text-xs font-semibold uppercase tracking-[0.16em]", isDark ? "text-foreground-subtle" : "text-muted-foreground")}>
                                     {section.title}
                                 </p>
                                 <ul className="mt-3 space-y-2">
@@ -204,7 +204,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
 
                     {FOOTER_LINK_SECTIONS.map((section) => (
                         <div key={section.title} className="col-span-1 text-left">
-                            <h3 className={cn("mb-2 md:mb-4 font-semibold uppercase tracking-wider text-2xs md:text-xs", isDark ? "text-slate-300" : "text-foreground")}>
+                            <h3 className={cn("mb-2 md:mb-4 font-semibold uppercase tracking-wider text-2xs md:text-xs", isDark ? "text-foreground-subtle" : "text-foreground")}>
                                 {section.title}
                             </h3>
                             <ul className="space-y-0.5 md:space-y-2">
@@ -260,7 +260,7 @@ export function Footer({ theme = "light", onNavigate, className }: FooterProps) 
                             © {currentYear} Esparex Platform. Built for the future of tech repair.
                         </span>
                     </div>
-                    <p className={cn("text-left text-2xs uppercase tracking-[0.2em] font-bold", isDark ? "text-slate-600" : "text-slate-400")}>
+                    <p className={cn("text-left text-2xs uppercase tracking-[0.2em] font-bold", isDark ? "text-foreground-tertiary" : "text-foreground-subtle")}>
                         India's Leading Spare Parts Exchange
                     </p>
                 </div>

--- a/frontend/src/components/common/InfoPage.tsx
+++ b/frontend/src/components/common/InfoPage.tsx
@@ -12,7 +12,7 @@ export function InfoPage({ title, lastUpdated, children }: InfoPageProps) {
                     <div className="mb-6 md:mb-8 not-prose border-b border-slate-100 pb-5">
                         <h1 className="text-xl md:text-2xl font-bold tracking-tight text-foreground">{title}</h1>
                         {lastUpdated && (
-                            <p className="mt-1.5 text-xs text-slate-400 font-medium">Last updated: {lastUpdated}</p>
+                            <p className="mt-1.5 text-xs text-foreground-subtle font-medium">Last updated: {lastUpdated}</p>
                         )}
                     </div>
                     {children}

--- a/frontend/src/components/home/BusinessQuickActions.tsx
+++ b/frontend/src/components/home/BusinessQuickActions.tsx
@@ -38,7 +38,7 @@ export function BusinessQuickActions() {
 
     return (
         <div className="bg-white border-b border-slate-100 px-4 py-3 md:hidden">
-            <p className="text-2xs font-bold text-slate-400 uppercase tracking-widest mb-2">
+            <p className="text-2xs font-bold text-foreground-subtle uppercase tracking-widest mb-2">
                 Quick Actions
             </p>
             <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-1">

--- a/frontend/src/components/home/CategoryBrowser.tsx
+++ b/frontend/src/components/home/CategoryBrowser.tsx
@@ -41,7 +41,7 @@ export function CategoryBrowser({ categories }: CategoryBrowserProps) {
                     <h2 id="browse-categories" className="text-base font-bold md:text-2xl text-foreground tracking-tight">
                         Browse Categories
                     </h2>
-                    <p className="mt-1 text-slate-400 text-xs hidden md:block">
+                    <p className="mt-1 text-foreground-subtle text-xs hidden md:block">
                         Explore diverse categories to find exactly what you need.
                     </p>
                 </div>

--- a/frontend/src/components/home/HomeFeed.tsx
+++ b/frontend/src/components/home/HomeFeed.tsx
@@ -123,7 +123,7 @@ export function HomeFeed({ initialData }: HomeFeedProps) {
                     >
                         Recommended for You
                     </h2>
-                    <p className="mt-1 text-xs md:text-base text-slate-400 max-w-2xl hidden md:block">
+                    <p className="mt-1 text-xs md:text-base text-foreground-subtle max-w-2xl hidden md:block">
                         Spotlight, boosted, and latest listings curated for your location.
                     </p>
                 </div>
@@ -149,7 +149,7 @@ export function HomeFeed({ initialData }: HomeFeedProps) {
 
                 {!isLoading && !isError && recommendedAds.length === 0 && (
                     <div className="rounded-xl border border-slate-200 bg-slate-50 p-10 text-center">
-                        <PackageOpen className="mx-auto h-10 w-10 text-slate-300" />
+                        <PackageOpen className="mx-auto h-10 w-10 text-foreground-subtle" />
                         <p className="mt-3 text-sm text-muted-foreground">
                             No ads available right now.
                         </p>

--- a/frontend/src/components/location/useLocationSearch.ts
+++ b/frontend/src/components/location/useLocationSearch.ts
@@ -1,3 +1,5 @@
+const LOCATION_SEARCH_DEBOUNCE_MS = 300;
+
 import { useState, useEffect, useRef, useCallback } from "react";
 import { searchLocations, type Location } from "@/lib/api/user/locations";
 import { getCurrentLocationResult } from "@/lib/location/locationService";
@@ -145,7 +147,7 @@ export function useLocationSearch({
                 setIsSearching(false);
                 setShowSkeleton(false);
             }
-        }, 300);
+        }, LOCATION_SEARCH_DEBOUNCE_MS);
 
         return () => {
             clearTimeout(debounce);

--- a/frontend/src/components/mobile/MobileHeader.tsx
+++ b/frontend/src/components/mobile/MobileHeader.tsx
@@ -97,12 +97,12 @@ export default function MobileHeader({ navigateTo, isLoggedIn, isAuthLoading = f
                         title={headerLocationDetails.tooltipText || resolvedHeaderLocation}
                     >
                         <MapPin className="h-3.5 w-3.5 text-blue-500 mr-1.5 flex-shrink-0" />
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-600">
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground-tertiary">
                             <span className={`block transition-opacity duration-200 ${isMounted ? "opacity-100" : "opacity-0"}`}>
                                 {isMounted ? (resolvedHeaderLocation || "India") : "India"}
                             </span>
                         </span>
-                        <ChevronDown className="h-3.5 w-3.5 text-slate-400 ml-1.5 flex-shrink-0" />
+                        <ChevronDown className="h-3.5 w-3.5 text-foreground-subtle ml-1.5 flex-shrink-0" />
                     </button>
                 </div>
 
@@ -120,7 +120,7 @@ export default function MobileHeader({ navigateTo, isLoggedIn, isAuthLoading = f
                     <Button
                         variant="ghost"
                         size="icon"
-                        className="h-11 w-11 rounded-xl -ml-1 hover:bg-slate-100 text-slate-700"
+                        className="h-11 w-11 rounded-xl -ml-1 hover:bg-slate-100 text-foreground-secondary"
                         aria-label="Open navigation menu"
                         onClick={() => setIsOpen(true)}
                     >
@@ -135,16 +135,16 @@ export default function MobileHeader({ navigateTo, isLoggedIn, isAuthLoading = f
                             className="flex min-w-0 flex-1 items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-left"
                             aria-label={`Current search: ${stickySearchLabel}`}
                         >
-                            <Search className="h-4 w-4 shrink-0 text-slate-400" />
-                            <span className="truncate text-sm font-medium text-slate-700">
+                            <Search className="h-4 w-4 shrink-0 text-foreground-subtle" />
+                            <span className="truncate text-sm font-medium text-foreground-secondary">
                                 {stickySearchLabel}
                             </span>
                         </button>
                     ) : (
                         <form onSubmit={handleSearchSubmit} className="flex-1 relative">
-                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-foreground-subtle" />
                             <Input
-                                className="w-full pl-9 h-11 bg-slate-100 border-transparent focus:bg-white focus:border-blue-300 focus:ring-2 focus:ring-blue-100 transition-all rounded-xl text-sm placeholder:text-slate-400"
+                                className="w-full pl-9 h-11 bg-slate-100 border-transparent focus:bg-white focus:border-blue-300 focus:ring-2 focus:ring-blue-100 transition-all rounded-xl text-sm placeholder:text-foreground-subtle"
                                 placeholder="Search listings..."
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/frontend/src/components/mobile/MobileNavDrawer.tsx
+++ b/frontend/src/components/mobile/MobileNavDrawer.tsx
@@ -70,7 +70,7 @@ export function MobileNavDrawer({
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="font-bold text-base text-white truncate">{user?.name}</p>
-                  <p className="text-xs text-slate-400 mt-0.5">View profile</p>
+                  <p className="text-xs text-foreground-subtle mt-0.5">View profile</p>
                 </div>
               </div>
             ) : (
@@ -78,7 +78,7 @@ export function MobileNavDrawer({
                 <div>
                   <Image src="/icons/logo.png" alt="Esparex" width={512} height={206} style={{ height: '36px', width: 'auto' }} className="mb-3" />
                   <h2 className="text-lg font-bold text-white">Welcome to Esparex</h2>
-                  <p className="text-xs text-slate-400 mt-0.5">Buy & sell mobile spares</p>
+                  <p className="text-xs text-foreground-subtle mt-0.5">Buy & sell mobile spares</p>
                 </div>
                 {!isAuthLoading ? (
                   <Button
@@ -89,7 +89,7 @@ export function MobileNavDrawer({
                     <LogIn className="h-4 w-4" /> Login / Sign Up
                   </Button>
                 ) : (
-                  <p className="text-sm text-slate-400">Checking session...</p>
+                  <p className="text-sm text-foreground-subtle">Checking session...</p>
                 )}
               </div>
             )}
@@ -97,7 +97,7 @@ export function MobileNavDrawer({
 
           {/* Nav Items */}
           <div className="flex-1 overflow-y-auto px-3 py-4 space-y-0.5">
-            <p className="px-3 text-2xs font-bold text-slate-400 uppercase tracking-widest mb-2">
+            <p className="px-3 text-2xs font-bold text-foreground-subtle uppercase tracking-widest mb-2">
               {isLoggedIn ? "Account" : "Navigation"}
             </p>
             {visibleDrawerItems.map((item) => {
@@ -106,10 +106,10 @@ export function MobileNavDrawer({
                 <Button
                   key={item.id}
                   variant="ghost"
-                  className="w-full justify-start gap-3 h-11 text-sm font-medium text-slate-700 hover:bg-slate-50 hover:text-foreground rounded-xl"
+                  className="w-full justify-start gap-3 h-11 text-sm font-medium text-foreground-secondary hover:bg-slate-50 hover:text-foreground rounded-xl"
                   onClick={() => handleNavigationItemClick(item)}
                 >
-                  <Icon className="h-4.5 w-4.5 text-slate-400 flex-shrink-0" /> {item.label}
+                  <Icon className="h-4.5 w-4.5 text-foreground-subtle flex-shrink-0" /> {item.label}
                 </Button>
               );
             })}

--- a/frontend/src/components/search/SearchFiltersPanel.tsx
+++ b/frontend/src/components/search/SearchFiltersPanel.tsx
@@ -102,7 +102,7 @@ export function SearchFiltersPanel({
         <AccordionContent className="space-y-4 pt-2">
           {dynamicSpecificFilters.map((filter) => (
             <div key={filter.name} className="space-y-3">
-              <Label className="text-2xs font-bold text-slate-400 uppercase tracking-wider">
+              <Label className="text-2xs font-bold text-foreground-subtle uppercase tracking-wider">
                 {filter.name}
               </Label>
 

--- a/frontend/src/components/search/SearchFiltersShell.tsx
+++ b/frontend/src/components/search/SearchFiltersShell.tsx
@@ -38,7 +38,7 @@ function SearchFiltersDesktopShell({
         >
             <div className="flex items-center justify-between mb-6">
                 <h3 className="text-base font-bold text-foreground">Filters</h3>
-                <SlidersHorizontal className="size-4 text-slate-400" />
+                <SlidersHorizontal className="size-4 text-foreground-subtle" />
             </div>
             {children}
         </aside>
@@ -102,7 +102,7 @@ export function SearchFiltersShell({
                         open={mobileDrawerOpen}
                         onOpenChange={setMobileDrawerOpen}
                         trigger={
-                            <Button variant="outline" className="h-11 px-4 gap-2 text-slate-700 border-slate-200 hover:bg-slate-50 font-semibold text-sm rounded-full shadow-none">
+                            <Button variant="outline" className="h-11 px-4 gap-2 text-foreground-secondary border-slate-200 hover:bg-slate-50 font-semibold text-sm rounded-full shadow-none">
                                 <SlidersHorizontal className="size-4 text-muted-foreground" />
                                 <span>Filters</span>
                                 {activeFilterCount > 0 && (

--- a/frontend/src/components/search/SearchResultsHeader.tsx
+++ b/frontend/src/components/search/SearchResultsHeader.tsx
@@ -55,7 +55,7 @@ const SortDropdownTrigger = React.forwardRef<HTMLButtonElement, SortDropdownTrig
                 aria-label={`Sort listings, current ${SORT_LABELS[sort]}`}
                 className={cn(
                     buttonVariants({ variant: "outline" }),
-                    "h-11 max-w-[10.5rem] shrink-0 gap-1.5 rounded-full border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 shadow-none hover:bg-slate-50",
+                    "h-11 max-w-[10.5rem] shrink-0 gap-1.5 rounded-full border-slate-200 bg-white px-4 text-sm font-semibold text-foreground-secondary shadow-none hover:bg-slate-50",
                     className
                 )}
                 {...props}
@@ -80,9 +80,9 @@ const SortDropdownTrigger = React.forwardRef<HTMLButtonElement, SortDropdownTrig
             )}
             {...props}
         >
-            <SortAsc className="size-4 text-slate-400" />
-            <span className="font-semibold text-slate-700 text-sm">{SORT_LABELS[sort]}</span>
-            <ChevronDown className={cn("size-4 text-slate-400 transition-transform", open && "rotate-180")} />
+            <SortAsc className="size-4 text-foreground-subtle" />
+            <span className="font-semibold text-foreground-secondary text-sm">{SORT_LABELS[sort]}</span>
+            <ChevronDown className={cn("size-4 text-foreground-subtle transition-transform", open && "rotate-180")} />
         </button>
     );
 });
@@ -116,7 +116,7 @@ function SortDropdownMenu({
                         "min-h-[44px] cursor-pointer rounded-lg px-3 py-2.5 text-sm",
                         sort === key
                             ? "bg-slate-900 text-white font-medium focus:bg-slate-900 focus:text-white"
-                            : "text-slate-600 focus:bg-slate-50 focus:text-slate-700"
+                            : "text-foreground-tertiary focus:bg-slate-50 focus:text-foreground-secondary"
                     )}
                 >
                     {SORT_LABELS[key]}
@@ -197,8 +197,8 @@ export function SearchResultsHeader({
                             className="h-10 w-10 flex-shrink-0 rounded-full border-slate-200 bg-white shadow-none"
                         >
                             {view === "grid"
-                                ? <List className="size-4 text-slate-600" />
-                                : <LayoutGrid className="size-4 text-slate-600" />}
+                                ? <List className="size-4 text-foreground-tertiary" />
+                                : <LayoutGrid className="size-4 text-foreground-tertiary" />}
                         </Button>
                     </div>
                     <div className="mt-3 flex flex-wrap items-center gap-2 pb-1">
@@ -258,7 +258,7 @@ export function SearchResultsHeader({
                             aria-label="Grid view"
                             className={cn(
                                 "h-8 w-8 rounded-md",
-                                view === "grid" ? "bg-white shadow-sm text-foreground" : "text-slate-400 hover:text-slate-600"
+                                view === "grid" ? "bg-white shadow-sm text-foreground" : "text-foreground-subtle hover:text-foreground-tertiary"
                             )}
                         >
                             <LayoutGrid className="size-4" />
@@ -270,7 +270,7 @@ export function SearchResultsHeader({
                             aria-label="List view"
                             className={cn(
                                 "h-8 w-8 rounded-md",
-                                view === "list" ? "bg-white shadow-sm text-foreground" : "text-slate-400 hover:text-slate-600"
+                                view === "list" ? "bg-white shadow-sm text-foreground" : "text-foreground-subtle hover:text-foreground-tertiary"
                             )}
                         >
                             <List className="size-4" />

--- a/frontend/src/components/ui/CompletedFieldCard.tsx
+++ b/frontend/src/components/ui/CompletedFieldCard.tsx
@@ -35,7 +35,7 @@ export function CompletedFieldCard({
                     <CheckCircle2 className="h-5 w-5 text-emerald-600 shrink-0" />
                     <div className="min-w-0 flex-1">
                         <span className="font-medium text-foreground">{title}:</span>{" "}
-                        <span className="text-slate-600 truncate">{summary}</span>
+                        <span className="text-foreground-tertiary truncate">{summary}</span>
                     </div>
                 </div>
                 <Button

--- a/frontend/src/components/ui/field.tsx
+++ b/frontend/src/components/ui/field.tsx
@@ -18,7 +18,7 @@ export function Field({
     return (
         <div className={cn("space-y-1.5", className)}>
             {label && (
-                <label className="text-sm font-medium leading-snug text-slate-800 peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                <label className="text-sm font-medium leading-snug text-foreground-secondary peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
                     {label}
                     {required && <span className="text-destructive ml-1">*</span>}
                 </label>

--- a/frontend/src/components/user/BrandSearchSelect.tsx
+++ b/frontend/src/components/user/BrandSearchSelect.tsx
@@ -117,7 +117,7 @@ export function BrandSearchSelect({
     return (
         <div className={cn("relative", className)} ref={containerRef}>
             <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground-subtle pointer-events-none" />
                 <Input
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -139,7 +139,7 @@ export function BrandSearchSelect({
                         className="bg-white border border-slate-200 rounded-xl shadow-lg overflow-y-auto"
                     >
                         {filtered.length === 0 ? (
-                            <div className="py-4 px-4 text-center text-sm text-slate-400">
+                            <div className="py-4 px-4 text-center text-sm text-foreground-subtle">
                                 No brands found for &ldquo;{search}&rdquo;
                             </div>
                         ) : (
@@ -151,7 +151,7 @@ export function BrandSearchSelect({
                                         e.preventDefault();
                                         handleSelect(b);
                                     }}
-                                    className="w-full px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 active:bg-slate-100"
+                                    className="w-full px-4 py-2.5 text-left text-sm font-medium text-foreground-secondary transition-colors hover:bg-slate-50 active:bg-slate-100"
                                 >
                                     {b}
                                 </button>

--- a/frontend/src/components/user/BrowseAds.tsx
+++ b/frontend/src/components/user/BrowseAds.tsx
@@ -496,7 +496,7 @@ export function BrowseAds({
             {isEmptyState && (
               <div className="flex min-h-[340px] flex-col items-center justify-center rounded-[28px] border border-slate-200 bg-white px-6 py-12 text-center shadow-sm sm:min-h-[400px] sm:px-10 sm:py-14">
                 <div className="mb-4 rounded-full bg-slate-100 p-6">
-                  <PackageOpen className="h-10 w-10 text-slate-300" />
+                  <PackageOpen className="h-10 w-10 text-foreground-subtle" />
                 </div>
                 <h3 className="mb-2 text-xl font-semibold text-foreground">
                   {emptyStateTitle}
@@ -509,14 +509,14 @@ export function BrowseAds({
                     {activeFilterBadges.map((badge) => (
                       <span
                         key={badge}
-                        className="max-w-full rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-600"
+                        className="max-w-full rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-foreground-tertiary"
                       >
                         {badge}
                       </span>
                     ))}
                   </div>
                 )}
-                <p className="mb-6 max-w-sm text-xs font-medium uppercase tracking-widest text-slate-400">
+                <p className="mb-6 max-w-sm text-xs font-medium uppercase tracking-widest text-foreground-subtle">
                   Sorted by {PUBLIC_BROWSE_SORT_LABELS[sort]}
                 </p>
                 <p className="text-muted-foreground max-w-xs mb-6">
@@ -543,7 +543,7 @@ export function BrowseAds({
                   )}
                 </div>
                 {query && (
-                  <p className="mt-4 text-xs text-slate-400 max-w-xs">
+                  <p className="mt-4 text-xs text-foreground-subtle max-w-xs">
                     Set a Smart Alert and we&apos;ll notify you when a matching listing is posted.
                   </p>
                 )}
@@ -606,7 +606,7 @@ export function BrowseAds({
             {/* ── Inline load-more skeleton (pagination) ───────────────── */}
             {isFetching && displayAds.length > 0 && (
               <div className="flex justify-center py-6">
-                <RefreshCw className="h-5 w-5 animate-spin text-slate-400" />
+                <RefreshCw className="h-5 w-5 animate-spin text-foreground-subtle" />
               </div>
             )}
           </div>

--- a/frontend/src/components/user/BrowseFiltersBar.tsx
+++ b/frontend/src/components/user/BrowseFiltersBar.tsx
@@ -81,7 +81,7 @@ export const BrowseFiltersBar = memo(function BrowseFiltersBar({
     <div className="sticky top-[6.25rem] md:top-0 z-30 bg-white border-b border-slate-100 shadow-sm">
       <div className="mx-auto max-w-7xl px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
         <div className="relative w-full sm:flex-1 sm:min-w-[180px] sm:max-w-md">
-          <Search className="absolute left-3 top-3 h-4 w-4 text-slate-400 pointer-events-none" />
+          <Search className="absolute left-3 top-3 h-4 w-4 text-foreground-subtle pointer-events-none" />
           <Input
             id={inputId}
             aria-label={searchAriaLabel}
@@ -147,7 +147,7 @@ export const BrowseFiltersHeaderTrigger = memo(function BrowseFiltersHeaderTrigg
       trigger={
         <Button
           variant="outline"
-          className="h-11 px-4 gap-2 text-slate-700 border-slate-200 hover:bg-slate-50 font-semibold text-sm rounded-full shadow-none"
+          className="h-11 px-4 gap-2 text-foreground-secondary border-slate-200 hover:bg-slate-50 font-semibold text-sm rounded-full shadow-none"
         >
           <SlidersHorizontal className="size-4 text-muted-foreground" />
           <span>Filters</span>
@@ -161,7 +161,7 @@ export const BrowseFiltersHeaderTrigger = memo(function BrowseFiltersHeaderTrigg
     >
       <div className="space-y-4 pb-8 pt-2">
         <div className="relative">
-          <Search className="absolute left-3 top-3 h-4 w-4 text-slate-400 pointer-events-none" />
+          <Search className="absolute left-3 top-3 h-4 w-4 text-foreground-subtle pointer-events-none" />
           <Input
             id={inputId}
             aria-label={searchAriaLabel}

--- a/frontend/src/components/user/BrowseListingCard.tsx
+++ b/frontend/src/components/user/BrowseListingCard.tsx
@@ -47,7 +47,7 @@ export const BrowseListingCard = memo(function BrowseListingCard({
     />
   ) : (
     <div className="w-full h-full flex items-center justify-center">
-      <FallbackIcon className="h-10 w-10 text-slate-200" />
+      <FallbackIcon className="h-10 w-10 text-foreground-subtle" />
     </div>
   );
 

--- a/frontend/src/components/user/BrowseResultsPanel.tsx
+++ b/frontend/src/components/user/BrowseResultsPanel.tsx
@@ -110,7 +110,7 @@ export function BrowseResultsPanel<TItem>({
       {!loading && !error && items.length === 0 ? (
         <div className="flex min-h-[320px] flex-col items-center justify-center rounded-[28px] border border-slate-200 bg-white px-6 py-12 text-center shadow-sm sm:min-h-[380px] sm:px-10 sm:py-14">
           <div className="rounded-full bg-slate-100 p-6 mb-4">
-            <PackageOpen className="h-10 w-10 text-slate-300" />
+            <PackageOpen className="h-10 w-10 text-foreground-subtle" />
           </div>
           <h3 className="text-xl font-semibold text-foreground mb-2">
             {activeFilterCount > 0 ? "No results match these filters" : emptyTitle}
@@ -123,14 +123,14 @@ export function BrowseResultsPanel<TItem>({
               {activeFilterBadges.map((badge) => (
                 <span
                   key={badge}
-                  className="max-w-full rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-600"
+                  className="max-w-full rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-foreground-tertiary"
                 >
                   {badge}
                 </span>
               ))}
             </div>
           ) : null}
-          <p className="mb-6 text-xs font-medium uppercase tracking-widest text-slate-400">
+          <p className="mb-6 text-xs font-medium uppercase tracking-widest text-foreground-subtle">
             Sorted by {PUBLIC_BROWSE_SORT_LABELS[sort]}
           </p>
           <Button variant="outline" onClick={onReset}>
@@ -167,7 +167,7 @@ export function BrowseResultsPanel<TItem>({
 
       {loading && items.length > 0 ? (
         <div className="flex justify-center py-6">
-          <RefreshCw className="h-5 w-5 animate-spin text-slate-400" />
+          <RefreshCw className="h-5 w-5 animate-spin text-foreground-subtle" />
         </div>
       ) : null}
     </div>

--- a/frontend/src/components/user/BusinessListingGatePage.tsx
+++ b/frontend/src/components/user/BusinessListingGatePage.tsx
@@ -43,7 +43,7 @@ export function BusinessListingGatePage({
                         <Building2 className="w-8 h-8" />
                     </div>
                     <h1 className="text-xl font-bold text-foreground">Business Verification Required</h1>
-                    <p className="text-slate-600">
+                    <p className="text-foreground-tertiary">
                         Only admin-verified business accounts can post {listingTypeLabel}. Your account is{" "}
                         <strong>{businessData?.status ?? "not registered"}</strong>.
                     </p>

--- a/frontend/src/components/user/ListingDetail.tsx
+++ b/frontend/src/components/user/ListingDetail.tsx
@@ -614,7 +614,7 @@ export function ListingDetail({
               <BackButton
                 onClick={navigateBack}
                 variant="outline"
-                className="rounded-full border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                className="rounded-full border-slate-200 bg-white text-foreground-secondary hover:bg-slate-50"
               />
             </div>
           ) : null}

--- a/frontend/src/components/user/NotificationBellDropdown.tsx
+++ b/frontend/src/components/user/NotificationBellDropdown.tsx
@@ -53,8 +53,8 @@ const NOTIFICATION_META: Record<NotificationTypeValue, NotificationMeta> = {
     SYSTEM: {
         label: "System",
         icon: Megaphone,
-        iconTone: "text-slate-700",
-        badgeTone: "border-slate-200 bg-slate-100 text-slate-700",
+        iconTone: "text-foreground-secondary",
+        badgeTone: "border-slate-200 bg-slate-100 text-foreground-secondary",
     },
     CHAT: {
         label: "Message",
@@ -169,14 +169,14 @@ function NotificationDropdownRow({
                         ) : null}
                     </div>
 
-                    <p className={cn("mt-2 line-clamp-1 text-sm", notification.isRead ? "font-medium text-slate-800" : "font-semibold text-foreground")}>
+                    <p className={cn("mt-2 line-clamp-1 text-sm", notification.isRead ? "font-medium text-foreground-secondary" : "font-semibold text-foreground")}>
                         {notification.title}
                     </p>
-                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-600">{notification.message}</p>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-foreground-tertiary">{notification.message}</p>
 
                     <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
                         <span>{relativeTime}</span>
-                        <span className="inline-flex items-center gap-1 font-medium text-slate-700">
+                        <span className="inline-flex items-center gap-1 font-medium text-foreground-secondary">
                             {notification.actionUrl ? "Open" : notification.isRead ? "Read" : "Mark read"}
                             <ChevronRight className="h-3 w-3" />
                         </span>
@@ -333,7 +333,7 @@ export function NotificationBellDropdown({
                             <Button
                                 variant="ghost"
                                 size="sm"
-                                className="shrink-0 h-11 rounded-full px-3 text-xs font-medium text-slate-600 hover:bg-slate-100"
+                                className="shrink-0 h-11 rounded-full px-3 text-xs font-medium text-foreground-tertiary hover:bg-slate-100"
                                 onClick={() => markAllReadMutation.mutate()}
                                 disabled={markAllReadMutation.isPending}
                             >
@@ -347,7 +347,7 @@ export function NotificationBellDropdown({
                     {notifications.length === 0 ? (
                         <div className="flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-slate-200 bg-slate-50 px-5 py-10 text-center">
                             <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white shadow-sm">
-                                <Inbox className="h-5 w-5 text-slate-400" />
+                                <Inbox className="h-5 w-5 text-foreground-subtle" />
                             </div>
                             <div className="space-y-1">
                                 <p className="text-sm font-semibold text-foreground">No new notifications</p>
@@ -361,7 +361,7 @@ export function NotificationBellDropdown({
                             {unreadItems.length > 0 ? (
                                 <section className="space-y-2">
                                     <div className="flex items-center justify-between px-1">
-                                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-subtle">
                                             Unread now
                                         </p>
                                         <p className="text-xs text-muted-foreground">{unreadCount} unread</p>
@@ -384,7 +384,7 @@ export function NotificationBellDropdown({
                                     {unreadItems.length > 0 ? <DropdownMenuSeparator className="mx-1" /> : null}
                                     <section className="space-y-2">
                                         <div className="px-1">
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-subtle">
                                                 Read recently
                                             </p>
                                         </div>

--- a/frontend/src/components/user/NotificationBellDropdown.tsx
+++ b/frontend/src/components/user/NotificationBellDropdown.tsx
@@ -15,6 +15,7 @@ import {
     Tag,
     type LucideIcon,
 } from "lucide-react";
+import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
 import { READ_NOTIFICATION_RETENTION_HOURS } from "@shared/constants/notificationRetention";
@@ -403,6 +404,17 @@ export function NotificationBellDropdown({
                             ) : null}
                         </div>
                     )}
+                </div>
+
+                <div className="border-t border-slate-100 px-3 py-3">
+                    <Link
+                        href="/notifications"
+                        className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2 text-xs font-semibold text-foreground-tertiary transition hover:bg-slate-50 hover:text-foreground-secondary"
+                        onClick={() => setOpen(false)}
+                    >
+                        View all notifications
+                        <ChevronRight className="h-3.5 w-3.5" />
+                    </Link>
                 </div>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/src/components/user/ProfileSettingsSidebar.tsx
+++ b/frontend/src/components/user/ProfileSettingsSidebar.tsx
@@ -224,11 +224,11 @@ export function ProfileSettingsSidebar({
       case "rejected":
         return renderBadge("Rejected", "bg-red-100 text-red-700");
       case "expired":
-        return renderBadge("Expired", "bg-slate-200 text-slate-700");
+        return renderBadge("Expired", "bg-slate-200 text-foreground-secondary");
       case "deactivated":
         return renderBadge("Deactivated", "bg-orange-100 text-orange-700");
       default:
-        return renderBadge(status || "Unknown", "bg-gray-100 text-slate-600");
+        return renderBadge(status || "Unknown", "bg-gray-100 text-foreground-tertiary");
     }
   };
 
@@ -353,7 +353,7 @@ export function ProfileSettingsSidebar({
           ) : (
             <div className="flex items-center gap-3">
               <Button variant="ghost" size="icon" onClick={() => setIsMobileMenuView(true)} className="h-11 w-11 rounded-full hover:bg-gray-200 -ml-1">
-                <ChevronRight className="h-5 w-5 rotate-180 text-slate-700" />
+                <ChevronRight className="h-5 w-5 rotate-180 text-foreground-secondary" />
               </Button>
               <h1 className="text-lg font-bold text-foreground">
                 {activeTabLabel}
@@ -374,9 +374,9 @@ export function ProfileSettingsSidebar({
                   <button
                     key={item.value} onClick={() => handleTabChange(item.value)}
                     className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-all duration-200 font-medium group text-sm
-                      ${isActive ? "bg-blue-50 text-link-dark shadow-sm shadow-blue-100 ring-1 ring-blue-200" : "text-slate-600 hover:bg-slate-50 hover:text-foreground"}`}
+                      ${isActive ? "bg-blue-50 text-link-dark shadow-sm shadow-blue-100 ring-1 ring-blue-200" : "text-foreground-tertiary hover:bg-slate-50 hover:text-foreground"}`}
                   >
-                    <Icon className={`h-4.5 w-4.5 flex-shrink-0 transition-colors ${isActive ? "text-link" : "text-slate-400 group-hover:text-slate-600"}`} />
+                    <Icon className={`h-4.5 w-4.5 flex-shrink-0 transition-colors ${isActive ? "text-link" : "text-foreground-subtle group-hover:text-foreground-tertiary"}`} />
                     <span>{item.label}</span>
                     {renderTabBadge(item.value)}
                     {isActive && <ChevronRight className="h-4 w-4 opacity-50" />}
@@ -414,11 +414,11 @@ export function ProfileSettingsSidebar({
                   </div>
                   <Card className="p-2 border-0 shadow-sm">
                     {visibleProfileTabItems.map((item) => (
-                      <button key={item.value} onClick={() => handleMobileTabClick(item.value)} className="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-colors active:bg-gray-100 text-slate-700 border-b border-gray-50 last:border-0">
+                      <button key={item.value} onClick={() => handleMobileTabClick(item.value)} className="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-colors active:bg-gray-100 text-foreground-secondary border-b border-gray-50 last:border-0">
                         <div className="p-1.5 bg-gray-100 rounded-lg text-muted-foreground"><item.icon className="h-4.5 w-4.5" /></div>
                         <span className="text-sm font-semibold flex-1">{item.label}</span>
                         {renderTabBadge(item.value)}
-                        <ChevronRight className="h-4 w-4 text-slate-400" />
+                        <ChevronRight className="h-4 w-4 text-foreground-subtle" />
                       </button>
                     ))}
                     <Separator className="my-1" />

--- a/frontend/src/components/user/SavedAds.tsx
+++ b/frontend/src/components/user/SavedAds.tsx
@@ -149,7 +149,7 @@ function SavedAdTypeBadge({
   return (
     <Badge
       variant="secondary"
-      className={`text-2xs font-bold border-0 ${unavailable ? "bg-gray-100 text-slate-400" : "bg-blue-50 text-link"} ${className ?? ""}`}
+      className={`text-2xs font-bold border-0 ${unavailable ? "bg-gray-100 text-foreground-subtle" : "bg-blue-50 text-link"} ${className ?? ""}`}
     >
       {label.toUpperCase()}
     </Badge>
@@ -296,10 +296,10 @@ export function SavedAds({ navigateTo: _navigateTo }: SavedAdsProps) {
       />
 
       <CardContent className="p-3 space-y-1.5">
-        <h3 className={`font-semibold line-clamp-2 text-base leading-tight ${unavailable ? "text-slate-400" : ""}`}>
+        <h3 className={`font-semibold line-clamp-2 text-base leading-tight ${unavailable ? "text-foreground-subtle" : ""}`}>
           {ad.title}
         </h3>
-        <div className={`text-xl font-extrabold ${unavailable ? "text-slate-400" : "text-link"}`}>
+        <div className={`text-xl font-extrabold ${unavailable ? "text-foreground-subtle" : "text-link"}`}>
           {formatPrice(ad.price)}
         </div>
         <div className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -343,10 +343,10 @@ export function SavedAds({ navigateTo: _navigateTo }: SavedAdsProps) {
           <div className="flex-1 py-2 pr-2 md:py-4 md:pr-4 min-w-0">
             <div className="flex flex-col gap-1.5 md:gap-2 mb-1.5 md:mb-2">
               <SavedAdTypeBadge label={getCategoryLabel(ad)} unavailable={unavailable} className="w-fit" />
-              <div className={`text-lg md:text-2xl font-extrabold ${unavailable ? "text-slate-400" : "text-link"}`}>
+              <div className={`text-lg md:text-2xl font-extrabold ${unavailable ? "text-foreground-subtle" : "text-link"}`}>
                 {formatPrice(ad.price)}
               </div>
-              <h3 className={`font-semibold line-clamp-2 text-xs md:text-base leading-tight ${unavailable ? "text-slate-400" : ""}`}>
+              <h3 className={`font-semibold line-clamp-2 text-xs md:text-base leading-tight ${unavailable ? "text-foreground-subtle" : ""}`}>
                 {ad.title}
               </h3>
             </div>
@@ -492,8 +492,8 @@ export function SavedAds({ navigateTo: _navigateTo }: SavedAdsProps) {
               {unavailable.length > 0 && (
                 <div className="mt-8">
                   <div className="flex items-center gap-2 mb-3">
-                    <AlertCircle className="h-4 w-4 text-slate-400" />
-                    <h2 className="text-sm font-semibold text-slate-400 uppercase tracking-wide">
+                    <AlertCircle className="h-4 w-4 text-foreground-subtle" />
+                    <h2 className="text-sm font-semibold text-foreground-subtle uppercase tracking-wide">
                       No longer available ({unavailable.length})
                     </h2>
                   </div>

--- a/frontend/src/components/user/SellerProfilePage.tsx
+++ b/frontend/src/components/user/SellerProfilePage.tsx
@@ -64,7 +64,7 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
                                             className="h-20 w-20 md:h-24 md:w-24 rounded-xl object-cover"
                                         />
                                     ) : (
-                                        <div className="h-20 w-20 md:h-24 md:w-24 rounded-xl bg-slate-100 text-slate-700 flex items-center justify-center text-2xl md:text-3xl font-bold">
+                                        <div className="h-20 w-20 md:h-24 md:w-24 rounded-xl bg-slate-100 text-foreground-secondary flex items-center justify-center text-2xl md:text-3xl font-bold">
                                             {initials}
                                         </div>
                                     )}
@@ -82,7 +82,7 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
                                             </Badge>
                                         )}
                                     </div>
-                                    <p className="text-xs md:text-sm font-medium text-slate-400">
+                                    <p className="text-xs md:text-sm font-medium text-foreground-subtle">
                                         Active since {joinDate} {locationLabel && <span className="mx-1 opacity-50">·</span>} {locationLabel}
                                     </p>
                                 </div>
@@ -90,19 +90,19 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
                                 {/* Stats Grid */}
                                 <div className="grid grid-cols-2 gap-2 bg-slate-50 border border-slate-100 rounded-2xl p-3 text-left mx-auto md:mx-0 w-full max-w-sm md:max-w-xl">
                                     <div className="space-y-0.5">
-                                        <p className="text-2xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                        <p className="text-2xs font-bold text-foreground-subtle uppercase tracking-wider flex items-center gap-1">
                                             <Megaphone className="w-3 h-3" /> Live Listings
                                         </p>
                                         <p className="text-xl font-bold text-foreground">{listingSummary.totalActive}</p>
                                     </div>
                                     <div className="space-y-0.5 border-l border-slate-200 pl-3">
-                                        <p className="text-2xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                        <p className="text-2xs font-bold text-foreground-subtle uppercase tracking-wider flex items-center gap-1">
                                             <LayoutGrid className="w-3 h-3" /> Showing Here
                                         </p>
                                         <p className="text-xl font-bold text-foreground">{listingSummary.visibleCount}</p>
                                     </div>
                                 </div>
-                                <p className="text-xs text-slate-400">
+                                <p className="text-xs text-foreground-subtle">
                                     {listingSummary.hasMore
                                         ? `Showing the latest ${listingSummary.visibleCount} public listings from this seller.`
                                         : "All active listings from this seller are shown below."}
@@ -123,9 +123,9 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
 
                     {profile.ads.length === 0 ? (
                         <div className="flex flex-col items-center justify-center gap-3 py-14 text-center border-2 border-dashed border-slate-200 rounded-2xl bg-white">
-                            <LayoutGrid className="h-8 w-8 text-slate-300" />
-                            <p className="font-semibold text-slate-400 text-sm">No active listings</p>
-                            <p className="text-xs text-slate-400 max-w-xs">
+                            <LayoutGrid className="h-8 w-8 text-foreground-subtle" />
+                            <p className="font-semibold text-foreground-subtle text-sm">No active listings</p>
+                            <p className="text-xs text-foreground-subtle max-w-xs">
                                 {sellerName} does not have any active listings right now.
                             </p>
                         </div>

--- a/frontend/src/components/user/SoldOutDialog.tsx
+++ b/frontend/src/components/user/SoldOutDialog.tsx
@@ -161,7 +161,7 @@ export function SoldOutDialog({
                     htmlFor="others"
                     className="flex items-center gap-2 font-semibold cursor-pointer"
                   >
-                    <MoreHorizontal className="h-4 w-4 text-slate-600" />
+                    <MoreHorizontal className="h-4 w-4 text-foreground-tertiary" />
                     Others (Offline/Direct)
                   </Label>
                   <p className="text-xs text-muted-foreground mt-1">

--- a/frontend/src/components/user/UserHeader.tsx
+++ b/frontend/src/components/user/UserHeader.tsx
@@ -276,7 +276,7 @@ export function UserHeader({ navigateTo, isLoggedIn, isAuthLoading = false, onLo
                         onError={() => setAvatarSrc(DEFAULT_IMAGE_PLACEHOLDER)}
                       />
                     ) : (
-                      <div className="flex h-8 w-8 items-center justify-center bg-slate-100 text-slate-700 font-semibold border border-slate-200 rounded-full hover:bg-white hover:border-slate-300">
+                      <div className="flex h-8 w-8 items-center justify-center bg-slate-100 text-foreground-secondary font-semibold border border-slate-200 rounded-full hover:bg-white hover:border-slate-300">
                         {getUserInitials(user?.name || "", user?.mobile)}
                       </div>
                     )}

--- a/frontend/src/components/user/ad-card/AdCardList.tsx
+++ b/frontend/src/components/user/ad-card/AdCardList.tsx
@@ -67,7 +67,7 @@ export const AdCardList = memo(function AdCardList({
                   sizes="(max-width: 768px) 100px, 150px"
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center bg-gray-200 text-slate-400">
+                <div className="w-full h-full flex items-center justify-center bg-gray-200 text-foreground-subtle">
                   <span className="text-2xs">No Image</span>
                 </div>
               )}
@@ -96,7 +96,7 @@ export const AdCardList = memo(function AdCardList({
                       }}
                       aria-label={isSaved ? "Remove from favorites" : "Add to favorites"}
                     >
-                      <Heart className={cn("h-5 w-5", isSaved ? "fill-red-500 text-red-500" : "text-slate-300")} />
+                      <Heart className={cn("h-5 w-5", isSaved ? "fill-red-500 text-red-500" : "text-foreground-subtle")} />
                     </Button>
                   )}
                 </div>
@@ -105,7 +105,7 @@ export const AdCardList = memo(function AdCardList({
                 </h3>
               </div>
               
-              <div className="mt-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400">
+              <div className="mt-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-foreground-subtle">
                 <span className="max-w-full rounded bg-slate-100 px-2 py-0.5 text-2xs font-medium text-muted-foreground">
                   {ad.category}
                 </span>

--- a/frontend/src/components/user/ad-card/primitives/AdCardCover.tsx
+++ b/frontend/src/components/user/ad-card/primitives/AdCardCover.tsx
@@ -70,7 +70,7 @@ export const AdCardCover = memo(function AdCardCover({
           )}
         />
       ) : (
-        <div className="w-full h-full flex items-center justify-center bg-gray-200 text-slate-400">
+        <div className="w-full h-full flex items-center justify-center bg-gray-200 text-foreground-subtle">
           <span className="text-xs md:text-sm">No Image</span>
         </div>
       )}

--- a/frontend/src/components/user/ad-card/primitives/AdCardMeta.tsx
+++ b/frontend/src/components/user/ad-card/primitives/AdCardMeta.tsx
@@ -53,7 +53,7 @@ export const AdCardMeta = memo(function AdCardMeta({
 
   return (
     <div className={cn("flex flex-col gap-1", className)}>
-      <div className="font-semibold line-clamp-2 text-sm leading-snug min-h-[2.4rem] text-slate-800">
+      <div className="font-semibold line-clamp-2 text-sm leading-snug min-h-[2.4rem] text-foreground-secondary">
         {ad.title.replace(/\*\*/g, '')}
       </div>
 
@@ -79,7 +79,7 @@ export const AdCardMeta = memo(function AdCardMeta({
       </div>
 
       <div className={cn(
-        "flex items-center justify-between text-2xs text-slate-400 pt-1.5 border-t border-slate-100 mt-0.5",
+        "flex items-center justify-between text-2xs text-foreground-subtle pt-1.5 border-t border-slate-100 mt-0.5",
         isDashboard && "grid grid-cols-2 gap-2 justify-start",
         isList && "border-none pt-0 mt-0"
       )}>
@@ -100,13 +100,13 @@ export const AdCardMeta = memo(function AdCardMeta({
             <div className="flex items-center gap-1 flex-1 min-w-0">
               {formatLocation(ad.location) && (
                 <>
-                  <MapPin className="h-2.5 w-2.5 flex-shrink-0 text-slate-300" />
+                  <MapPin className="h-2.5 w-2.5 flex-shrink-0 text-foreground-subtle" />
                   <span className="truncate">{formatLocation(ad.location)}</span>
                 </>
               )}
             </div>
             <div className="flex items-center gap-1 flex-shrink-0 ml-1">
-              {!isList && <Clock className="h-2.5 w-2.5 text-slate-300" />}
+              {!isList && <Clock className="h-2.5 w-2.5 text-foreground-subtle" />}
               <span className="whitespace-nowrap">{'time' in ad ? ad.time : 'Just now'}</span>
             </div>
           </>

--- a/frontend/src/components/user/business-registration/BusinessProfileWizard.tsx
+++ b/frontend/src/components/user/business-registration/BusinessProfileWizard.tsx
@@ -148,7 +148,7 @@ export function BusinessProfileWizard({
                             variant="ghost"
                             size="sm"
                             onClick={onHeaderBack}
-                            className="h-11 rounded-full px-3 text-slate-600 hover:bg-slate-100"
+                            className="h-11 rounded-full px-3 text-foreground-tertiary hover:bg-slate-100"
                         >
                             <ArrowLeft className="mr-1.5 h-4 w-4" />
                             {wizardVariant === "registration" ? "Exit setup" : "Close"}
@@ -178,7 +178,7 @@ export function BusinessProfileWizard({
                         <h2 className="text-xl font-semibold tracking-tight text-foreground md:text-2xl">
                             {activeStep.title}
                         </h2>
-                        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                        <p className="mt-2 max-w-2xl text-sm leading-6 text-foreground-tertiary">
                             {activeStep.description}
                         </p>
                     </div>

--- a/frontend/src/components/user/business-registration/FileUploadCard.tsx
+++ b/frontend/src/components/user/business-registration/FileUploadCard.tsx
@@ -51,7 +51,7 @@ export function FileUploadCard({
                         <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p>
                     </div>
                     {file && (
-                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-foreground-tertiary">
                             {file instanceof File ? "Ready" : "Attached"}
                         </span>
                     )}

--- a/frontend/src/components/user/business-registration/ReviewSection.tsx
+++ b/frontend/src/components/user/business-registration/ReviewSection.tsx
@@ -17,7 +17,7 @@ export function ReviewSection({
         <div className="rounded-2xl border border-slate-200 p-4 sm:p-5">
             <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0 flex-1">
-                    <h4 className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                    <h4 className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-subtle">
                         {title}
                     </h4>
                     <div className="mt-3 space-y-2">{content}</div>

--- a/frontend/src/components/user/business-registration/ShopPhotosField.tsx
+++ b/frontend/src/components/user/business-registration/ShopPhotosField.tsx
@@ -37,7 +37,7 @@ function ShopImageTile({
                 className="object-cover"
             />
             <div className="absolute inset-0 flex items-start justify-between bg-gradient-to-t from-slate-900/65 via-slate-900/0 to-slate-900/0 p-3 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
-                <span className="rounded-full bg-white/90 px-2 py-1 text-xs font-semibold text-slate-700 shadow-sm">
+                <span className="rounded-full bg-white/90 px-2 py-1 text-xs font-semibold text-foreground-secondary shadow-sm">
                     Photo {index + 1}
                 </span>
                 <Button
@@ -45,7 +45,7 @@ function ShopImageTile({
                     size="icon"
                     variant="secondary"
                     onClick={onRemove}
-                    className="h-11 w-11 rounded-full bg-white/90 text-slate-700 shadow-sm hover:bg-white"
+                    className="h-11 w-11 rounded-full bg-white/90 text-foreground-secondary shadow-sm hover:bg-white"
                 >
                     <X className="h-4 w-4" />
                 </Button>
@@ -108,7 +108,7 @@ export function ShopPhotosField({
     return (
         <div className="space-y-3">
             <div className="space-y-1">
-                <p className="text-sm font-medium text-slate-800">
+                <p className="text-sm font-medium text-foreground-secondary">
                     Shop or workshop photos <span className="text-destructive">*</span>
                 </p>
                 <p className="text-xs leading-5 text-muted-foreground">
@@ -128,8 +128,8 @@ export function ShopPhotosField({
 
                 {formData.shopImages.length < 5 && (
                     <label className="flex aspect-square cursor-pointer flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 text-center transition-colors hover:border-blue-400 hover:bg-blue-50">
-                        <Upload className="mb-3 h-6 w-6 text-slate-400" />
-                        <span className="text-sm font-semibold text-slate-700">Add photo</span>
+                        <Upload className="mb-3 h-6 w-6 text-foreground-subtle" />
+                        <span className="text-sm font-semibold text-foreground-secondary">Add photo</span>
                         <span className="mt-1 text-xs text-muted-foreground">{formData.shopImages.length}/5 uploaded</span>
                         <input
                             id="reg-shop-images"

--- a/frontend/src/components/user/business-registration/StepAddress.tsx
+++ b/frontend/src/components/user/business-registration/StepAddress.tsx
@@ -294,9 +294,14 @@ export function StepAddress({
                     error={formData.errors?.fullAddress}
                     className="space-y-1.5"
                 >
-                    <span className="text-xs leading-5 text-muted-foreground">
-                        Enter complete business address including shop/building name, street/area, pincode, and landmark if available.
-                    </span>
+                    <div className="flex items-center justify-between">
+                        <span className="text-xs leading-5 text-muted-foreground">
+                            Include shop/building name, street/area, pincode, and landmark.
+                        </span>
+                        <span className={`shrink-0 ml-3 text-xs font-medium ${formData.fullAddress.length >= 300 ? "text-amber-600" : "text-muted-foreground"}`}>
+                            {formData.fullAddress.length}/300
+                        </span>
+                    </div>
                     <Textarea
                         id="reg-full-address"
                         value={formData.fullAddress}

--- a/frontend/src/components/user/business-registration/StepAddress.tsx
+++ b/frontend/src/components/user/business-registration/StepAddress.tsx
@@ -85,7 +85,7 @@ function CompactReadonlyField({
     return (
         <div className="space-y-1.5">
             <div className="flex flex-wrap items-center gap-2">
-                <label className="text-sm font-medium leading-snug text-slate-800" htmlFor={id}>
+                <label className="text-sm font-medium leading-snug text-foreground-secondary" htmlFor={id}>
                     {label}
                 </label>
                 {badge}
@@ -252,7 +252,7 @@ export function StepAddress({
                     error={currentLocationError}
                     badge={(
                         <>
-                            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+                            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-foreground-secondary">
                                 Required
                             </span>
                             {sourceLabel ? (

--- a/frontend/src/components/user/business-registration/StepDocuments.tsx
+++ b/frontend/src/components/user/business-registration/StepDocuments.tsx
@@ -39,7 +39,7 @@ export function StepDocuments({
 
     return (
         <div className="space-y-5">
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-foreground-secondary">
                 {isRegistration
                     ? "Upload the owner ID and one business proof document the review team needs for approval."
                     : "Replace these files only if details changed or the review team asked for fresh documents."}

--- a/frontend/src/components/user/business-registration/StepReview.tsx
+++ b/frontend/src/components/user/business-registration/StepReview.tsx
@@ -53,7 +53,7 @@ export function StepReview({
                 content={
                     <>
                         <p className="text-sm font-semibold text-foreground">{formData.businessName}</p>
-                        <p className="text-sm leading-6 text-slate-600">{formData.businessDescription}</p>
+                        <p className="text-sm leading-6 text-foreground-tertiary">{formData.businessDescription}</p>
                         <p className="text-sm text-muted-foreground">{formData.email}</p>
                     </>
                 }
@@ -67,7 +67,7 @@ export function StepReview({
                         <p className="text-sm font-semibold text-foreground">
                             {formData.currentLocationDisplay || "Current location pending"}
                         </p>
-                        <p className="text-sm leading-6 text-slate-600">{formData.fullAddress}</p>
+                        <p className="text-sm leading-6 text-foreground-tertiary">{formData.fullAddress}</p>
                         <p className="text-sm text-muted-foreground">
                             Current location is recorded first, then the full address is sent for admin review.
                         </p>
@@ -87,10 +87,10 @@ export function StepReview({
                             <p className="text-sm font-semibold text-foreground">
                                 {formData.idProofType ? `${idProofTypeLabel} selected as owner ID` : idProofTypeLabel}
                             </p>
-                            <p className="text-sm text-slate-600">
+                            <p className="text-sm text-foreground-tertiary">
                                 {formData.idProof ? "Owner ID proof attached" : "Owner ID proof missing"}
                             </p>
-                            <p className="text-sm text-slate-600">
+                            <p className="text-sm text-foreground-tertiary">
                                 {formData.businessProof ? "Business proof attached" : "Business proof missing"}
                             </p>
                             <p className="text-sm text-muted-foreground">

--- a/frontend/src/components/user/listing-detail/AdBusinessCard.tsx
+++ b/frontend/src/components/user/listing-detail/AdBusinessCard.tsx
@@ -39,7 +39,7 @@ export function AdBusinessCard({ ad, navigateTo }: AdBusinessCardProps) {
                                 VERIFIED
                             </Badge>
                         </div>
-                        <p className="text-xs text-slate-400 font-medium">{businessType}</p>
+                        <p className="text-xs text-foreground-subtle font-medium">{businessType}</p>
                     </div>
                 </div>
 
@@ -57,8 +57,8 @@ export function AdBusinessCard({ ad, navigateTo }: AdBusinessCardProps) {
                                     <Icon className="h-3.5 w-3.5 text-link" />
                                 </div>
                                 <div className="min-w-0">
-                                    <p className="text-2xs uppercase font-bold text-slate-300 tracking-wider">{detail.label}</p>
-                                    <p className="font-bold text-slate-700 truncate">{detail.value}</p>
+                                    <p className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">{detail.label}</p>
+                                    <p className="font-bold text-foreground-secondary truncate">{detail.value}</p>
                                 </div>
                             </div>
                         );
@@ -85,11 +85,11 @@ export function AdBusinessCard({ ad, navigateTo }: AdBusinessCardProps) {
                 <div className="flex items-center justify-between px-1">
                     <div className="flex items-center gap-2">
                         <div className="size-1.5 rounded-full bg-green-500 animate-pulse" />
-                        <span className="text-2xs font-bold text-slate-400 uppercase tracking-widest">Active Partner</span>
+                        <span className="text-2xs font-bold text-foreground-subtle uppercase tracking-widest">Active Partner</span>
                     </div>
                     <div className="flex items-center gap-1">
-                        <span className="text-2xs font-black text-slate-700">100%</span>
-                        <span className="text-2xs font-bold text-slate-400 uppercase tracking-widest">Verified</span>
+                        <span className="text-2xs font-black text-foreground-secondary">100%</span>
+                        <span className="text-2xs font-bold text-foreground-subtle uppercase tracking-widest">Verified</span>
                     </div>
                 </div>
             </CardContent>

--- a/frontend/src/components/user/listing-detail/AdImageCarousel.tsx
+++ b/frontend/src/components/user/listing-detail/AdImageCarousel.tsx
@@ -55,7 +55,7 @@ export function AdImageCarousel({ images, title, isFavorited, onFavorite, onShar
                                 onClick={onShare}
                                 aria-label="Share this ad"
                             >
-                                <Share2 className="h-4 w-4 text-slate-600" />
+                                <Share2 className="h-4 w-4 text-foreground-tertiary" />
                             </Button>
                             <Button
                                 size="icon"
@@ -65,7 +65,7 @@ export function AdImageCarousel({ images, title, isFavorited, onFavorite, onShar
                                 aria-label="Add to favorites"
                             >
                                 <Heart
-                                    className={`h-4 w-4 ${isFavorited ? "fill-red-500 text-red-500" : "text-slate-600"}`}
+                                    className={`h-4 w-4 ${isFavorited ? "fill-red-500 text-red-500" : "text-foreground-tertiary"}`}
                                 />
                             </Button>
                         </div>
@@ -88,7 +88,7 @@ export function AdImageCarousel({ images, title, isFavorited, onFavorite, onShar
                                 onClick={prevImage}
                                 aria-label="Previous image"
                             >
-                                <ChevronLeft className="h-5 w-5 md:h-6 md:w-6 text-slate-600" />
+                                <ChevronLeft className="h-5 w-5 md:h-6 md:w-6 text-foreground-tertiary" />
                             </Button>
                             <Button
                                 size="icon"
@@ -97,7 +97,7 @@ export function AdImageCarousel({ images, title, isFavorited, onFavorite, onShar
                                 onClick={nextImage}
                                 aria-label="Next image"
                             >
-                                <ChevronRight className="h-5 w-5 md:h-6 md:w-6 text-slate-600" />
+                                <ChevronRight className="h-5 w-5 md:h-6 md:w-6 text-foreground-tertiary" />
                             </Button>
                         </>
                     )}

--- a/frontend/src/components/user/listing-detail/AdOwnerActions.tsx
+++ b/frontend/src/components/user/listing-detail/AdOwnerActions.tsx
@@ -80,20 +80,20 @@ export function AdOwnerActions({
                 {isSold && (
                     <div className="bg-slate-100 border-2 border-slate-200 rounded-xl p-4 text-center">
                         <CheckCheck className="h-6 w-6 text-muted-foreground mx-auto mb-2" />
-                        <p className="text-sm font-bold text-slate-700">Listing Marked as Sold</p>
+                        <p className="text-sm font-bold text-foreground-secondary">Listing Marked as Sold</p>
                         <p className="text-xs text-muted-foreground mt-1">This listing is now archived</p>
                     </div>
                 )}
 
                 {isChatLocked && !isSold && (
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600 flex items-center gap-2">
-                        <CheckCheck className="h-4 w-4 text-slate-400" />
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs text-foreground-tertiary flex items-center gap-2">
+                        <CheckCheck className="h-4 w-4 text-foreground-subtle" />
                         Chat is locked for this listing.
                     </div>
                 )}
 
                 {showViewOnlyState && !isChatLocked && (
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600">
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs text-foreground-tertiary">
                         This listing is no longer active. View-only mode is enabled.
                     </div>
                 )}

--- a/frontend/src/components/user/listing-detail/AdSafetyTips.tsx
+++ b/frontend/src/components/user/listing-detail/AdSafetyTips.tsx
@@ -9,7 +9,7 @@ export function AdSafetyTips() {
                     <div className="h-8 w-8 rounded-xl bg-amber-100 flex items-center justify-center flex-shrink-0">
                         <ShieldAlert className="h-4 w-4 text-amber-600" />
                     </div>
-                    <h3 className="font-bold text-sm text-slate-800">Buying Safely</h3>
+                    <h3 className="font-bold text-sm text-foreground-secondary">Buying Safely</h3>
                 </div>
 
                 <div className="space-y-3">
@@ -18,7 +18,7 @@ export function AdSafetyTips() {
                             <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
                         </div>
                         <div>
-                            <p className="text-xs font-bold text-slate-700">Inspect Personally</p>
+                            <p className="text-xs font-bold text-foreground-secondary">Inspect Personally</p>
                             <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">Meet in a public place to check the item status.</p>
                         </div>
                     </div>
@@ -28,7 +28,7 @@ export function AdSafetyTips() {
                             <AlertCircle className="h-3.5 w-3.5 text-amber-600" />
                         </div>
                         <div>
-                            <p className="text-xs font-bold text-slate-700">Avoid Advance Payments</p>
+                            <p className="text-xs font-bold text-foreground-secondary">Avoid Advance Payments</p>
                             <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">Never pay before receiving and verifying the item.</p>
                         </div>
                     </div>
@@ -38,7 +38,7 @@ export function AdSafetyTips() {
                             <Info className="h-3.5 w-3.5 text-link" />
                         </div>
                         <div>
-                            <p className="text-xs font-bold text-slate-700">Fraud Protection</p>
+                            <p className="text-xs font-bold text-foreground-secondary">Fraud Protection</p>
                             <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">Report suspicious activity to our support team.</p>
                         </div>
                     </div>

--- a/frontend/src/components/user/listing-detail/AdSellerCard.tsx
+++ b/frontend/src/components/user/listing-detail/AdSellerCard.tsx
@@ -62,7 +62,7 @@ export function AdSellerCard({
         }
         return (
             <div className={`h-12 w-12 rounded-2xl bg-slate-100 flex items-center justify-center flex-shrink-0 ${isInteractive ? 'group-hover:scale-105 transition-transform' : ''}`}>
-                <span className="font-bold text-slate-600 text-base">
+                <span className="font-bold text-foreground-tertiary text-base">
                     {ad.sellerName?.charAt(0) || sellerDisplayName.charAt(0) || 'E'}
                 </span>
             </div>
@@ -78,14 +78,14 @@ export function AdSellerCard({
                     avatar={renderAvatar()}
                     name={sellerDisplayName}
                     subtitle={
-                        <p className="text-xs text-slate-400 font-medium">
+                        <p className="text-xs text-foreground-subtle font-medium">
                             {ad.isBusiness ? "Verified Business Account" : "Registered Member"}
                         </p>
                     }
                     badge={ad.isBusiness && ad.verified ? (
                         <Badge className="bg-blue-600 text-white text-2xs h-4 px-1.5 rounded-md border-none font-bold">PRO</Badge>
                     ) : undefined}
-                    trailing={isInteractive ? <ChevronRight className="h-4 w-4 text-slate-300 group-hover:translate-x-1 transition-transform" /> : undefined}
+                    trailing={isInteractive ? <ChevronRight className="h-4 w-4 text-foreground-subtle group-hover:translate-x-1 transition-transform" /> : undefined}
                 />
 
                 {showDesktopActions && (
@@ -96,7 +96,7 @@ export function AdSellerCard({
                                     onClick={onRevealPhone}
                                     variant="outline"
                                     disabled={isPhoneLoading}
-                                    className="w-full h-11 rounded-xl font-semibold gap-2 border-slate-200 text-slate-700 hover:bg-slate-50"
+                                    className="w-full h-11 rounded-xl font-semibold gap-2 border-slate-200 text-foreground-secondary hover:bg-slate-50"
                                 >
                                     <Phone className="h-4 w-4" />
                                     <span className="min-w-0 truncate">{phoneButtonLabel}</span>
@@ -123,11 +123,11 @@ export function AdSellerCard({
                 {isChatLocked && (
                     <div className="p-3.5 rounded-2xl bg-slate-50 border border-slate-100 flex items-center gap-3">
                         <div className="h-9 w-9 rounded-xl bg-slate-200 flex items-center justify-center flex-shrink-0">
-                            <MessageSquareOff className="h-4 w-4 text-slate-400" />
+                            <MessageSquareOff className="h-4 w-4 text-foreground-subtle" />
                         </div>
                         <div>
-                            <p className="text-xs font-bold text-slate-600">Chat Locked</p>
-                            <p className="text-2xs text-slate-400 mt-0.5">This listing is no longer accepting new messages.</p>
+                            <p className="text-xs font-bold text-foreground-tertiary">Chat Locked</p>
+                            <p className="text-2xs text-foreground-subtle mt-0.5">This listing is no longer accepting new messages.</p>
                         </div>
                     </div>
                 )}

--- a/frontend/src/components/user/listing-detail/AdTitlePriceCard.tsx
+++ b/frontend/src/components/user/listing-detail/AdTitlePriceCard.tsx
@@ -68,23 +68,23 @@ export function AdTitlePriceCard({
                         {formatPrice(ad.price)}
                     </div>
 
-                    <div className="grid grid-cols-2 gap-2 text-xs text-slate-400 border-t border-slate-100 pt-3">
+                    <div className="grid grid-cols-2 gap-2 text-xs text-foreground-subtle border-t border-slate-100 pt-3">
                         <div className="flex items-center gap-1.5">
-                            <MapPin className="h-3 w-3 flex-shrink-0 text-slate-300" />
+                            <MapPin className="h-3 w-3 flex-shrink-0 text-foreground-subtle" />
                             <span className="truncate">{formatLocation(ad.location)}</span>
                         </div>
                         <div className="flex items-center gap-1.5">
-                            <Clock className="h-3 w-3 flex-shrink-0 text-slate-300" />
+                            <Clock className="h-3 w-3 flex-shrink-0 text-foreground-subtle" />
                             <span className="truncate">{ad.time}</span>
                         </div>
                         {viewCount !== undefined && viewCount > 0 && (
                             <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
-                                <Eye className="h-3 w-3 text-slate-300" />
+                                <Eye className="h-3 w-3 text-foreground-subtle" />
                                 <span>{viewCount.toLocaleString()} views</span>
                             </div>
                         )}
                         <div className="flex items-center gap-1.5">
-                            <span className="text-slate-400 truncate">Ad #{ad.id}</span>
+                            <span className="text-foreground-subtle truncate">Ad #{ad.id}</span>
                         </div>
                     </div>
                 </CardContent>
@@ -98,7 +98,7 @@ export function AdTitlePriceCard({
             <CardContent className="p-6">
                 <div className="flex items-start justify-between gap-3 mb-4">
                     <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary" className="bg-slate-100 text-slate-600 border-none font-medium px-2.5 py-0.5 text-2xs">
+                        <Badge variant="secondary" className="bg-slate-100 text-foreground-tertiary border-none font-medium px-2.5 py-0.5 text-2xs">
                             {categoryLabel}
                         </Badge>
                         {ad.deviceCondition && (
@@ -145,33 +145,33 @@ export function AdTitlePriceCard({
                 </div>
 
                 {/* Meta Info Grid */}
-                <div className="grid grid-cols-2 gap-y-4 gap-x-2 text-xs text-slate-400 pt-5 border-t border-slate-50">
+                <div className="grid grid-cols-2 gap-y-4 gap-x-2 text-xs text-foreground-subtle pt-5 border-t border-slate-50">
                     <div className="flex flex-col gap-1">
-                        <span className="text-2xs uppercase font-bold text-slate-400 tracking-wider">Location</span>
-                        <div className="flex items-center gap-1.5 text-slate-600 font-medium">
-                            <MapPin className="h-3 w-3 text-slate-400" />
+                        <span className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">Location</span>
+                        <div className="flex items-center gap-1.5 text-foreground-tertiary font-medium">
+                            <MapPin className="h-3 w-3 text-foreground-subtle" />
                             <span className="truncate">{formatLocation(ad.location)}</span>
                         </div>
                     </div>
                     <div className="flex flex-col gap-1">
-                        <span className="text-2xs uppercase font-bold text-slate-400 tracking-wider">Posted</span>
-                        <div className="flex items-center gap-1.5 text-slate-600 font-medium">
-                            <Clock className="h-3 w-3 text-slate-400" />
+                        <span className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">Posted</span>
+                        <div className="flex items-center gap-1.5 text-foreground-tertiary font-medium">
+                            <Clock className="h-3 w-3 text-foreground-subtle" />
                             <span className="truncate">{ad.time}</span>
                         </div>
                     </div>
                     {viewCount !== undefined && viewCount > 0 && (
                         <div className="flex flex-col gap-1 text-xs">
-                            <span className="text-2xs uppercase font-bold text-slate-400 tracking-wider">Views</span>
-                            <div className="flex items-center gap-1.5 text-slate-600 font-medium">
-                                <Eye className="h-3 w-3 text-slate-400" />
+                            <span className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">Views</span>
+                            <div className="flex items-center gap-1.5 text-foreground-tertiary font-medium">
+                                <Eye className="h-3 w-3 text-foreground-subtle" />
                                 <span className="truncate">{viewCount.toLocaleString()} views</span>
                             </div>
                         </div>
                     )}
                     <div className="flex flex-col gap-1">
-                        <span className="text-2xs uppercase font-bold text-slate-400 tracking-wider">Ad ID</span>
-                        <div className="flex items-center gap-1.5 text-slate-600 font-medium">
+                        <span className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">Ad ID</span>
+                        <div className="flex items-center gap-1.5 text-foreground-tertiary font-medium">
                             <span className="truncate font-bold">#{ad.id}</span>
                         </div>
                     </div>

--- a/frontend/src/components/user/listing-detail/ListingBottomActions.tsx
+++ b/frontend/src/components/user/listing-detail/ListingBottomActions.tsx
@@ -137,7 +137,7 @@ export function ListingBottomActions({
               {/* Edit */}
               <Button
                 variant="outline"
-                className="flex flex-col gap-1 h-11 text-xs rounded-xl border-slate-200 text-slate-600"
+                className="flex flex-col gap-1 h-11 text-xs rounded-xl border-slate-200 text-foreground-tertiary"
                 onClick={onEditClick}
               >
                 <Edit2 className="h-5 w-5" />
@@ -147,7 +147,7 @@ export function ListingBottomActions({
               {/* Mark Sold */}
               <Button
                 variant="outline"
-                className="flex flex-col gap-1 h-11 text-xs rounded-xl border-slate-200 text-slate-600"
+                className="flex flex-col gap-1 h-11 text-xs rounded-xl border-slate-200 text-foreground-tertiary"
                 onClick={onMarkSoldClick}
               >
                 <svg
@@ -180,7 +180,7 @@ export function ListingBottomActions({
             {/* Analytics Quick View */}
             <button
               onClick={onAnalyticsClick}
-              className="w-full py-2 text-xs text-center text-slate-400 border-t border-slate-100 hover:bg-slate-50 active:bg-slate-100 transition-colors"
+              className="w-full py-2 text-xs text-center text-foreground-subtle border-t border-slate-100 hover:bg-slate-50 active:bg-slate-100 transition-colors"
             >
               <span className="font-medium text-muted-foreground">View Analytics</span> · Tap for detailed stats
             </button>
@@ -207,7 +207,7 @@ export function ListingBottomActions({
                 variant="outline"
                 onClick={onRevealPhone}
                 disabled={isPhoneLoading}
-                className="w-full h-11 rounded-xl font-semibold gap-2 border-slate-200 text-slate-700 hover:bg-slate-50"
+                className="w-full h-11 rounded-xl font-semibold gap-2 border-slate-200 text-foreground-secondary hover:bg-slate-50"
               >
                 <Phone className="h-4 w-4" />
                 <span className="min-w-0 truncate">{phoneButtonLabel}</span>

--- a/frontend/src/components/user/listing-detail/ListingDescriptionCard.tsx
+++ b/frontend/src/components/user/listing-detail/ListingDescriptionCard.tsx
@@ -25,19 +25,19 @@ export function ListingDescriptionCard({ ad, variant }: ListingDescriptionCardPr
                     <div className="grid grid-cols-2 gap-3 pb-4 border-b border-slate-100">
                         {!!ad.warranty && (
                             <div className="flex items-start gap-2.5 bg-slate-50 rounded-xl p-3">
-                                <Wrench className="h-4 w-4 text-slate-400 mt-0.5 flex-shrink-0" />
+                                <Wrench className="h-4 w-4 text-foreground-subtle mt-0.5 flex-shrink-0" />
                                 <div>
-                                    <p className="text-2xs uppercase font-bold text-slate-400 tracking-wider">Warranty</p>
-                                    <p className="text-sm font-semibold text-slate-800 mt-0.5">{String(ad.warranty)}</p>
+                                    <p className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">Warranty</p>
+                                    <p className="text-sm font-semibold text-foreground-secondary mt-0.5">{String(ad.warranty)}</p>
                                 </div>
                             </div>
                         )}
                         {ad.listingType === 'service' && ad.onsiteService !== undefined && (
                             <div className="flex items-start gap-2.5 bg-slate-50 rounded-xl p-3">
-                                <Wrench className="h-4 w-4 text-slate-400 mt-0.5 flex-shrink-0" />
+                                <Wrench className="h-4 w-4 text-foreground-subtle mt-0.5 flex-shrink-0" />
                                 <div>
-                                    <p className="text-2xs uppercase font-bold text-slate-400 tracking-wider">On-site</p>
-                                    <p className="text-sm font-semibold text-slate-800 mt-0.5">{ad.onsiteService ? 'Yes' : 'No'}</p>
+                                    <p className="text-2xs uppercase font-bold text-foreground-subtle tracking-wider">On-site</p>
+                                    <p className="text-sm font-semibold text-foreground-secondary mt-0.5">{ad.onsiteService ? 'Yes' : 'No'}</p>
                                 </div>
                             </div>
                         )}
@@ -50,7 +50,7 @@ export function ListingDescriptionCard({ ad, variant }: ListingDescriptionCardPr
                             <Info className="h-3.5 w-3.5 text-blue-500" />
                             What&apos;s Included
                         </h4>
-                        <div className="text-sm text-slate-600 leading-relaxed bg-blue-50 p-3.5 rounded-xl border border-blue-100">
+                        <div className="text-sm text-foreground-tertiary leading-relaxed bg-blue-50 p-3.5 rounded-xl border border-blue-100">
                             {String(ad.included)}
                         </div>
                     </div>
@@ -59,17 +59,17 @@ export function ListingDescriptionCard({ ad, variant }: ListingDescriptionCardPr
                 {!!ad.excluded && (
                     <div className="space-y-2">
                         <h4 className="text-xs font-bold flex items-center gap-1.5 text-muted-foreground uppercase tracking-wide">
-                            <Info className="h-3.5 w-3.5 text-slate-400" />
+                            <Info className="h-3.5 w-3.5 text-foreground-subtle" />
                             What&apos;s Excluded
                         </h4>
-                        <div className="text-sm text-slate-600 leading-relaxed bg-slate-50 p-3.5 rounded-xl border border-slate-100">
+                        <div className="text-sm text-foreground-tertiary leading-relaxed bg-slate-50 p-3.5 rounded-xl border border-slate-100">
                             {String(ad.excluded)}
                         </div>
                     </div>
                 )}
 
                 <div className="space-y-2">
-                    <h3 className={`font-bold text-slate-800 ${isMobile ? "text-sm" : "text-sm md:text-base"}`}>
+                    <h3 className={`font-bold text-foreground-secondary ${isMobile ? "text-sm" : "text-sm md:text-base"}`}>
                         Description
                     </h3>
                     <div className={`text-muted-foreground whitespace-pre-wrap leading-7 ${isMobile ? "text-sm" : "text-sm md:text-base"}`}>

--- a/frontend/src/components/user/listing-detail/ListingDetailDialogs.tsx
+++ b/frontend/src/components/user/listing-detail/ListingDetailDialogs.tsx
@@ -131,7 +131,7 @@ export function ListingDetailDialogs({
 
           <div className="rounded-2xl border bg-white p-4">
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Last activity</p>
-            <p className="mt-2 text-sm text-slate-700">
+            <p className="mt-2 text-sm text-foreground-secondary">
               {isAnalyticsLoading
                 ? "Loading latest activity..."
                 : analyticsSummary?.lastViewedAt

--- a/frontend/src/components/user/post-ad/PostAdShell.tsx
+++ b/frontend/src/components/user/post-ad/PostAdShell.tsx
@@ -31,7 +31,7 @@ export function PostAdShell({ children }: { children: React.ReactNode }) {
                     <h2 className="text-xl font-bold text-foreground mb-2">
                         Service Unavailable
                     </h2>
-                    <p className="text-slate-600 mb-8">
+                    <p className="text-foreground-tertiary mb-8">
                         We are currently unable to connect to our servers. You cannot post new ads at this time.
                     </p>
                     <button
@@ -62,7 +62,7 @@ export function PostAdShell({ children }: { children: React.ReactNode }) {
                     <h2 className="text-xl font-bold text-foreground mb-2">
                         Something went wrong
                     </h2>
-                    <p className="text-slate-600 mb-8">
+                    <p className="text-foreground-tertiary mb-8">
                         {mapErrorToMessage(loadError, "We encountered an issue loading the necessary data. Please try again.")}
                     </p>
                     <button

--- a/frontend/src/components/user/post-ad/PostAdWizard.tsx
+++ b/frontend/src/components/user/post-ad/PostAdWizard.tsx
@@ -74,7 +74,7 @@ function PostAdWizardContent({ navigateTo }: { navigateTo: PostAdWizardProps["na
             ) : (
               <>
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
+                  <span className="text-xs font-semibold text-foreground-subtle uppercase tracking-widest">
                     Step {currentStep} of 2
                   </span>
                   <span className="text-xs font-semibold text-link uppercase tracking-widest">

--- a/frontend/src/components/user/post-ad/steps/DeviceIdentityFields.tsx
+++ b/frontend/src/components/user/post-ad/steps/DeviceIdentityFields.tsx
@@ -105,8 +105,8 @@ export default function DeviceIdentityFields() {
                                             : "bg-white hover:bg-slate-50 border-slate-100"
                                     )}
                                 >
-                                    <Icon className={cn("w-5 h-5", selected ? "text-primary-foreground" : "text-slate-400")} />
-                                    <span className={cn("text-xs font-semibold text-center leading-tight truncate w-full px-1", selected ? "text-primary-foreground" : "text-slate-600")}>
+                                    <Icon className={cn("w-5 h-5", selected ? "text-primary-foreground" : "text-foreground-subtle")} />
+                                    <span className={cn("text-xs font-semibold text-center leading-tight truncate w-full px-1", selected ? "text-primary-foreground" : "text-foreground-tertiary")}>
                                         {cat.name}
                                     </span>
                                 </Button>
@@ -177,7 +177,7 @@ export default function DeviceIdentityFields() {
                                             "h-auto rounded-xl border px-2 py-2.5 text-sm font-semibold transition-all",
                                             isSelected
                                                 ? "bg-primary border-primary text-primary-foreground shadow-sm scale-[1.02]"
-                                                : "bg-white border-slate-100 text-slate-600 hover:border-slate-200"
+                                                : "bg-white border-slate-100 text-foreground-tertiary hover:border-slate-200"
                                         )}
                                     >
                                         <span className="truncate">{part.name}</span>
@@ -186,7 +186,7 @@ export default function DeviceIdentityFields() {
                             })}
                         </div>
                     ) : (
-                        <p className="text-xs text-slate-400 text-center py-3">
+                        <p className="text-xs text-foreground-subtle text-center py-3">
                             No spare parts listed for this category.
                         </p>
                     )}
@@ -209,7 +209,7 @@ export default function DeviceIdentityFields() {
                                     "flex items-center gap-2 h-11 px-4 rounded-xl border-2 text-sm font-bold transition-all",
                                     deviceCondition === value
                                         ? active
-                                        : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
+                                        : "bg-white border-slate-200 text-foreground-tertiary hover:border-slate-300"
                                 )}
                             >
                                 <div className={cn("w-2.5 h-2.5 rounded-full shrink-0", deviceCondition === value ? "bg-white/80" : dot)} />

--- a/frontend/src/components/user/post-ad/steps/DeviceIdentityFields.tsx
+++ b/frontend/src/components/user/post-ad/steps/DeviceIdentityFields.tsx
@@ -87,7 +87,7 @@ export default function DeviceIdentityFields() {
 
             {/* Category */}
             <section className="space-y-4">
-                <Field error={categoryError} label="Select Category">
+                <Field error={categoryError} label="Select Category" required>
                     <div className="grid grid-cols-4 sm:grid-cols-5 gap-2">
                         {dynamicCategories.map((cat) => {
                             const Icon = cat.icon || CircuitBoard;

--- a/frontend/src/components/user/post-ad/steps/ListingDetailsFields.tsx
+++ b/frontend/src/components/user/post-ad/steps/ListingDetailsFields.tsx
@@ -182,7 +182,7 @@ export default function ListingDetailsFields() {
         <div className="space-y-6" data-testid="listing-details-fields">
             {/* Ad Title */}
             <section className="space-y-4">
-                <Field label="Choose a catchy title" error={titleError}>
+                <Field label="Choose a catchy title" required error={titleError}>
                     <div className="space-y-3">
                         <div className="relative">
                             <Input
@@ -216,7 +216,7 @@ export default function ListingDetailsFields() {
 
             {/* Description */}
             <section className="space-y-4">
-                <Field label="Describe your product" error={descriptionError}>
+                <Field label="Describe your product" required error={descriptionError}>
                     <div className="space-y-3">
                         <div className="relative">
                             <Textarea
@@ -305,7 +305,7 @@ export default function ListingDetailsFields() {
 
             {/* Location */}
             <section className="space-y-4">
-                <Field label="Where are you located?" error={locationError}>
+                <Field label="Where are you located?" required error={locationError}>
                     <div className="space-y-3">
                         <LocationSelector
                             variant="inline"
@@ -328,7 +328,7 @@ export default function ListingDetailsFields() {
 
             {/* Price */}
             <section className="space-y-6">
-                <Field label="Set your price" error={priceError}>
+                <Field label="Set your price" required error={priceError}>
                     <div className="space-y-4">
                         <div className="relative h-20">
                             <Input

--- a/frontend/src/components/user/post-ad/steps/ListingDetailsFields.tsx
+++ b/frontend/src/components/user/post-ad/steps/ListingDetailsFields.tsx
@@ -205,7 +205,7 @@ export default function ListingDetailsFields() {
                         <div className="flex justify-end">
                             <span className={cn(
                                 "text-xs font-bold tracking-tight",
-                                (watch("title") || "").length >= MAX_AD_TITLE_CHARS ? "text-amber-600" : "text-slate-400"
+                                (watch("title") || "").length >= MAX_AD_TITLE_CHARS ? "text-amber-600" : "text-foreground-subtle"
                             )}>
                                 {(watch("title") || "").length} / {MAX_AD_TITLE_CHARS}
                             </span>
@@ -239,7 +239,7 @@ export default function ListingDetailsFields() {
                         <div className="flex justify-end">
                             <span className={cn(
                                 "text-xs font-bold tracking-tight",
-                                (watch("description") || "").length >= MAX_AD_DESCRIPTION_CHARS ? "text-amber-600" : "text-slate-400"
+                                (watch("description") || "").length >= MAX_AD_DESCRIPTION_CHARS ? "text-amber-600" : "text-foreground-subtle"
                             )}>
                                 {(watch("description") || "").length} / {MAX_AD_DESCRIPTION_CHARS}
                             </span>
@@ -252,7 +252,7 @@ export default function ListingDetailsFields() {
             <section className="space-y-6">
                 <div className="text-center space-y-1">
                     <label className="text-sm font-bold text-foreground block">Product Photos</label>
-                    <p className="text-xs text-slate-400 font-medium italic">Photos should be clear and product-focused</p>
+                    <p className="text-xs text-foreground-subtle font-medium italic">Photos should be clear and product-focused</p>
                 </div>
 
                 <Field error={imagesError}>
@@ -287,14 +287,14 @@ export default function ListingDetailsFields() {
                                     disabled={isUploadingImages}
                                 />
                                 {isUploadingImages ? (
-                                    <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+                                    <Loader2 className="w-6 h-6 animate-spin text-foreground-subtle" />
                                 ) : (
                                     <>
                                         <div className="w-10 h-10 rounded-full bg-white shadow-sm flex items-center justify-center mb-2 border border-slate-100">
                                             <Upload className="w-5 h-5 text-primary" />
                                         </div>
-                                        <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Add Photo</span>
-                                        <span className="text-2xs text-slate-300 mt-0.5">{listingImages.length}/{MAX_AD_IMAGES}</span>
+                                        <span className="text-xs font-semibold text-foreground-subtle uppercase tracking-wider">Add Photo</span>
+                                        <span className="text-2xs text-foreground-subtle mt-0.5">{listingImages.length}/{MAX_AD_IMAGES}</span>
                                     </>
                                 )}
                             </label>
@@ -320,7 +320,7 @@ export default function ListingDetailsFields() {
                                 Location cannot be changed once an ad is live or under review.
                             </p>
                         ) : (
-                            <p className="text-xs text-slate-400 text-center font-medium">Use GPS auto-detect or search manually for your city.</p>
+                            <p className="text-xs text-foreground-subtle text-center font-medium">Use GPS auto-detect or search manually for your city.</p>
                         )}
                     </div>
                 </Field>
@@ -338,12 +338,12 @@ export default function ListingDetailsFields() {
                                 disabled={isFree}
                                 className={cn(
                                     "h-full pl-12 pr-4 rounded-2xl border-2 font-bold text-2xl transition-all",
-                                    isFree ? "bg-slate-50 border-slate-100 text-slate-300" : "bg-white border-slate-200 focus:border-primary"
+                                    isFree ? "bg-slate-50 border-slate-100 text-foreground-subtle" : "bg-white border-slate-200 focus:border-primary"
                                 )}
                             />
                             <span className={cn(
                                 "absolute left-5 top-1/2 -translate-y-1/2 font-bold text-2xl",
-                                isFree ? "text-slate-300" : "text-slate-400"
+                                isFree ? "text-foreground-subtle" : "text-foreground-subtle"
                             )}>₹</span>
                         </div>
 
@@ -365,7 +365,7 @@ export default function ListingDetailsFields() {
                             <div className="flex items-center gap-3">
                                 <div className={cn(
                                     "w-10 h-10 rounded-full flex items-center justify-center transition-colors",
-                                    isFree ? "bg-green-600 text-white" : "bg-slate-100 text-slate-400"
+                                    isFree ? "bg-green-600 text-white" : "bg-slate-100 text-foreground-subtle"
                                 )}>
                                     <Checkbox
                                         id="isFree-check"

--- a/frontend/src/components/user/post-service/PostServiceForm.tsx
+++ b/frontend/src/components/user/post-service/PostServiceForm.tsx
@@ -229,7 +229,7 @@ export function PostServiceForm({ editServiceId }: { editServiceId?: string }) {
             formId="post-service-form"
         >
             {isEditMode ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-foreground-secondary">
                     <p className="font-semibold text-foreground">Catalog fields are partially locked while editing.</p>
                     <p className="mt-1">
                         Category and brand stay fixed so this service keeps the same catalog placement. Create a new listing if those details changed.
@@ -285,7 +285,7 @@ export function PostServiceForm({ editServiceId }: { editServiceId?: string }) {
                                                 "rounded-xl border px-3 py-3 text-left text-sm font-semibold transition-all",
                                                 selected
                                                     ? "bg-primary border-primary text-white shadow-sm"
-                                                    : "bg-white border-slate-100 text-slate-700 hover:border-slate-200"
+                                                    : "bg-white border-slate-100 text-foreground-secondary hover:border-slate-200"
                                             )}
                                         >
                                             {selected ? <Check className="mr-1 inline h-3.5 w-3.5" /> : null}
@@ -296,7 +296,7 @@ export function PostServiceForm({ editServiceId }: { editServiceId?: string }) {
                             </div>
                         </>
                     ) : isEditMode && selectedServiceTypes.length > 0 ? (
-                        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-foreground-secondary">
                             <p className="font-semibold text-foreground">Existing service types are preserved.</p>
                             <p className="mt-1">
                                 This listing keeps its current service-type mapping while you edit pricing, photos, and description.

--- a/frontend/src/components/user/post-service/PostServiceForm.tsx
+++ b/frontend/src/components/user/post-service/PostServiceForm.tsx
@@ -259,7 +259,7 @@ export function PostServiceForm({ editServiceId }: { editServiceId?: string }) {
             )}
 
             {categoryId && (
-                <Field label="Service Types" error={getFirstFormErrorMessage(errors.serviceTypeIds)}>
+                <Field label="Service Types" required error={getFirstFormErrorMessage(errors.serviceTypeIds)}>
                     {isLoadingServiceTypes ? (
                         <div className="grid grid-cols-2 gap-2">
                             {Array.from({ length: 4 }).map((_, index) => (

--- a/frontend/src/components/user/post-spare-part/PostSparePartForm.tsx
+++ b/frontend/src/components/user/post-spare-part/PostSparePartForm.tsx
@@ -224,7 +224,7 @@ export default function PostSparePartForm({ editSparePartId }: { editSparePartId
             )}
 
             {categoryId && (
-                <Field label="Spare Part" error={errors.sparePartTypeId?.message}>
+                <Field label="Spare Part" required error={errors.sparePartTypeId?.message}>
                     {isLoadingSpareParts ? (
                         <div className="grid grid-cols-3 gap-2">
                             {[1, 2, 3, 4, 5, 6].map(i => (

--- a/frontend/src/components/user/post-spare-part/PostSparePartForm.tsx
+++ b/frontend/src/components/user/post-spare-part/PostSparePartForm.tsx
@@ -194,7 +194,7 @@ export default function PostSparePartForm({ editSparePartId }: { editSparePartId
             formId="post-spare-part-form"
         >
             {isEditMode ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-foreground-secondary">
                     <p className="font-semibold text-foreground">Catalog fields are locked while editing.</p>
                     <p className="mt-1">
                         Category, brand, and spare part type stay fixed so this listing remains mapped to the same catalog item.
@@ -246,7 +246,7 @@ export default function PostSparePartForm({ editSparePartId }: { editSparePartId
                                             "rounded-xl border px-2 py-3 text-sm font-semibold transition-all",
                                             selected
                                                 ? "bg-primary border-primary text-white shadow-sm"
-                                                : "bg-white border-slate-100 text-slate-700 hover:border-slate-200",
+                                                : "bg-white border-slate-100 text-foreground-secondary hover:border-slate-200",
                                             isEditMode && !selected ? "opacity-40" : ""
                                         )}
                                     >
@@ -257,7 +257,7 @@ export default function PostSparePartForm({ editSparePartId }: { editSparePartId
                             })}
                         </div>
                     ) : isEditMode && sparePartTypeId ? (
-                        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-foreground-secondary">
                             <p className="font-semibold text-foreground">Existing spare-part mapping is preserved.</p>
                             <p className="mt-1">
                                 This listing keeps its current catalog mapping while you edit pricing, photos, and description.

--- a/frontend/src/components/user/profile/BusinessApplicationStatus.tsx
+++ b/frontend/src/components/user/profile/BusinessApplicationStatus.tsx
@@ -262,7 +262,7 @@ export function BusinessApplicationStatus({
                             <Button
                                 onClick={navigateToBusinessTab}
                                 variant="outline"
-                                className="w-full text-slate-700 border-gray-300 hover:bg-gray-100"
+                                className="w-full text-foreground-secondary border-gray-300 hover:bg-gray-100"
                             >
                                 Manage Profile
                             </Button>
@@ -277,7 +277,7 @@ export function BusinessApplicationStatus({
                     </>
                 }
             >
-                <div className="bg-gray-100 border border-gray-200 rounded-lg p-3 text-sm text-slate-700 mb-4">
+                <div className="bg-gray-100 border border-gray-200 rounded-lg p-3 text-sm text-foreground-secondary mb-4">
                     <p className="font-medium mb-1">Action Required:</p>
                     <p className="text-xs">Your business registration has reached its expiry date. Your profile and services are currently offline. You must renew or re-verify your registration to continue operations.</p>
                 </div>

--- a/frontend/src/components/user/profile/PlanFeatureList.tsx
+++ b/frontend/src/components/user/profile/PlanFeatureList.tsx
@@ -24,7 +24,7 @@ export function PlanFeatureList({
           <CheckCircle2
             className={cn("mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-link", iconClassName)}
           />
-          <span className={cn("text-slate-600", textClassName)}>{feature}</span>
+          <span className={cn("text-foreground-tertiary", textClassName)}>{feature}</span>
         </li>
       ))}
     </ul>

--- a/frontend/src/components/user/profile/dialogs/DeleteAccountDialog.tsx
+++ b/frontend/src/components/user/profile/dialogs/DeleteAccountDialog.tsx
@@ -87,13 +87,19 @@ export function DeleteAccountDialog({
                         <FormError message={deleteAccountErrors?.reason} />
                     </div>
                     <div className="space-y-1.5">
-                        <Label htmlFor="delete-account-feedback">Optional feedback</Label>
+                        <div className="flex items-center justify-between">
+                            <Label htmlFor="delete-account-feedback">Optional feedback</Label>
+                            <span className={`text-xs font-medium ${deleteFeedback.length >= 500 ? "text-amber-600" : "text-muted-foreground"}`}>
+                                {deleteFeedback.length}/500
+                            </span>
+                        </div>
                         <Textarea
                             id="delete-account-feedback"
                             value={deleteFeedback}
-                            onChange={(e) => setDeleteFeedback(e.target.value)}
+                            onChange={(e) => setDeleteFeedback(e.target.value.slice(0, 500))}
                             placeholder="Tell us what went wrong or what we could improve"
                             rows={4}
+                            maxLength={500}
                             aria-invalid={!!deleteAccountErrors?.feedback}
                         />
                         <FormError message={deleteAccountErrors?.feedback} />

--- a/frontend/src/components/user/profile/tabs/MyAdsTab.tsx
+++ b/frontend/src/components/user/profile/tabs/MyAdsTab.tsx
@@ -155,7 +155,7 @@ export function MyAdsTab({
                             onClick={() => setMyAdsTab(tab)}
                             className={`px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${myAdsTab === tab
                                 ? "bg-slate-900 text-white shadow-lg"
-                                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                                : "bg-slate-100 text-foreground-tertiary hover:bg-slate-200"
                                 }`}
                         >
                             {tab.charAt(0).toUpperCase() + tab.slice(1)}
@@ -184,14 +184,14 @@ export function MyAdsTab({
                         }
                         empty={
                             <div className="text-center py-12 bg-slate-50 rounded-xl border border-dashed border-slate-200">
-                                <Package className="h-12 w-12 mx-auto text-slate-300 mb-3" />
+                                <Package className="h-12 w-12 mx-auto text-foreground-subtle mb-3" />
                                 <h3 className="text-sm font-medium text-foreground">No {myAdsTab} ads</h3>
                                 <p className="text-xs text-muted-foreground mt-1 max-w-[200px] mx-auto">
                                     Ads marked as {myAdsTab} will appear here.
                                 </p>
                                 {myAdsTab === 'active' && (
                                     <>
-                                        <p className="text-2xs text-slate-400 mt-2">Active ads are visible on the Home Page until they expire.</p>
+                                        <p className="text-2xs text-foreground-subtle mt-2">Active ads are visible on the Home Page until they expire.</p>
                                         <Button
                                             variant="outline"
                                             size="sm"
@@ -204,8 +204,8 @@ export function MyAdsTab({
                                 )}
                                 {myAdsTab === 'pending' && <p className="text-2xs text-amber-600 mt-2">Pending ads are being reviewed and are NOT visible on Home Page yet.</p>}
                                 {myAdsTab === 'rejected' && <p className="text-2xs text-red-500 mt-2">Rejected ads are hidden from public view. Edit and resubmit for review.</p>}
-                                {myAdsTab === 'expired' && <p className="text-2xs text-slate-400 mt-2">Expired ads are no longer visible on the Home Page. You can mark them as sold or delete them.</p>}
-                                {myAdsTab === 'deactivated' && <p className="text-2xs text-slate-400 mt-2">Deactivated ads are hidden. Reactivate them to make them visible again.</p>}
+                                {myAdsTab === 'expired' && <p className="text-2xs text-foreground-subtle mt-2">Expired ads are no longer visible on the Home Page. You can mark them as sold or delete them.</p>}
+                                {myAdsTab === 'deactivated' && <p className="text-2xs text-foreground-subtle mt-2">Deactivated ads are hidden. Reactivate them to make them visible again.</p>}
                             </div>
                         }
                         error={

--- a/frontend/src/components/user/profile/tabs/PersonalTab.tsx
+++ b/frontend/src/components/user/profile/tabs/PersonalTab.tsx
@@ -126,12 +126,18 @@ export function PersonalTab({
 
                     <div className="grid md:grid-cols-2 gap-4">
                         <div className="space-y-1.5">
-                            <Label htmlFor="profile-name">Full Name *</Label>
+                            <div className="flex items-center justify-between">
+                                <Label htmlFor="profile-name">Full Name *</Label>
+                                <span className={`text-xs font-medium ${(formData.name || "").length > 50 ? "text-destructive" : "text-muted-foreground"}`}>
+                                    {(formData.name || "").length}/50
+                                </span>
+                            </div>
                             <Input
                                 id="profile-name"
                                 name="name"
                                 placeholder="Enter your name"
                                 value={formData.name}
+                                maxLength={50}
                                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                     if (profileErrors?.name) clearProfileError?.("name");
                                     setFormData({ ...formData, name: e.target.value });
@@ -188,12 +194,18 @@ export function PersonalTab({
                             </div>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                                 <div className="space-y-1.5">
-                                    <Label htmlFor="billing-business-name">Business Name</Label>
+                                    <div className="flex items-center justify-between">
+                                        <Label htmlFor="billing-business-name">Business Name</Label>
+                                        <span className={`text-xs font-medium ${(formData.businessName || "").length > 100 ? "text-destructive" : "text-muted-foreground"}`}>
+                                            {(formData.businessName || "").length}/100
+                                        </span>
+                                    </div>
                                     <Input
                                         id="billing-business-name"
                                         name="businessName"
                                         placeholder="Registered Business Name"
                                         value={formData.businessName || ""}
+                                        maxLength={100}
                                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                             if (profileErrors?.businessName) clearProfileError?.("businessName");
                                             setFormData({ ...formData, businessName: e.target.value });
@@ -206,15 +218,21 @@ export function PersonalTab({
                                     <FormError id="profile-business-name-error" message={profileErrors?.businessName} />
                                 </div>
                                 <div className="space-y-1.5">
-                                    <Label htmlFor="billing-gst-number">GST Number</Label>
+                                    <div className="flex items-center justify-between">
+                                        <Label htmlFor="billing-gst-number">GST Number</Label>
+                                        <span className={`text-xs font-medium ${(formData.gstNumber || "").length > 0 && (formData.gstNumber || "").length !== 15 ? "text-amber-600" : "text-muted-foreground"}`}>
+                                            {(formData.gstNumber || "").length}/15
+                                        </span>
+                                    </div>
                                     <Input
                                         id="billing-gst-number"
                                         name="gstNumber"
-                                        placeholder="GSTIN"
+                                        placeholder="22AAAAA0000A1Z5"
                                         value={formData.gstNumber || ""}
+                                        maxLength={15}
                                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                             if (profileErrors?.gstNumber) clearProfileError?.("gstNumber");
-                                            setFormData({ ...formData, gstNumber: e.target.value });
+                                            setFormData({ ...formData, gstNumber: e.target.value.toUpperCase() });
                                         }}
                                         className={`bg-white ${profileErrors?.gstNumber ? "border-red-500" : ""}`}
                                         aria-invalid={!!profileErrors?.gstNumber}

--- a/frontend/src/components/user/profile/tabs/PersonalTab.tsx
+++ b/frontend/src/components/user/profile/tabs/PersonalTab.tsx
@@ -79,7 +79,7 @@ export function PersonalTab({
                                             sizes="80px"
                                         />
                                     ) : (
-                                        <User className="h-8 w-8 md:h-10 md:w-10 text-slate-300" />
+                                        <User className="h-8 w-8 md:h-10 md:w-10 text-foreground-subtle" />
                                     )}
                                 </div>
                                 <button
@@ -254,7 +254,7 @@ export function PersonalTab({
                 </CardHeader>
                 <CardContent className="space-y-4">
                     <div className="space-y-3">
-                        <p className="text-sm font-semibold text-slate-700">Choose who can view your number:</p>
+                        <p className="text-sm font-semibold text-foreground-secondary">Choose who can view your number:</p>
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                             {/* Show to All */}
@@ -264,7 +264,7 @@ export function PersonalTab({
                                 ${mobileVisibility === "show" ? "border-blue-600 bg-blue-50/50" : "border-slate-100 hover:border-slate-200 bg-white"}`}
                             >
                                 <div className="flex items-center justify-between">
-                                    <Eye className={`h-5 w-5 ${mobileVisibility === "show" ? "text-link" : "text-slate-400"}`} />
+                                    <Eye className={`h-5 w-5 ${mobileVisibility === "show" ? "text-link" : "text-foreground-subtle"}`} />
                                     {mobileVisibility === "show" && <div className="h-2 w-2 rounded-full bg-blue-600 animate-pulse" />}
                                 </div>
                                 <div>
@@ -280,7 +280,7 @@ export function PersonalTab({
                                 ${mobileVisibility === "hide" ? "border-red-600 bg-red-50/50" : "border-slate-100 hover:border-slate-200 bg-white"}`}
                             >
                                 <div className="flex items-center justify-between">
-                                    <EyeOff className={`h-5 w-5 ${mobileVisibility === "hide" ? "text-red-600" : "text-slate-400"}`} />
+                                    <EyeOff className={`h-5 w-5 ${mobileVisibility === "hide" ? "text-red-600" : "text-foreground-subtle"}`} />
                                     {mobileVisibility === "hide" && <div className="h-2 w-2 rounded-full bg-red-600 animate-pulse" />}
                                 </div>
                                 <div>

--- a/frontend/src/components/user/profile/tabs/PurchasesTab.tsx
+++ b/frontend/src/components/user/profile/tabs/PurchasesTab.tsx
@@ -56,7 +56,7 @@ export function PurchasesTab({
                             <p className="text-xs text-muted-foreground">Pending Orders</p>
                         </div>
                         <div>
-                            <p className="text-2xl font-bold text-slate-600">
+                            <p className="text-2xl font-bold text-foreground-tertiary">
                                 {successfulOrders}
                             </p>
                             <p className="text-xs text-muted-foreground">Successful Orders</p>

--- a/frontend/src/components/user/profile/tabs/SmartAlertsTab.tsx
+++ b/frontend/src/components/user/profile/tabs/SmartAlertsTab.tsx
@@ -265,12 +265,18 @@ export function SmartAlertsTab({
                         <CardContent>
                             <div className="space-y-3">
                                 <div>
-                                    <Label htmlFor="smart-alert-name" className="text-sm">Alert Name</Label>
+                                    <div className="flex items-center justify-between">
+                                        <Label htmlFor="smart-alert-name" className="text-sm">Alert Name</Label>
+                                        <span className={`text-xs font-medium ${smartAlertForm.name.length > 50 ? "text-destructive" : "text-muted-foreground"}`}>
+                                            {smartAlertForm.name.length}/50
+                                        </span>
+                                    </div>
                                     <Input
                                         id="smart-alert-name"
                                         placeholder="e.g., iPhone 14 Pro in New York"
                                         className={`mt-1.5 ${smartAlertErrors?.name ? "border-red-500" : ""}`}
                                         value={smartAlertForm.name}
+                                        maxLength={50}
                                         onChange={(e) => {
                                             if (smartAlertErrors?.name) clearSmartAlertError?.("name");
                                             updateSmartAlertForm({ name: e.target.value });
@@ -281,12 +287,18 @@ export function SmartAlertsTab({
                                     <FormError id="smart-alert-name-error" message={smartAlertErrors?.name} />
                                 </div>
                                 <div>
-                                    <Label htmlFor="smart-alert-keywords" className="text-sm">Search Keywords</Label>
+                                    <div className="flex items-center justify-between">
+                                        <Label htmlFor="smart-alert-keywords" className="text-sm">Search Keywords</Label>
+                                        <span className={`text-xs font-medium ${smartAlertForm.keywords.length > 150 ? "text-destructive" : "text-muted-foreground"}`}>
+                                            {smartAlertForm.keywords.length}/150
+                                        </span>
+                                    </div>
                                     <Input
                                         id="smart-alert-keywords"
                                         placeholder="e.g., iPhone 14 Pro Max 256GB"
                                         className={`mt-1.5 ${smartAlertErrors?.keywords ? "border-red-500" : ""}`}
                                         value={smartAlertForm.keywords}
+                                        maxLength={150}
                                         onChange={(e) => {
                                             if (smartAlertErrors?.keywords) clearSmartAlertError?.("keywords");
                                             updateSmartAlertForm({ keywords: e.target.value });
@@ -297,12 +309,18 @@ export function SmartAlertsTab({
                                     <FormError id="smart-alert-keywords-error" message={smartAlertErrors?.keywords} />
                                 </div>
                                 <div>
-                                    <Label htmlFor="smart-alert-category" className="text-sm">Category</Label>
+                                    <div className="flex items-center justify-between">
+                                        <Label htmlFor="smart-alert-category" className="text-sm">Category</Label>
+                                        <span className={`text-xs font-medium ${smartAlertForm.category.length > 80 ? "text-destructive" : "text-muted-foreground"}`}>
+                                            {smartAlertForm.category.length}/80
+                                        </span>
+                                    </div>
                                     <Input
                                         id="smart-alert-category"
                                         placeholder="Mobile Phones"
                                         className={`mt-1.5 ${smartAlertErrors?.category ? "border-red-500" : ""}`}
                                         value={smartAlertForm.category}
+                                        maxLength={80}
                                         onChange={(e) => {
                                             if (smartAlertErrors?.category) clearSmartAlertError?.("category");
                                             updateSmartAlertForm({ category: e.target.value });

--- a/frontend/src/components/user/profile/tabs/SmartAlertsTab.tsx
+++ b/frontend/src/components/user/profile/tabs/SmartAlertsTab.tsx
@@ -127,7 +127,7 @@ export function SmartAlertsTab({
                                             <h4 className="font-semibold">{alert.name}</h4>
                                             <Badge
                                                 variant="secondary"
-                                                className={`text-xs ${alert.active === false ? "bg-slate-100 text-slate-700" : "bg-green-100 text-green-700"}`}
+                                                className={`text-xs ${alert.active === false ? "bg-slate-100 text-foreground-secondary" : "bg-green-100 text-green-700"}`}
                                             >
                                                 {alert.active === false ? "Paused" : "Active"}
                                             </Badge>

--- a/frontend/src/components/user/related-businesses/RelatedBusinessesSection.tsx
+++ b/frontend/src/components/user/related-businesses/RelatedBusinessesSection.tsx
@@ -155,8 +155,8 @@ export function RelatedBusinessesSection({
             <h3 className="line-clamp-1 text-sm font-bold text-foreground">
               {business.name}
             </h3>
-            <div className="flex items-center gap-1 text-xs text-slate-400">
-              <MapPin className="h-3 w-3 flex-shrink-0 text-slate-300" />
+            <div className="flex items-center gap-1 text-xs text-foreground-subtle">
+              <MapPin className="h-3 w-3 flex-shrink-0 text-foreground-subtle" />
               <span className="truncate">
                 {business.location?.city || business.location?.display || "Nearby"}
               </span>
@@ -171,7 +171,7 @@ export function RelatedBusinessesSection({
               </Badge>
             ) : null}
             {activeServicesCount > 0 ? (
-              <Badge variant="secondary" className="rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-600 border-none">
+              <Badge variant="secondary" className="rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-foreground-tertiary border-none">
                 {activeServicesCount} live
               </Badge>
             ) : null}
@@ -202,7 +202,7 @@ export function RelatedBusinessesSection({
       <div className="mb-4 md:mb-6 flex items-center justify-between gap-4">
         <div>
           <h2 className="text-base font-bold md:text-xl text-foreground">{sectionCopy.title}</h2>
-          <p className="mt-0.5 text-xs text-slate-400 hidden md:block">
+          <p className="mt-0.5 text-xs text-foreground-subtle hidden md:block">
             {sectionCopy.description}
           </p>
         </div>
@@ -259,13 +259,13 @@ export function RelatedBusinessesSection({
       ) : null}
 
       {!isLoading && !isError && !canSearch ? (
-        <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm text-slate-600">
+        <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm text-foreground-tertiary">
           Nearby service-center suggestions are unavailable because this listing is missing location details.
         </div>
       ) : null}
 
       {!isLoading && !isError && canSearch && businesses.length === 0 ? (
-        <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm text-slate-600">
+        <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm text-foreground-tertiary">
           {sectionCopy.empty}
         </div>
       ) : null}

--- a/frontend/src/components/user/shared/ListingFormFields.tsx
+++ b/frontend/src/components/user/shared/ListingFormFields.tsx
@@ -31,8 +31,8 @@ export function ListingImagesField({
         <Field label="Photos (up to 10)" error={error}>
             <div className="space-y-3">
                 <label className="flex h-28 w-full cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50/50 transition-colors hover:bg-slate-50">
-                    <Upload className="w-6 h-6 text-slate-400 mb-1" />
-                    <span className="text-sm font-medium text-slate-600">Tap to add photos</span>
+                    <Upload className="w-6 h-6 text-foreground-subtle mb-1" />
+                    <span className="text-sm font-medium text-foreground-tertiary">Tap to add photos</span>
                     <input
                         type="file"
                         accept="image/*"
@@ -103,8 +103,8 @@ export function ListingLocationField({
         <Field label="Listing Location" error={error}>
             <div className="space-y-2">
                 {display ? (
-                    <div className="flex h-11 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm text-slate-700">
-                        <MapPin className="w-4 h-4 text-slate-400 shrink-0" />
+                    <div className="flex h-11 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm text-foreground-secondary">
+                        <MapPin className="w-4 h-4 text-foreground-subtle shrink-0" />
                         <span className="truncate">{display}</span>
                         <span className="ml-auto shrink-0 rounded bg-slate-200 px-2 py-0.5 text-xs font-semibold uppercase text-muted-foreground">
                             {fixedLabel}
@@ -113,8 +113,8 @@ export function ListingLocationField({
                 ) : (
                     placeholder
                         ? (
-                            <div className="flex h-11 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm text-slate-700">
-                                <MapPin className="w-4 h-4 text-slate-400 shrink-0" />
+                            <div className="flex h-11 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm text-foreground-secondary">
+                                <MapPin className="w-4 h-4 text-foreground-subtle shrink-0" />
                                 <span className="truncate">{placeholder}</span>
                                 <span className="ml-auto shrink-0 rounded bg-slate-200 px-2 py-0.5 text-xs font-semibold uppercase text-muted-foreground">
                                     {fixedLabel}
@@ -151,7 +151,7 @@ export function ListingTitleField({ label, error, registerProps, placeholder, va
                 />
                 <span className={cn(
                     "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium tabular-nums",
-                    valueLength > (maxLength - 5) ? "text-red-400" : "text-slate-400"
+                    valueLength > (maxLength - 5) ? "text-red-400" : "text-foreground-subtle"
                 )}>
                     {valueLength}/{maxLength}
                 </span>
@@ -209,7 +209,7 @@ export function ListingDescriptionField({ label = "Description", error, register
                 />
                 <span className={cn(
                     "pointer-events-none absolute right-3 bottom-2 text-xs font-medium tabular-nums",
-                    valueLength > (maxLength - 100) ? "text-red-400" : "text-slate-400"
+                    valueLength > (maxLength - 100) ? "text-red-400" : "text-foreground-subtle"
                 )}>
                     {valueLength}/{maxLength}
                 </span>
@@ -254,11 +254,11 @@ export function CategorySelectorGrid({
                             "flex flex-col items-center gap-1 rounded-xl border px-1 py-3 text-center transition-all",
                             selected
                                 ? "bg-primary border-primary text-white"
-                                : "bg-white border-slate-200 text-slate-600 hover:border-slate-300",
+                                : "bg-white border-slate-200 text-foreground-tertiary hover:border-slate-300",
                             disabled && !selected ? "opacity-40" : ""
                         )}
                     >
-                        <Icon className={cn("w-5 h-5", selected ? "text-white" : "text-slate-400")} />
+                        <Icon className={cn("w-5 h-5", selected ? "text-white" : "text-foreground-subtle")} />
                         <span className="w-full truncate px-1 text-xs font-semibold leading-tight">
                             {cat.name}
                         </span>

--- a/frontend/src/components/user/shared/ListingFormFields.tsx
+++ b/frontend/src/components/user/shared/ListingFormFields.tsx
@@ -134,14 +134,15 @@ export function ListingLocationField({
 interface ListingTitleFieldProps {
     label: string;
     error?: string;
+    required?: boolean;
     registerProps: UseFormRegisterReturn;
     placeholder: string;
     valueLength: number;
     maxLength?: number;
 }
-export function ListingTitleField({ label, error, registerProps, placeholder, valueLength, maxLength = 60 }: ListingTitleFieldProps) {
+export function ListingTitleField({ label, error, required = true, registerProps, placeholder, valueLength, maxLength = 60 }: ListingTitleFieldProps) {
     return (
-        <Field label={label} error={error}>
+        <Field label={label} error={error} required={required}>
             <div className="relative">
                 <Input
                     {...registerProps}
@@ -163,13 +164,14 @@ export function ListingTitleField({ label, error, registerProps, placeholder, va
 interface ListingPriceFieldProps {
     label?: string;
     error?: string;
+    required?: boolean;
     registerProps: UseFormRegisterReturn;
     placeholder?: string;
     showCurrencySymbol?: boolean;
 }
-export function ListingPriceField({ label = "Price (₹)", error, registerProps, placeholder = "0", showCurrencySymbol = false }: ListingPriceFieldProps) {
+export function ListingPriceField({ label = "Price (₹)", error, required = true, registerProps, placeholder = "0", showCurrencySymbol = false }: ListingPriceFieldProps) {
     return (
-        <Field label={label} error={error}>
+        <Field label={label} error={error} required={required}>
             <div className="relative">
                 {showCurrencySymbol && (
                     <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground font-semibold text-sm pointer-events-none">₹</span>
@@ -192,14 +194,15 @@ export function ListingPriceField({ label = "Price (₹)", error, registerProps,
 interface ListingDescriptionFieldProps {
     label?: string;
     error?: string;
+    required?: boolean;
     registerProps: UseFormRegisterReturn;
     placeholder?: string;
     valueLength: number;
     maxLength?: number;
 }
-export function ListingDescriptionField({ label = "Description", error, registerProps, placeholder, valueLength, maxLength = 2000 }: ListingDescriptionFieldProps) {
+export function ListingDescriptionField({ label = "Description", error, required = true, registerProps, placeholder, valueLength, maxLength = 2000 }: ListingDescriptionFieldProps) {
     return (
-        <Field label={label} error={error}>
+        <Field label={label} error={error} required={required}>
             <div className="relative">
                 <Textarea
                     {...registerProps}

--- a/frontend/src/components/user/shared/ListingItem.tsx
+++ b/frontend/src/components/user/shared/ListingItem.tsx
@@ -141,7 +141,7 @@ export function ListingItem({
                             </span>
                         ))}
                         {!isActive && timeAgo && (
-                            <span className="flex items-center gap-1 text-slate-400">
+                            <span className="flex items-center gap-1 text-foreground-subtle">
                                 <Clock className="h-3 w-3" /> {timeAgo}
                             </span>
                         )}
@@ -151,7 +151,7 @@ export function ListingItem({
                     {tags.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1.5">
                             {tags.map((tag, idx) => (
-                                <span key={idx} className={cn("px-2 py-0.5 rounded-full text-2xs font-medium border", tag.className || "bg-slate-50 text-slate-600 border-slate-100")}>
+                                <span key={idx} className={cn("px-2 py-0.5 rounded-full text-2xs font-medium border", tag.className || "bg-slate-50 text-foreground-tertiary border-slate-100")}>
                                     {tag.label}
                                 </span>
                             ))}

--- a/frontend/src/components/user/shared/ListingModalLayout.tsx
+++ b/frontend/src/components/user/shared/ListingModalLayout.tsx
@@ -90,7 +90,7 @@ export function ListingModalLoading() {
         <div className="fixed inset-0 z-[1001] flex flex-col bg-white overflow-hidden sm:bg-slate-900/40 sm:backdrop-blur-md sm:items-center sm:justify-center sm:p-6">
             <div className="flex flex-col bg-white flex-1 overflow-hidden sm:flex-none sm:w-full sm:max-w-lg sm:max-h-[90dvh] sm:rounded-2xl sm:shadow-2xl sm:border sm:border-slate-900/10">
                 <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm gap-2">
-                    <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+                    <Loader2 className="w-6 h-6 animate-spin text-foreground-subtle" />
                 </div>
             </div>
         </div>

--- a/frontend/src/components/user/shared/ListingSubmissionSuccessModal.tsx
+++ b/frontend/src/components/user/shared/ListingSubmissionSuccessModal.tsx
@@ -30,12 +30,12 @@ export function ListingSubmissionSuccessModal({
                     <h2 className="text-xl font-bold text-foreground">
                         {isEditMode ? `${entityLabel} Updated Successfully` : `${entityLabel} Submitted Successfully`}
                     </h2>
-                    <p className="text-sm text-slate-600">
+                    <p className="text-sm text-foreground-tertiary">
                         {isEditMode
                             ? "Your changes are pending admin review. They will go live after approval."
                             : "Pending admin review. It will go live after approval."}
                     </p>
-                    <p className="mt-1 text-xs text-slate-400">Typically reviewed within 24 hours.</p>
+                    <p className="mt-1 text-xs text-foreground-subtle">Typically reviewed within 24 hours.</p>
                 </div>
 
                 <div className="space-y-3 pt-2">
@@ -48,7 +48,7 @@ export function ListingSubmissionSuccessModal({
                     <Button
                         variant="outline"
                         onClick={onSecondaryAction}
-                        className="w-full h-11 border-slate-200 text-slate-700 hover:bg-slate-50"
+                        className="w-full h-11 border-slate-200 text-foreground-secondary hover:bg-slate-50"
                     >
                         {pendingActionLabel}
                     </Button>

--- a/frontend/src/components/user/shared/UserListingsTemplate.tsx
+++ b/frontend/src/components/user/shared/UserListingsTemplate.tsx
@@ -91,7 +91,7 @@ export function UserListingsTemplate<TStatus extends string, TItem>({
                                 className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-semibold border-b-2 transition-colors -mb-px whitespace-nowrap
                                     ${activeSubTab === t.value
                                         ? activeTabClass
-                                        : "border-transparent text-muted-foreground hover:text-slate-700"
+                                        : "border-transparent text-muted-foreground hover:text-foreground-secondary"
                                     }`}
                             >
                                 {t.icon}
@@ -111,7 +111,7 @@ export function UserListingsTemplate<TStatus extends string, TItem>({
                             onClick={() => onStatusChange(status)}
                             className={`px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${selectedStatus === status
                                 ? "bg-slate-900 text-white shadow"
-                                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                                : "bg-slate-100 text-foreground-tertiary hover:bg-slate-200"
                                 }`}
                         >
                             {status.charAt(0).toUpperCase() + status.slice(1)}
@@ -134,7 +134,7 @@ export function UserListingsTemplate<TStatus extends string, TItem>({
                     </div>
                 ) : items.length === 0 ? (
                     <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-                        <div className="mb-4 text-slate-200">{emptyState.icon}</div>
+                        <div className="mb-4 text-foreground-subtle">{emptyState.icon}</div>
                         <h3 className="text-sm font-semibold text-foreground mb-1">{emptyState.title}</h3>
                         <p className="text-xs text-muted-foreground max-w-[240px] mb-6">{emptyState.description}</p>
                         {emptyState.cta}

--- a/frontend/src/components/user/useBrowseListingsController.ts
+++ b/frontend/src/components/user/useBrowseListingsController.ts
@@ -1,5 +1,7 @@
 "use client";
 
+const SEARCH_DEBOUNCE_MS = 350;
+
 import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -315,7 +317,7 @@ export function useBrowseListingsController<TItem, TFilters>({
       debounceRef.current = setTimeout(() => {
         setQuery(value);
         router.replace(buildNextUrl({ q: value }), { scroll: false });
-      }, 350);
+      }, SEARCH_DEBOUNCE_MS);
     },
     [buildNextUrl, router]
   );

--- a/frontend/src/components/user/wizard/WizardModalShell.tsx
+++ b/frontend/src/components/user/wizard/WizardModalShell.tsx
@@ -83,7 +83,7 @@ export function WizardModalShell({
             <button
               type="button"
               onClick={onClose}
-              className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center rounded-full text-slate-700 transition-colors hover:bg-slate-100"
+              className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center rounded-full text-foreground-secondary transition-colors hover:bg-slate-100"
               aria-label="Close"
             >
               <X className="h-5 w-5" />

--- a/frontend/src/config/categoryVisuals.ts
+++ b/frontend/src/config/categoryVisuals.ts
@@ -28,7 +28,7 @@ export interface CategoryVisual {
 
 export const DEFAULT_CATEGORY_VISUAL: CategoryVisual = {
     icon: Package,
-    color: "text-slate-600",
+    color: "text-foreground-tertiary",
     bg: "bg-slate-50"
 };
 
@@ -64,7 +64,7 @@ export const CATEGORY_VISUALS: Record<string, CategoryVisual> = {
     consoles: { icon: Gamepad2, color: "text-emerald-600", bg: "bg-emerald-50" },
     gamepad: { icon: Gamepad2, color: "text-emerald-600", bg: "bg-emerald-50" },
 
-    jobs: { icon: Store, color: "text-slate-600", bg: "bg-slate-50" },
+    jobs: { icon: Store, color: "text-foreground-tertiary", bg: "bg-slate-50" },
     services: { icon: Wrench, color: "text-orange-600", bg: "bg-orange-50" },
 
     pets: { icon: PawPrint, color: "text-rose-600", bg: "bg-rose-50" },
@@ -79,7 +79,7 @@ export const CATEGORY_VISUALS: Record<string, CategoryVisual> = {
     watch: { icon: Watch, color: "text-teal-600", bg: "bg-teal-50" },
     smartwatch: { icon: Watch, color: "text-teal-600", bg: "bg-teal-50" },
 
-    components: { icon: HardDrive, color: "text-slate-600", bg: "bg-slate-50" },
+    components: { icon: HardDrive, color: "text-foreground-tertiary", bg: "bg-slate-50" },
     cameras: { icon: Camera, color: "text-yellow-600", bg: "bg-yellow-50" },
 
     "spare-parts": { icon: Wrench, color: "text-orange-600", bg: "bg-orange-50" },

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -207,9 +207,6 @@ export function AuthProvider({
         }
 
         if (typeof window !== "undefined") {
-          localStorage.removeItem(
-            "esparex_access_token"
-          );
           localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
         }
 
@@ -392,8 +389,7 @@ export function AuthProvider({
       }
     } finally {
       if (typeof window !== "undefined") {
-        localStorage.removeItem("esparex_access_token");
-        localStorage.removeItem("esparex_user_session");
+        localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
         localStorage.removeItem("esparex_fcm_token");
         localStorage.removeItem("esparex_fcm_registration_v1");
       }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -116,6 +116,8 @@ export function AuthProvider({
   const authBannerShownRef = useRef(false);
   const wasAuthenticatedRef = useRef(false);
   const staleSessionCleanupRef = useRef(false);
+  const networkRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const networkRetryCountRef = useRef(0);
 
   /* ------------------------------------------------------------------------ */
   /* Fetch User                                                               */
@@ -224,6 +226,32 @@ export function AuthProvider({
         return;
       }
 
+      /* Network error — backend is sleeping (Render free tier) or unreachable.
+         Do NOT treat this as a session expiry. Stay in "loading" and retry so
+         the user isn't kicked to the login page just because the backend is cold. */
+      if (!err.response) {
+        const MAX_NETWORK_RETRIES = 3;
+        if (networkRetryCountRef.current < MAX_NETWORK_RETRIES) {
+          networkRetryCountRef.current += 1;
+          const delay = networkRetryCountRef.current * 5_000; // 5s, 10s, 15s
+          if (process.env.NODE_ENV === "development") {
+            logger.warn(`[Auth] Network error — retrying in ${delay / 1000}s (attempt ${networkRetryCountRef.current}/${MAX_NETWORK_RETRIES})`);
+          }
+          networkRetryTimerRef.current = setTimeout(() => {
+            fetchingRef.current = false;
+            void fetchUser();
+          }, delay);
+          // Stay in "loading" — withGuard shows null, no login redirect
+          return;
+        }
+        // Give up after MAX_NETWORK_RETRIES — backend is genuinely down
+        networkRetryCountRef.current = 0;
+        setUser(null);
+        setStatus("unauthenticated");
+        // Preserve hasAuthHint so next page load re-attempts without requiring re-login
+        return;
+      }
+
       /* Rate limit / boot noise */
       if (
         err.isExpected ||
@@ -245,7 +273,6 @@ export function AuthProvider({
         );
       }
 
-      /* ✅ FIXED ERROR TYPE */
       setError(
         new Error(
           err.message ||
@@ -377,6 +404,11 @@ export function AuthProvider({
   /* ------------------------------------------------------------------------ */
 
   const logout = useCallback(async (options?: { skipServerLogout?: boolean }) => {
+    if (networkRetryTimerRef.current) {
+      clearTimeout(networkRetryTimerRef.current);
+      networkRetryTimerRef.current = null;
+    }
+    networkRetryCountRef.current = 0;
     try {
       if (!options?.skipServerLogout) {
         await authApi.logout();
@@ -401,7 +433,7 @@ export function AuthProvider({
       authBannerShownRef.current = false;
       staleSessionCleanupRef.current = false;
     }
-  }, []);
+  }, [fetchUser]);
 
   /* ------------------------------------------------------------------------ */
   /* Provider                                                                 */

--- a/frontend/src/context/BackendStatusContext.tsx
+++ b/frontend/src/context/BackendStatusContext.tsx
@@ -18,6 +18,8 @@ const BackendStatusContext = createContext<BackendStatus>({
     checked: false,
 });
 
+const HEALTH_CHECK_INTERVAL_MS = 2 * 60 * 1000; // re-check every 2 minutes
+
 export function BackendStatusProvider({
     children,
 }: {
@@ -30,12 +32,17 @@ export function BackendStatusProvider({
         const apiBase = resolveBrowserApiBaseUrl((
             process.env.NEXT_PUBLIC_API_URL || `${DEFAULT_LOCAL_API_ORIGIN}${API_V1_BASE_PATH}`
         )).replace(/\/$/, "");
-        fetch(`${apiBase}/${API_ROUTES.USER.HEALTH}`, {
-            method: "GET",
-        })
-            .then(() => setIsBackendUp(true))
-            .catch(() => setIsBackendUp(false))
-            .finally(() => setChecked(true));
+
+        const check = () => {
+            fetch(`${apiBase}/${API_ROUTES.USER.HEALTH}`, { method: "GET" })
+                .then(() => setIsBackendUp(true))
+                .catch(() => setIsBackendUp(false))
+                .finally(() => setChecked(true));
+        };
+
+        check();
+        const interval = setInterval(check, HEALTH_CHECK_INTERVAL_MS);
+        return () => clearInterval(interval);
     }, []);
 
     const value = useMemo(

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -92,7 +92,7 @@ class APIClient {
     private healthCheckTimestamp = 0;
     private csrfToken: string | null = null;
     private csrfTokenPromise: Promise<string | null> | null = null;
-    private readonly HEALTH_CACHE_MS = 30_000;
+    private readonly HEALTH_CACHE_MS = 10_000;
 
     constructor() {
         validateApiEnv();
@@ -226,6 +226,8 @@ class APIClient {
                     const headers = new AxiosHeaders(config.headers);
                     headers.set('x-csrf-token', csrfToken);
                     config.headers = headers;
+                } else {
+                    logger.warn('[API Client] CSRF token unavailable for state-changing request. If this results in a 403, refresh the page. Endpoint:', config.url);
                 }
             }
 
@@ -297,6 +299,17 @@ class APIClient {
                 return response;
             },
             async (rawError: unknown) => {
+                // Decrypt encrypted error responses before processing
+                const rawErrorObj = rawError as { response?: { headers?: Record<string, string>; data?: unknown } };
+                if (rawErrorObj?.response?.headers?.['x-encrypted'] === 'true' && rawErrorObj.response.data) {
+                    try {
+                        const decrypted = decryptData((rawErrorObj.response.data as { payload?: string })?.payload ?? rawErrorObj.response.data as string);
+                        if (decrypted) rawErrorObj.response.data = decrypted;
+                    } catch {
+                        // Decryption failed — use original data
+                    }
+                }
+
                 let normalized = normalizeError(rawError);
 
                 const getResponseMessage = (current: typeof normalized) => {

--- a/frontend/src/lib/api/normalizeError.ts
+++ b/frontend/src/lib/api/normalizeError.ts
@@ -50,7 +50,9 @@ export function normalizeError(raw: unknown): NormalizedApiError {
                 status,
                 data: error.response.data
             },
-            category: status >= 500 ? ErrorCategory.SYSTEM : ErrorCategory.NETWORK,
+            // 5xx errors with a response came from the backend — not a true SYSTEM (no-response) failure.
+            // SYSTEM is reserved for errors with no HTTP response at all.
+            category: ErrorCategory.NETWORK,
             isExpected: status < 500 || status === 429,
             message: error.message || 'Request failed',
             retryAfter

--- a/frontend/src/lib/errorHandler.ts
+++ b/frontend/src/lib/errorHandler.ts
@@ -344,6 +344,7 @@ export const createAuthError = (reason: string): EsparexError | null => {
   // � ARCHITECTURAL STANDARDS RULE: 
   // Authentication state is NOT an error. Expected transitions (logged out / expired) return null.
   if (reason === 'sessionExpired' || reason === 'notLoggedIn') {
+    console.info(`[Auth] Silent state transition: ${reason}`);
     return null; // Silent state transition
   }
 
@@ -637,36 +638,3 @@ export const requireOnline = (operation: string): void => {
   }
 };
 
-// ============================================================================
-// ERROR RECOVERY
-// ============================================================================
-
-export const createRecoveryAction = (
-  error: EsparexError
-): { text: string; action: () => void } | null => {
-  switch (error.code) {
-    case ErrorCode.NETWORK_OFFLINE:
-      return {
-        text: "Check Connection",
-        action: () => window.location.reload(),
-      };
-    case ErrorCode.AUTH_NOT_LOGGED_IN:
-    case ErrorCode.AUTH_SESSION_EXPIRED:
-      return {
-        text: "Log In",
-        action: () => {
-          // Navigate to login
-          window.location.href = "/";
-        },
-      };
-    case ErrorCode.DATA_LOAD_FAILED:
-      return {
-        text: "Refresh Page",
-        action: () => window.location.reload(),
-      };
-    default:
-      return error.retryable
-        ? { text: "Try Again", action: () => { } }
-        : null;
-  }
-};

--- a/frontend/src/lib/errorMapper.ts
+++ b/frontend/src/lib/errorMapper.ts
@@ -72,6 +72,12 @@ export function mapErrorToMessage(error: unknown, fallback?: string): string {
         return fallback || 'An unexpected error occurred';
     }
 
+    // If the error already carries a user-friendly message (e.g. EsparexError), return it directly.
+    if (typeof error === 'object' && error !== null && typeof (error as { userMessage?: unknown }).userMessage === 'string') {
+        const msg = ((error as { userMessage: string }).userMessage).trim();
+        if (msg.length > 0) return msg;
+    }
+
     // Handle ApiError with code
     if (typeof error === 'object' && error !== null) {
         const apiError = error as ApiError;

--- a/frontend/src/lib/errors/errorToPopup.ts
+++ b/frontend/src/lib/errors/errorToPopup.ts
@@ -38,7 +38,8 @@ export function errorToPopup(
   let type: PopupType = "error";
 
   if (error.status === 404) type = "info";
-  else if (error.status === 400 || error.status === 409) type = "warning";
+  else if (error.status === 400) type = "warning";
+  else if (error.status === 409) type = "error";
   else if (error.status >= 500 || error.status === 0) type = "error";
   else if (error.status === 401 || error.status === 403) type = "error";
 

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -4,6 +4,7 @@
  */
 
 import { createValidationError, EsparexError, sanitizeInput } from "./errorHandler";
+import { CONTACT_LIMITS } from "@shared/constants/fieldLimits";
 
 // ============================================================================
 // VALIDATION RESULT
@@ -169,8 +170,7 @@ export const formatPhoneForAPI = (mobile: string): string => {
  * @returns boolean
  */
 export const validateIndianMobile = (mobile: string): boolean => {
-  const regex = /^[6-9]\d{9}$/;
-  return regex.test(mobile.replace(/\D/g, ""));
+  return CONTACT_LIMITS.PHONE.PATTERN.test(mobile.replace(/\D/g, ""));
 };
 
 // ============================================================================

--- a/frontend/src/schemas/business.schema.shared.ts
+++ b/frontend/src/schemas/business.schema.shared.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CONTACT_LIMITS } from "@shared/constants/fieldLimits";
 
 const ALLOWED_ID_PROOF_TYPES = ["aadhaar", "pan", "driving_license", "voter_id"] as const;
 
@@ -87,7 +88,7 @@ const requiredBusinessFields = {
         .string()
         .transform((value) => value.replace(/\D/g, "").slice(-10))
         .refine(
-            (value) => /^[6-9]\d{9}$/.test(value),
+            (value) => CONTACT_LIMITS.PHONE.PATTERN.test(value),
             "Contact number must be a valid 10-digit Indian mobile starting with 6-9",
         ),
 

--- a/frontend/src/schemas/profileSettings.schema.ts
+++ b/frontend/src/schemas/profileSettings.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { MOBILE_VISIBILITY } from "@shared/constants/mobileVisibility";
+import { BUSINESS_LIMITS } from "@shared/constants/fieldLimits";
 
 import { DELETE_ACCOUNT_REASONS } from "@/components/user/profile/types";
 
@@ -30,8 +31,20 @@ export const profileFormSchema = z.object({
   businessName: optionalTrimmedString(
     z.string().max(100, "Business name must be 100 characters or fewer.")
   ),
-  gstNumber: optionalTrimmedString(
-    z.string().max(20, "GST number must be 20 characters or fewer.")
+  gstNumber: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const trimmed = value.trim().toUpperCase();
+      return trimmed === "" ? undefined : trimmed;
+    },
+    z
+      .string()
+      .length(BUSINESS_LIMITS.GST.LENGTH, BUSINESS_LIMITS.GST.ERROR_FORMAT)
+      .refine(
+        (val) => BUSINESS_LIMITS.GST.PATTERN.test(val),
+        BUSINESS_LIMITS.GST.ERROR_FORMAT
+      )
+      .optional()
   ),
   mobileVisibility: z.enum([
     MOBILE_VISIBILITY.SHOW,

--- a/frontend/src/schemas/serviceListingPayload.schema.ts
+++ b/frontend/src/schemas/serviceListingPayload.schema.ts
@@ -32,7 +32,7 @@ export const ServiceListingPayloadSchema = BaseServicePayloadSchema
         // serviceTypeIds uses ObjectIdSchema (z.preprocess → unknown output); override with plain string[]
         serviceTypeIds: z.array(z.string()).min(1, 'Select at least one service type'),
         // Single price field — mapped to priceMin on submit (backend expects priceMin)
-        price: z.number({ invalid_type_error: 'Enter a valid price' }).min(0, 'Price must be at least 0'),
+        price: z.number({ invalid_type_error: 'Enter a valid price' }).min(0, 'Price must be at least 0').max(10_000_000, 'Price cannot exceed ₹1 crore'),
     }));
 
 export type ServiceListingFormData = z.infer<typeof ServiceListingPayloadSchema>;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -71,6 +71,11 @@
   --font-weight-medium: 500;
   --font-weight-normal: 400;
 
+  /* Extended foreground text tokens — fills gap between foreground and muted-foreground */
+  --foreground-secondary: 215.4 25% 26.7%;   /* ≈ slate-700 — secondary body text */
+  --foreground-tertiary: 215.3 19.3% 34.5%;  /* ≈ slate-600 — captions, labels */
+  --foreground-subtle: 215.4 16.3% 56.9%;    /* ≈ slate-400 — placeholder, disabled */
+
   /* Sidebar Tokens */
   --sidebar: 210 40% 98%;
   --sidebar-foreground: 0 0% 10.2%;
@@ -156,6 +161,11 @@
   --sidebar-accent-foreground: 210 40% 98%;
   --sidebar-border: 217.2 32.6% 17.5%;
   --sidebar-ring: 142.1 76.2% 45.3%;
+
+  /* Extended foreground text tokens (dark mode) */
+  --foreground-secondary: 215 20.2% 75.1%;
+  --foreground-tertiary: 215 20.2% 65.1%;
+  --foreground-subtle: 215 20.2% 45.1%;
 
   /* Link / interactive blue (slightly lighter in dark mode) */
   --link: 213.1 93.9% 67.8%;        /* blue-400 for better contrast on dark bg */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,6 +18,10 @@ const config = {
 					dark: 'hsl(var(--link-dark))',
 					foreground: 'hsl(var(--link-foreground))',
 				},
+				/* Extended foreground tokens (fills gap between foreground ↔ muted-foreground) */
+				'foreground-secondary': 'hsl(var(--foreground-secondary))',  /* ≈ slate-700 */
+				'foreground-tertiary': 'hsl(var(--foreground-tertiary))',    /* ≈ slate-600 */
+				'foreground-subtle': 'hsl(var(--foreground-subtle))',        /* ≈ slate-400 */
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',

--- a/render.yaml
+++ b/render.yaml
@@ -18,3 +18,21 @@ services:
         sync: false # Set this in the Render Dashboard for security
       - key: CORS_ORIGIN
         sync: false # Set this in the Render Dashboard: https://esparex.in
+
+  # --- Keep-alive cron (prevents free-tier cold starts) ---
+  - type: cron
+    name: esparex-keepalive
+    env: node
+    plan: free
+    schedule: "*/10 * * * *"
+    buildCommand: "echo 'no build needed'"
+    startCommand: >
+      node -e "
+        const https = require('https');
+        https.get('https://api.esparex.in/health', (res) => {
+          console.log('ping status:', res.statusCode);
+        }).on('error', (e) => {
+          console.error('ping failed:', e.message);
+          process.exit(1);
+        });
+      "

--- a/shared/schemas/adPayload.schema.ts
+++ b/shared/schemas/adPayload.schema.ts
@@ -70,7 +70,7 @@ export const BaseAdPayloadSchema = z.object({
         checkQuality: true
     }),
 
-    price: z.number().min(0, 'Price must be at least 0'),
+    price: z.number().min(0, 'Price must be at least 0').max(10_000_000, 'Price cannot exceed ₹1 crore'),
     images: z
         .array(z.string())
         .min(MIN_AD_IMAGES, `At least ${MIN_AD_IMAGES} image is required`)

--- a/shared/schemas/servicePayload.schema.ts
+++ b/shared/schemas/servicePayload.schema.ts
@@ -46,6 +46,7 @@ const servicePayloadShape = {
 
     priceMin: z.number()
         .min(0, 'Minimum price must be at least 0')
+        .max(10_000_000, 'Price cannot exceed ₹1 crore')
         .optional(),
 
     // Uses centralized text validation (bans profanity, gibberish, etc.)

--- a/shared/schemas/sparePartPayload.schema.ts
+++ b/shared/schemas/sparePartPayload.schema.ts
@@ -28,7 +28,7 @@ export const BaseSparePartPayloadSchema = z.object({
 
     description: validatedTextSchema({
         fieldName: 'Description',
-        minLength: 10,
+        minLength: 20,
         maxLength: 2000,
         strictMode: false,
         checkBannedWords: true,
@@ -36,7 +36,7 @@ export const BaseSparePartPayloadSchema = z.object({
         checkQuality: true,
     }),
 
-    price: z.number().min(0, 'Price must be at least 0'),
+    price: z.number().min(0, 'Price must be at least 0').max(10_000_000, 'Price cannot exceed ₹1 crore'),
     images: z.array(z.string()).min(1, 'At least one image is required').max(10, 'Maximum 10 images allowed'),
 });
 


### PR DESCRIPTION
## Summary

7 commits of fixes across typography, security, auth, and error handling.

- **Typography system** — unified font scale, color tokens (slate → semantic), antialiased rendering
- **Two-session form/UX audit** — phone regex deduplication, GST validation, ₹1 crore price cap, character counters, required asterisks, notifications page
- **Auth network fix** — logged-in users no longer redirected to login when backend is briefly unavailable (cold start / Render free tier)
- **Keep-alive cron** — Render pings `/health` every 10 min, prevents free-tier sleep
- **Backend security audit** — PATCH /ads/:id added, Redis TTL 300→60s, delete cascade on account deletion, rate limit on /auth/me, phone normalization hardened, USE_DEFAULT_OTP blocked in prod, pagination capped, idempotency race fixed, coordinate validation, 204 on deletes
- **Error handling gaps** — EsparexError bridged, encrypted error decryption, health cache 10s, 409→error toast, CSRF logging, 5xx reclassified, pagination clamping surfaced
- **Font preload fix** — italic Inter not preloaded on first paint

## Test plan

- [ ] Login, OTP verify, blocked account message
- [ ] Post Ad / Service / Spare Part — required fields, character counters, price cap
- [ ] Edit listing — catalog fields locked, editable fields update correctly
- [ ] Delete listing → 204, account delete → cascades to listings
- [ ] Notifications page loads, bell dropdown shows "View all"
- [ ] Backend cold start — no spurious login redirect
- [ ] 409 conflict shows as red error toast (not yellow warning)
- [ ] Android keyboard doesn't overlap inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)