### PR TITLE
refactor(config): centralize backend runtime env access

### DIFF
--- a/backend/src/__tests__/config/firebaseAdmin.spec.ts
+++ b/backend/src/__tests__/config/firebaseAdmin.spec.ts
@@ -1,7 +1,9 @@
 describe("firebaseAdmin", () => {
-    const originalEnv = process.env;
-
-    const loadFirebaseAdmin = () => {
+    const loadFirebaseAdmin = (envOverrides: {
+        NODE_ENV?: "development" | "production" | "test";
+        FIREBASE_SERVICE_ACCOUNT_JSON?: string;
+        ALLOW_FIREBASE_ADMIN?: boolean;
+    } = {}) => {
         const mockInitializeApp = jest.fn();
         const mockCert = jest.fn(() => ({ kind: "credential" }));
         const mockAdmin = {
@@ -26,6 +28,14 @@ describe("firebaseAdmin", () => {
             __esModule: true,
             default: mockLogger,
         }));
+        jest.doMock("../../config/env", () => ({
+            __esModule: true,
+            env: {
+                NODE_ENV: envOverrides.NODE_ENV ?? "development",
+                FIREBASE_SERVICE_ACCOUNT_JSON: envOverrides.FIREBASE_SERVICE_ACCOUNT_JSON,
+                ALLOW_FIREBASE_ADMIN: envOverrides.ALLOW_FIREBASE_ADMIN ?? false,
+            },
+        }));
 
         const firebaseAdmin = require("../../config/firebaseAdmin").default;
 
@@ -41,19 +51,12 @@ describe("firebaseAdmin", () => {
     beforeEach(() => {
         jest.resetModules();
         jest.clearAllMocks();
-        process.env = { ...originalEnv };
-        delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-        delete process.env.ALLOW_FIREBASE_ADMIN;
-    });
-
-    afterAll(() => {
-        process.env = originalEnv;
     });
 
     it("uses the fallback mock when service-account credentials are absent", async () => {
-        process.env.NODE_ENV = "development";
-
-        const { firebaseAdmin, mockCert, mockInitializeApp, mockLogger } = loadFirebaseAdmin();
+        const { firebaseAdmin, mockCert, mockInitializeApp, mockLogger } = loadFirebaseAdmin({
+            NODE_ENV: "development",
+        });
 
         expect(mockCert).not.toHaveBeenCalled();
         expect(mockInitializeApp).not.toHaveBeenCalled();
@@ -73,14 +76,16 @@ describe("firebaseAdmin", () => {
     });
 
     it("initializes firebase-admin with a cleaned private key when credentials are configured", () => {
-        process.env.NODE_ENV = "production";
-        process.env.FIREBASE_SERVICE_ACCOUNT_JSON = JSON.stringify({
+        const serviceAccountJson = JSON.stringify({
             project_id: "esparex-test",
             client_email: "firebase-adminsdk@test.example.com",
             private_key: "-----BEGIN PRIVATE KEY-----\\nabc123\\n-----END PRIVATE KEY-----\\n",
         });
 
-        const { firebaseAdmin, mockAdmin, mockCert, mockInitializeApp } = loadFirebaseAdmin();
+        const { firebaseAdmin, mockAdmin, mockCert, mockInitializeApp } = loadFirebaseAdmin({
+            NODE_ENV: "production",
+            FIREBASE_SERVICE_ACCOUNT_JSON: serviceAccountJson,
+        });
 
         expect(mockCert).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -96,14 +101,16 @@ describe("firebaseAdmin", () => {
     });
 
     it("skips initialization in test by default even when credentials are present", async () => {
-        process.env.NODE_ENV = "test";
-        process.env.FIREBASE_SERVICE_ACCOUNT_JSON = JSON.stringify({
+        const serviceAccountJson = JSON.stringify({
             project_id: "esparex-test",
             client_email: "firebase-adminsdk@test.example.com",
             private_key: "-----BEGIN PRIVATE KEY-----\\nabc123\\n-----END PRIVATE KEY-----\\n",
         });
 
-        const { firebaseAdmin, mockCert, mockInitializeApp } = loadFirebaseAdmin();
+        const { firebaseAdmin, mockCert, mockInitializeApp } = loadFirebaseAdmin({
+            NODE_ENV: "test",
+            FIREBASE_SERVICE_ACCOUNT_JSON: serviceAccountJson,
+        });
 
         expect(mockCert).not.toHaveBeenCalled();
         expect(mockInitializeApp).not.toHaveBeenCalled();
@@ -117,25 +124,27 @@ describe("firebaseAdmin", () => {
     });
 
     it("allows initialization in test when explicitly enabled", () => {
-        process.env.NODE_ENV = "test";
-        process.env.ALLOW_FIREBASE_ADMIN = "true";
-        process.env.FIREBASE_SERVICE_ACCOUNT_JSON = JSON.stringify({
+        const serviceAccountJson = JSON.stringify({
             project_id: "esparex-test",
             client_email: "firebase-adminsdk@test.example.com",
             private_key: "-----BEGIN PRIVATE KEY-----\\nabc123\\n-----END PRIVATE KEY-----\\n",
         });
 
-        const { mockCert, mockInitializeApp } = loadFirebaseAdmin();
+        const { mockCert, mockInitializeApp } = loadFirebaseAdmin({
+            NODE_ENV: "test",
+            ALLOW_FIREBASE_ADMIN: true,
+            FIREBASE_SERVICE_ACCOUNT_JSON: serviceAccountJson,
+        });
 
         expect(mockCert).toHaveBeenCalledTimes(1);
         expect(mockInitializeApp).toHaveBeenCalledTimes(1);
     });
 
     it("falls back to the mock admin when credential parsing fails", async () => {
-        process.env.NODE_ENV = "production";
-        process.env.FIREBASE_SERVICE_ACCOUNT_JSON = "{bad-json";
-
-        const { firebaseAdmin, mockInitializeApp, mockLogger } = loadFirebaseAdmin();
+        const { firebaseAdmin, mockInitializeApp, mockLogger } = loadFirebaseAdmin({
+            NODE_ENV: "production",
+            FIREBASE_SERVICE_ACCOUNT_JSON: "{bad-json",
+        });
 
         expect(mockInitializeApp).not.toHaveBeenCalled();
         expect(mockLogger.error).toHaveBeenCalledWith(

--- a/backend/src/__tests__/config/validateEnv.spec.ts
+++ b/backend/src/__tests__/config/validateEnv.spec.ts
@@ -47,11 +47,20 @@ describe('validateProductionEnvOrThrow', () => {
         );
     });
 
-    it('does not throw when USE_DEFAULT_OTP is enabled in production (DLT-pending mode)', () => {
+    it('throws when USE_DEFAULT_OTP is enabled in production', () => {
         const env = { ...baseProductionEnv, USE_DEFAULT_OTP: 'true' };
 
-        // Guard was relaxed to a warning to allow startup while awaiting DLT/MSG91 approval.
-        expect(() => validateProductionEnvOrThrow(env)).not.toThrow();
+        expect(() => validateProductionEnvOrThrow(env)).toThrow(
+            /USE_DEFAULT_OTP=true is not allowed in production/
+        );
+    });
+
+    it('throws when AUTH_BYPASS_OTP_LOCK is enabled in production', () => {
+        const env = { ...baseProductionEnv, AUTH_BYPASS_OTP_LOCK: 'true' };
+
+        expect(() => validateProductionEnvOrThrow(env)).toThrow(
+            /AUTH_BYPASS_OTP_LOCK=true is not allowed in production/
+        );
     });
 
     it('infers COOKIE_DOMAIN from split-subdomain production origins when it is omitted', () => {

--- a/backend/src/__tests__/utils/appUrl.spec.ts
+++ b/backend/src/__tests__/utils/appUrl.spec.ts
@@ -1,22 +1,52 @@
-import { getAdminAppUrl, getFrontendAppUrl, getFrontendInternalUrl } from '../../utils/appUrl';
-
 describe('appUrl helpers', () => {
-    const originalEnv = process.env;
+    const loadAppUrl = (envOverrides: {
+        NODE_ENV?: 'development' | 'production' | 'test';
+        FRONTEND_URL?: string;
+        FRONTEND_INTERNAL_URL?: string;
+        ADMIN_URL?: string;
+        ADMIN_FRONTEND_URL?: string;
+    } = {}) => {
+        jest.resetModules();
 
-    beforeEach(() => {
-        process.env = { ...originalEnv };
-        delete process.env.FRONTEND_URL;
-        delete process.env.FRONTEND_INTERNAL_URL;
-        delete process.env.ADMIN_URL;
-        delete process.env.ADMIN_FRONTEND_URL;
-    });
+        const mockLogger = {
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
 
-    afterAll(() => {
-        process.env = originalEnv;
+        jest.doMock('../../utils/logger', () => ({
+            __esModule: true,
+            default: mockLogger,
+        }));
+
+        jest.doMock('../../config/env', () => ({
+            __esModule: true,
+            env: {
+                NODE_ENV: envOverrides.NODE_ENV ?? 'development',
+                FRONTEND_URL: envOverrides.FRONTEND_URL,
+                FRONTEND_INTERNAL_URL: envOverrides.FRONTEND_INTERNAL_URL,
+                ADMIN_URL: envOverrides.ADMIN_URL,
+                ADMIN_FRONTEND_URL: envOverrides.ADMIN_FRONTEND_URL,
+            },
+        }));
+
+        const appUrl = require('../../utils/appUrl') as typeof import('../../utils/appUrl');
+
+        return {
+            ...appUrl,
+            mockLogger,
+        };
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
     });
 
     it('uses local defaults outside production', () => {
-        process.env.NODE_ENV = 'development';
+        const { getFrontendAppUrl, getFrontendInternalUrl, getAdminAppUrl } = loadAppUrl({
+            NODE_ENV: 'development',
+        });
 
         expect(getFrontendAppUrl()).toBe('http://localhost:3000');
         expect(getFrontendInternalUrl()).toBe('http://localhost:3000');
@@ -24,7 +54,9 @@ describe('appUrl helpers', () => {
     });
 
     it('uses production-safe Esparex.in defaults when env vars are missing in production', () => {
-        process.env.NODE_ENV = 'production';
+        const { getFrontendAppUrl, getFrontendInternalUrl, getAdminAppUrl } = loadAppUrl({
+            NODE_ENV: 'production',
+        });
 
         expect(getFrontendAppUrl()).toBe('https://esparex.in');
         expect(getFrontendInternalUrl()).toBe('https://esparex.in');
@@ -32,10 +64,12 @@ describe('appUrl helpers', () => {
     });
 
     it('prefers configured runtime URLs when provided', () => {
-        process.env.NODE_ENV = 'production';
-        process.env.FRONTEND_URL = 'https://exparex.in/';
-        process.env.FRONTEND_INTERNAL_URL = 'https://frontend.internal.exparex.in/';
-        process.env.ADMIN_FRONTEND_URL = 'https://admin.exparex.in/';
+        const { getFrontendAppUrl, getFrontendInternalUrl, getAdminAppUrl } = loadAppUrl({
+            NODE_ENV: 'production',
+            FRONTEND_URL: 'https://exparex.in/',
+            FRONTEND_INTERNAL_URL: 'https://frontend.internal.exparex.in/',
+            ADMIN_FRONTEND_URL: 'https://admin.exparex.in/',
+        });
 
         expect(getFrontendAppUrl()).toBe('https://exparex.in');
         expect(getFrontendInternalUrl()).toBe('https://frontend.internal.exparex.in');

--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -13,10 +13,10 @@
  * Browser / CORS concerns do NOT apply here.
  */
 
-import 'dotenv/config';
 import mongoose, { Connection } from 'mongoose';
 import logger from '../utils/logger';
 import { mongooseSerializationPlugin } from '../plugins/mongooseSerializationPlugin';
+import { env } from './env';
 
 /* ======================================================
    GLOBAL MONGOOSE SETTINGS
@@ -26,7 +26,7 @@ mongoose.plugin(mongooseSerializationPlugin);
 
 // Boot safety: index mutation is disabled on normal startup.
 // Use explicit maintenance commands/migrations for index changes.
-const shouldAutoIndex = process.env.ALLOW_BOOT_AUTO_INDEX === 'true';
+const shouldAutoIndex = env.ALLOW_BOOT_AUTO_INDEX;
 if (shouldAutoIndex) {
     logger.warn('⚠ ALLOW_BOOT_AUTO_INDEX=true — startup index mutation is enabled for maintenance mode only.');
 } else {
@@ -41,19 +41,19 @@ mongoose.set('autoIndex', shouldAutoIndex);
    ENV VALIDATION
 ====================================================== */
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = env.NODE_ENV === 'production';
 
-if (isProd && !process.env.MONGODB_URI) {
+if (isProd && !env.MONGODB_URI) {
     throw new Error('❌ MONGODB_URI is required in production');
 }
 
-if (isProd && !process.env.ADMIN_MONGODB_URI) {
+if (isProd && !env.ADMIN_MONGODB_URI) {
     throw new Error('❌ ADMIN_MONGODB_URI is required in production');
 }
 
 if (isProd) {
-    const mongoUri = process.env.MONGODB_URI;
-    const adminUri = process.env.ADMIN_MONGODB_URI;
+    const mongoUri = env.MONGODB_URI;
+    const adminUri = env.ADMIN_MONGODB_URI;
 
     const validateUri = (uri: string | undefined, label: string) => {
         if (!uri) return;
@@ -81,20 +81,20 @@ if (isProd) {
 ====================================================== */
 
 const USER_DB_URI =
-    process.env.MONGODB_URI || 'mongodb://localhost:27017/esparex_user';
+    env.MONGODB_URI || 'mongodb://localhost:27017/esparex_user';
 
 const ADMIN_DB_URI =
-    process.env.ADMIN_MONGODB_URI || 'mongodb://localhost:27017/esparex_admin';
+    env.ADMIN_MONGODB_URI || 'mongodb://localhost:27017/esparex_admin';
 
-if (!process.env.MONGODB_URI) {
+if (!env.MONGODB_URI) {
     logger.warn('Using local User MongoDB (development mode)');
 }
 
-if (!process.env.ADMIN_MONGODB_URI) {
+if (!env.ADMIN_MONGODB_URI) {
     logger.warn('ADMIN_MONGODB_URI not set. Using local Admin MongoDB default (development mode).');
 }
 
-if (process.env.MONGODB_URI && process.env.ADMIN_MONGODB_URI && process.env.MONGODB_URI === process.env.ADMIN_MONGODB_URI) {
+if (env.MONGODB_URI && env.ADMIN_MONGODB_URI && env.MONGODB_URI === env.ADMIN_MONGODB_URI) {
     logger.warn('User and Admin databases point to the same URI. Split architecture is disabled for this runtime.');
 }
 
@@ -124,7 +124,7 @@ const userCache = globalWithMongoose.mongooseUserCache;
 const adminCache = globalWithMongoose.mongooseAdminCache;
 
 const isUnified = USER_DB_URI === ADMIN_DB_URI;
-const skipDbConnect = process.env.NODE_ENV === 'test' && process.env.ALLOW_DB_CONNECT !== 'true';
+const skipDbConnect = env.NODE_ENV === 'test' && !env.ALLOW_DB_CONNECT;
 
 /* ======================================================
    READINESS CHECK

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -108,6 +108,44 @@ const envSchema = z.object({
     ENABLE_SCHEDULER: z.string().transform(val => val === 'true').default('true'),
     PROCESS_ROLE: z.enum(['api', 'scheduler']).default('api'),
     TZ: z.string().default('UTC'),
+
+    // Database boot flags
+    ALLOW_BOOT_AUTO_INDEX: z.string().transform(val => val === 'true').default('false'),
+    ALLOW_DB_CONNECT: z.string().transform(val => val === 'true').default('false'),
+
+    // Redis extras
+    REDIS_DB: z.string().default('0').transform(Number).pipe(z.number()),
+    ALLOW_REDIS: z.string().transform(val => val === 'true').default('false'),
+
+    // Auth dev flags (must be blocked in production — see validateProductionEnvOrThrow)
+    AUTH_LOCAL_RELAXED: z.string().transform(val => val === 'true').default('false'),
+    ALLOW_DEFAULT_ADMIN_SEED: z.string().transform(val => val === 'true').default('false'),
+
+    // AWS extras
+    AWS_CLOUDFRONT_URL: z.string().optional(),
+
+    // Fraud service tuning
+    FRAUD_DECISION_TIMEOUT_MS: z.string().default('1200').transform(Number).pipe(z.number().min(100)),
+
+    // Sentry dev override
+    SENTRY_ENABLE_DEV: z.string().transform(val => val === 'true').default('false'),
+
+    // Admin rate limiter overrides (optional; defaults applied in rateLimiter.ts)
+    ADMIN_RATE_LIMIT_MAX: z.string().transform(Number).pipe(z.number().positive()).optional(),
+    ADMIN_MUTATION_RATE_LIMIT_MAX: z.string().transform(Number).pipe(z.number().positive()).optional(),
+
+    // Firebase dev flag
+    ALLOW_FIREBASE_ADMIN: z.string().transform(val => val === 'true').default('false'),
+
+    // Scheduler queue dev flag
+    ALLOW_SCHEDULER_QUEUE: z.string().transform(val => val === 'true').default('false'),
+
+    // Redis client mode (informational, used in cache stats)
+    REDIS_MODE: z.string().default('single'),
+
+    // Cookie configuration overrides
+    COOKIE_SAME_SITE: z.enum(['strict', 'lax', 'none']).optional(),
+    COOKIE_SECURE: z.string().transform(val => val === 'true').optional(),
 });
 
 /**

--- a/backend/src/config/firebaseAdmin.ts
+++ b/backend/src/config/firebaseAdmin.ts
@@ -1,9 +1,10 @@
 import admin from 'firebase-admin';
 import logger from '../utils/logger';
+import { env } from './env';
 
-const hasFirebaseServiceAccountJson = typeof process.env.FIREBASE_SERVICE_ACCOUNT_JSON === 'string'
-    && process.env.FIREBASE_SERVICE_ACCOUNT_JSON.trim().length > 0;
-const disableForTest = process.env.NODE_ENV === 'test' && process.env.ALLOW_FIREBASE_ADMIN !== 'true';
+const hasFirebaseServiceAccountJson = typeof env.FIREBASE_SERVICE_ACCOUNT_JSON === 'string'
+    && (env.FIREBASE_SERVICE_ACCOUNT_JSON as string).trim().length > 0;
+const disableForTest = env.NODE_ENV === 'test' && !env.ALLOW_FIREBASE_ADMIN;
 let shouldDisableFirebase = disableForTest || !hasFirebaseServiceAccountJson;
 
 type FirebaseServiceAccount = admin.ServiceAccount & Record<string, unknown>;
@@ -23,7 +24,7 @@ const mockAdmin = {
 // Prevent multiple initializations
 if (!shouldDisableFirebase && !admin.apps.length) {
     try {
-        const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON as string) as FirebaseServiceAccount;
+        const serviceAccount = JSON.parse(env.FIREBASE_SERVICE_ACCOUNT_JSON as string) as FirebaseServiceAccount;
         logger.info("🔥 Firebase Admin: Using credentials from environment");
 
         // Clean the private key

--- a/backend/src/config/redis.ts
+++ b/backend/src/config/redis.ts
@@ -1,14 +1,15 @@
 import Redis from 'ioredis';
 import logger from '../utils/logger';
+import { env } from './env';
 
 const isJestRuntime = typeof process.env.JEST_WORKER_ID !== 'undefined';
 const shouldDisableRedis =
-    (process.env.NODE_ENV === 'test' || isJestRuntime) && process.env.ALLOW_REDIS !== 'true';
-const redisHost = process.env.REDIS_HOST || 'localhost';
-const redisPort = Number(process.env.REDIS_PORT || '6379');
-const redisPassword = process.env.REDIS_PASSWORD;
-const redisDb = Number(process.env.REDIS_DB || '0');
-const redisUrl = process.env.REDIS_URL || (() => {
+    (env.NODE_ENV === 'test' || isJestRuntime) && !env.ALLOW_REDIS;
+const redisHost = env.REDIS_HOST;
+const redisPort = env.REDIS_PORT;
+const redisPassword = env.REDIS_PASSWORD;
+const redisDb = env.REDIS_DB;
+const redisUrl = env.REDIS_URL || (() => {
     const auth = redisPassword ? `:${encodeURIComponent(redisPassword)}@` : '';
     return `redis://${auth}${redisHost}:${redisPort}/${redisDb}`;
 })();
@@ -20,7 +21,7 @@ if (!shouldDisableRedis) {
     logger.warn(`[REDIS_BOOT] Protocol: ${(redisUrl || '').split(':')[0]} | URL: ${auditUrl}`);
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (env.NODE_ENV === 'production') {
     if (!redisPassword && !redisUrl.includes(':@') && !redisUrl.includes('//:')) {
         logger.warn('⚠️ Redis connection lacks a password. Ensure REDIS_PASSWORD is set in production.');
     }

--- a/backend/src/config/sentry.ts
+++ b/backend/src/config/sentry.ts
@@ -49,7 +49,7 @@ export function initSentry() {
             // Error filtering
             beforeSend(event, hint) {
                 // Don't send errors in development unless explicitly enabled
-                if (isDevelopment && !process.env.SENTRY_ENABLE_DEV) {
+                if (isDevelopment && !env.SENTRY_ENABLE_DEV) {
                     return null;
                 }
 

--- a/backend/src/config/socket.ts
+++ b/backend/src/config/socket.ts
@@ -51,7 +51,7 @@ export function initIO(httpServer: HttpServer): Server {
         const pubClient = redisClient;
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const Redis = require('ioredis');
-        const subClient = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+        const subClient = new Redis(env.REDIS_URL ?? `redis://localhost:${env.REDIS_PORT}`, {
             tls: undefined, // 🔒 FORCE DISABLE TLS
         }) as typeof redisClient;
         io.adapter(createAdapter(pubClient as any, subClient as any));

--- a/backend/src/config/validateEnv.ts
+++ b/backend/src/config/validateEnv.ts
@@ -143,10 +143,18 @@ export function validateProductionEnvOrThrow(sourceEnv: NodeJS.ProcessEnv): void
     }
 
     if ((sourceEnv.USE_DEFAULT_OTP || '').trim().toLowerCase() === 'true') {
-        bootstrapLogger.warn(
-            '⚠️  USE_DEFAULT_OTP is enabled in production. ' +
-            'All users can log in with the static OTP. ' +
-            'Disable this immediately after DLT/SMS approval.'
+        throw new Error(
+            '🚨 SECURITY BLOCK: USE_DEFAULT_OTP=true is not allowed in production. ' +
+            'This flag enables authentication bypass with a static OTP for every user. ' +
+            'Remove it from your production environment before deploying.'
+        );
+    }
+
+    if ((sourceEnv.AUTH_BYPASS_OTP_LOCK || '').trim().toLowerCase() === 'true') {
+        throw new Error(
+            '🚨 SECURITY BLOCK: AUTH_BYPASS_OTP_LOCK=true is not allowed in production. ' +
+            'This flag disables OTP attempt-count locking, enabling brute-force attacks. ' +
+            'Remove it from your production environment before deploying.'
         );
     }
 

--- a/backend/src/middleware/csrfProtection.ts
+++ b/backend/src/middleware/csrfProtection.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import logger from '../utils/logger';
 import { sendErrorResponse } from '../utils/errorResponse';
 import { getCsrfCookieOptions } from '../utils/cookieHelper';
+import { env } from '../config/env';
 
 /**
  * 🛡️ CSRF Protection Middleware
@@ -69,7 +70,7 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
     }
 
     // Skip in test and development environments
-    if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+    if (env.NODE_ENV === 'test' || env.NODE_ENV === 'development') {
         return next();
     }
 

--- a/backend/src/middleware/fraudMiddleware.ts
+++ b/backend/src/middleware/fraudMiddleware.ts
@@ -7,13 +7,14 @@ import { detectAiSpam } from '../utils/aiSpamDetector';
 import logger from '../utils/logger';
 import { getUserConnection } from '../config/db';
 import { FeatureFlag, isEnabled } from '../config/featureFlags';
+import { env } from '../config/env';
 
 export interface FraudRequest extends Request {
     fraudRisk?: RiskLevel;
     fraudScore?: number;
 }
 
-const FRAUD_DECISION_TIMEOUT_MS = Math.max(100, Number(process.env.FRAUD_DECISION_TIMEOUT_MS || 1200));
+const FRAUD_DECISION_TIMEOUT_MS = env.FRAUD_DECISION_TIMEOUT_MS;
 const SHADOW_ONLY_PREFIXES = ['/api/v1/auth/', '/api/v1/health', '/health'];
 
 const shouldRunInShadowMode = (req: Request): boolean => {

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -3,14 +3,15 @@ import RedisStore, { type RedisReply } from 'rate-limit-redis';
 import redisClient from '../config/redis';
 import { Request, Response } from 'express';
 import logger from '../utils/logger';
+import { env } from '../config/env';
 
 const isJestRuntime = typeof process.env.JEST_WORKER_ID !== 'undefined';
 const shouldDisableRedisStore =
-    (process.env.NODE_ENV === 'test' || isJestRuntime) && process.env.ALLOW_REDIS !== 'true';
+    (env.NODE_ENV === 'test' || isJestRuntime) && !env.ALLOW_REDIS;
 const isLocalRelaxedAuth =
-    process.env.NODE_ENV === 'development' &&
-    process.env.CI !== 'true' &&
-    process.env.AUTH_LOCAL_RELAXED === 'true';
+    env.NODE_ENV === 'development' &&
+    !env.CI &&
+    env.AUTH_LOCAL_RELAXED;
 
 type RedisCallable = {
     call: (...args: string[]) => Promise<RedisReply>;
@@ -83,7 +84,7 @@ const respondRateLimited = (
 };
 
 const createRedisStore = (prefix: string, windowMs: number) => {
-    if (process.env.NODE_ENV === 'production' && shouldDisableRedisStore) {
+    if (env.NODE_ENV === 'production' && shouldDisableRedisStore) {
         throw new Error('FATAL: Redis store is required in production. In-memory fallback is strictly banned by SSOT.');
     }
     return shouldDisableRedisStore
@@ -185,7 +186,7 @@ export function createLimiter({
  */
 export const globalLimiter = rateLimit({
     windowMs: 60 * 1000,
-    max: process.env.NODE_ENV === 'development' ? 3000 : 100,
+    max: env.NODE_ENV === 'development' ? 3000 : 100,
     store: createRedisStore('global:', 60 * 1000),
     skip: (req) => {
         return req.originalUrl === '/api/v1/health' || req.originalUrl === '/health' || req.originalUrl.includes('/webhook');
@@ -233,13 +234,7 @@ export const reportLimiter = createLimiter({
 /**
  * Strict Admin Limiter
  */
-const resolvedAdminLimiterMax = (() => {
-    const configured = Number(process.env.ADMIN_RATE_LIMIT_MAX);
-    if (Number.isFinite(configured) && configured > 0) {
-        return configured;
-    }
-    return process.env.NODE_ENV === 'development' ? 300 : 200;
-})();
+const resolvedAdminLimiterMax = env.ADMIN_RATE_LIMIT_MAX ?? (env.NODE_ENV === 'development' ? 300 : 200);
 
 export const adminLimiter = createLimiter({
     windowMs: 60 * 1000,
@@ -255,13 +250,7 @@ export const adminLimiter = createLimiter({
     }
 });
 
-const resolvedAdminMutationLimiterMax = (() => {
-    const configured = Number(process.env.ADMIN_MUTATION_RATE_LIMIT_MAX);
-    if (Number.isFinite(configured) && configured > 0) {
-        return configured;
-    }
-    return process.env.NODE_ENV === 'development' ? 300 : 100;
-})();
+const resolvedAdminMutationLimiterMax = env.ADMIN_MUTATION_RATE_LIMIT_MAX ?? (env.NODE_ENV === 'development' ? 300 : 100);
 
 export const adminMutationLimiter = createLimiter({
     windowMs: 5 * 60 * 1000,
@@ -311,7 +300,7 @@ export const paymentRateLimiter = createLimiter({
 
 export const otpIpLimiter = createLimiter({
     windowMs: 10 * 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 5 : 15,
+    max: env.NODE_ENV === 'production' ? 5 : 15,
     keyPrefix: 'otp:ip:',
     errorCode: 'OTP_SEND_IP_RATE_LIMIT'
 });
@@ -319,7 +308,7 @@ export const otpIpLimiter = createLimiter({
 /** Mobile-keyed limiter for /send-otp — isolated from verify-otp bucket */
 export const otpSendLimiter = createLimiter({
     windowMs: 10 * 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 5 : 15,
+    max: env.NODE_ENV === 'production' ? 5 : 15,
     keyPrefix: 'otp:send:',
     errorCode: 'OTP_SEND_MOBILE_RATE_LIMIT',
     keyGenerator: (req: Request) => {
@@ -331,7 +320,7 @@ export const otpSendLimiter = createLimiter({
 /** Mobile-keyed limiter for /verify-otp — isolated from send-otp bucket */
 export const otpVerifyLimiter = createLimiter({
     windowMs: 10 * 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 10 : 30,
+    max: env.NODE_ENV === 'production' ? 10 : 30,
     keyPrefix: 'otp:verify:',
     errorCode: 'OTP_VERIFY_RATE_LIMIT',
     keyGenerator: (req: Request) => {
@@ -347,7 +336,7 @@ export const otpVerifyLimiter = createLimiter({
 /** Send message: 20 per minute per userId */
 export const chatSendLimiter = createLimiter({
     windowMs: 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 20 : 200,
+    max: env.NODE_ENV === 'production' ? 20 : 200,
     keyPrefix: 'chat:send:',
     keyGenerator: (req: Request) => {
         const userId = req.user?._id ? String(req.user._id) : undefined;
@@ -358,7 +347,7 @@ export const chatSendLimiter = createLimiter({
 /** Start conversation: 10 per 10 minutes per userId */
 export const chatStartLimiter = createLimiter({
     windowMs: 10 * 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 10 : 100,
+    max: env.NODE_ENV === 'production' ? 10 : 100,
     keyPrefix: 'chat:start:',
     keyGenerator: (req: Request) => {
         const userId = req.user?._id ? String(req.user._id) : undefined;
@@ -369,7 +358,7 @@ export const chatStartLimiter = createLimiter({
 /** Report conversation: 3 per hour per userId */
 export const chatReportLimiter = createLimiter({
     windowMs: 60 * 60 * 1000,
-    max: process.env.NODE_ENV === 'production' ? 3 : 30,
+    max: env.NODE_ENV === 'production' ? 3 : 30,
     keyPrefix: 'chat:report:',
     keyGenerator: (req: Request) => {
         const userId = req.user?._id ? String(req.user._id) : undefined;

--- a/backend/src/middleware/verifyPaymentWebhook.ts
+++ b/backend/src/middleware/verifyPaymentWebhook.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import { Request, Response, NextFunction } from "express";
 import logger from '../utils/logger';
 import { sendErrorResponse } from '../utils/errorResponse';
+import { env } from '../config/env';
 
 /**
  * 🔐 PAYMENT WEBHOOK VERIFIER (HMAC)
@@ -15,7 +16,7 @@ import { sendErrorResponse } from '../utils/errorResponse';
  * - Sync crypto only
  */
 export function verifyPaymentWebhook(secret: string) {
-    const isProd = process.env.NODE_ENV === 'production';
+    const isProd = env.NODE_ENV === 'production';
 
     if (!secret) {
         if (isProd) {
@@ -67,8 +68,8 @@ export function verifyPaymentWebhook(secret: string) {
 
         // 🛡️ DEV BYPASS: Allow mock signature only in local development (not CI/staging)
         if (
-            process.env.NODE_ENV === 'development' &&
-            process.env.CI !== 'true' &&
+            env.NODE_ENV === 'development' &&
+            !env.CI &&
             signature === 'mock_verif_bypass'
         ) {
             logger.warn('⚠️ Webhook Signature Check BYPASSED (Development Mode)');

--- a/backend/src/queues/redisConnection.ts
+++ b/backend/src/queues/redisConnection.ts
@@ -1,13 +1,11 @@
 import { Redis } from "ioredis";
 import bootstrapLogger from "../utils/bootstrapLogger";
-import { loadEnvFiles } from "../config/loadEnvFiles";
+import { env } from "../config/env";
 
-loadEnvFiles();
+const REDIS_URL = env.REDIS_URL || 'redis://127.0.0.1:6379';
 
-const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
-
-if (process.env.NODE_ENV === 'production') {
-    if (!REDIS_URL.includes('@') && !process.env.REDIS_PASSWORD) {
+if (env.NODE_ENV === 'production') {
+    if (!REDIS_URL.includes('@') && !env.REDIS_PASSWORD) {
         bootstrapLogger.warn('Queue Redis connection lacks a password in production environment.');
     }
     if (!REDIS_URL.startsWith('rediss://')) {

--- a/backend/src/queues/schedulerQueue.ts
+++ b/backend/src/queues/schedulerQueue.ts
@@ -1,5 +1,6 @@
 import { Queue, Worker, QueueEvents, Job, type Processor } from 'bullmq';
 import logger from '../utils/logger';
+import { env } from '../config/env';
 
 export type SchedulerJobName =
     | 'expire_ads_job'
@@ -20,7 +21,7 @@ export type SchedulerJobName =
 type SchedulerProcessor = (job: Job) => Promise<unknown>;
 
 const shouldDisableSchedulerQueue =
-    process.env.NODE_ENV === 'test' && process.env.ALLOW_SCHEDULER_QUEUE !== 'true';
+    env.NODE_ENV === 'test' && !env.ALLOW_SCHEDULER_QUEUE;
 
 const schedulerRepeatCrons: Record<SchedulerJobName, string> = {
     expire_ads_job: '1 0 * * *',
@@ -29,7 +30,7 @@ const schedulerRepeatCrons: Record<SchedulerJobName, string> = {
     payment_reconciliation: '*/10 * * * *',
     monthly_slot_reset: '5 0 1 * *',
     expire_user_plans: '0 1 * * *',
-    database_backup_job: process.env.BACKUP_CRON_SCHEDULE || '0 2 * * *',
+    database_backup_job: env.BACKUP_CRON_SCHEDULE,
     location_analytics_refresh: '0 2 * * *',
     notification_scheduler_poll: '* * * * *',
     cleanup_read_notifications: '0 * * * *',
@@ -40,14 +41,14 @@ const schedulerRepeatCrons: Record<SchedulerJobName, string> = {
 };
 
 const parseRedisConnection = () => {
-    if (process.env.REDIS_URL) {
-        const parsedUrl = new URL(process.env.REDIS_URL);
+    if (env.REDIS_URL) {
+        const parsedUrl = new URL(env.REDIS_URL);
         const dbFromPath = Number(parsedUrl.pathname.replace('/', '') || '0');
         return {
             host: parsedUrl.hostname || 'localhost',
             port: Number(parsedUrl.port || '6379'),
             password: parsedUrl.password ? decodeURIComponent(parsedUrl.password) : undefined,
-            db: Number.isFinite(dbFromPath) ? dbFromPath : Number(process.env.REDIS_DB || '0'),
+            db: Number.isFinite(dbFromPath) ? dbFromPath : env.REDIS_DB,
             maxRetriesPerRequest: null,
             enableReadyCheck: false,
             tls: undefined, // 🔒 FORCE DISABLE TLS
@@ -55,10 +56,10 @@ const parseRedisConnection = () => {
     }
 
     return {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: Number(process.env.REDIS_PORT || '6379'),
-        password: process.env.REDIS_PASSWORD,
-        db: Number(process.env.REDIS_DB || '0'),
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD,
+        db: env.REDIS_DB,
         maxRetriesPerRequest: null,
         enableReadyCheck: false,
         tls: undefined, // 🔒 FORCE DISABLE TLS
@@ -135,7 +136,7 @@ export const registerSchedulerJobProcessors = async (
 export const registerSchedulerRepeatableJobs = async () => {
     if (shouldDisableSchedulerQueue || !schedulerQueue) return;
 
-    const timezone = process.env.TZ || 'Asia/Kolkata';
+    const timezone = env.TZ;
     for (const [jobName, cron] of Object.entries(schedulerRepeatCrons) as Array<[SchedulerJobName, string]>) {
         await schedulerQueue.upsertJobScheduler(
             `repeat:${jobName}`,

--- a/backend/src/utils/appUrl.ts
+++ b/backend/src/utils/appUrl.ts
@@ -1,4 +1,5 @@
 import logger from './logger';
+import { env } from '../config/env';
 
 const PRODUCTION_FRONTEND_URL = 'https://esparex.in';
 const PRODUCTION_ADMIN_URL = 'https://admin.esparex.in';
@@ -7,7 +8,7 @@ const LOCAL_ADMIN_URL = 'http://localhost:3001';
 
 const warnedFallbackKeys = new Set<string>();
 
-const isProduction = (): boolean => (process.env.NODE_ENV || 'development') === 'production';
+const isProduction = (): boolean => env.NODE_ENV === 'production';
 
 const normalizeBaseUrl = (value: string): string => value.trim().replace(/\/+$/, '');
 
@@ -22,7 +23,7 @@ const resolveAppUrl = (key: string, rawValue: string | undefined, fallback: stri
         logger.warn('[AppUrl] Missing app URL env, using fallback', {
             envKey: key,
             fallback,
-            nodeEnv: process.env.NODE_ENV || 'development',
+            nodeEnv: env.NODE_ENV,
         });
     }
 
@@ -32,20 +33,20 @@ const resolveAppUrl = (key: string, rawValue: string | undefined, fallback: stri
 export const getFrontendAppUrl = (): string =>
     resolveAppUrl(
         'FRONTEND_URL',
-        process.env.FRONTEND_URL,
+        env.FRONTEND_URL,
         isProduction() ? PRODUCTION_FRONTEND_URL : LOCAL_FRONTEND_URL
     );
 
 export const getFrontendInternalUrl = (): string =>
     resolveAppUrl(
         'FRONTEND_INTERNAL_URL',
-        process.env.FRONTEND_INTERNAL_URL || process.env.FRONTEND_URL,
+        env.FRONTEND_INTERNAL_URL || env.FRONTEND_URL,
         isProduction() ? PRODUCTION_FRONTEND_URL : LOCAL_FRONTEND_URL
     );
 
 export const getAdminAppUrl = (): string =>
     resolveAppUrl(
         'ADMIN_URL',
-        process.env.ADMIN_URL || process.env.ADMIN_FRONTEND_URL,
+        env.ADMIN_URL || env.ADMIN_FRONTEND_URL,
         isProduction() ? PRODUCTION_ADMIN_URL : LOCAL_ADMIN_URL
     );

--- a/backend/src/utils/cookieHelper.ts
+++ b/backend/src/utils/cookieHelper.ts
@@ -5,34 +5,30 @@ import { inferCookieDomainFromEnv, normalizeCookieDomainValue } from './originCo
 const resolveCookieDomain = (): string | undefined => {
     return (
         inferCookieDomainFromEnv({
-            NODE_ENV: process.env.NODE_ENV,
-            CORS_ORIGIN: process.env.CORS_ORIGIN,
-            COOKIE_DOMAIN: process.env.COOKIE_DOMAIN || env.COOKIE_DOMAIN,
-            FRONTEND_URL: process.env.FRONTEND_URL,
-            FRONTEND_INTERNAL_URL: process.env.FRONTEND_INTERNAL_URL,
-            ADMIN_FRONTEND_URL: process.env.ADMIN_FRONTEND_URL,
-            ADMIN_URL: process.env.ADMIN_URL,
+            NODE_ENV: env.NODE_ENV,
+            CORS_ORIGIN: env.CORS_ORIGIN,
+            COOKIE_DOMAIN: env.COOKIE_DOMAIN,
+            FRONTEND_URL: env.FRONTEND_URL,
+            FRONTEND_INTERNAL_URL: env.FRONTEND_INTERNAL_URL,
+            ADMIN_FRONTEND_URL: env.ADMIN_FRONTEND_URL,
+            ADMIN_URL: env.ADMIN_URL,
         }) ||
-        normalizeCookieDomainValue(process.env.COOKIE_DOMAIN || env.COOKIE_DOMAIN)
+        normalizeCookieDomainValue(env.COOKIE_DOMAIN)
     );
 };
 
 type SameSiteValue = Exclude<CookieOptions['sameSite'], boolean | undefined>;
 
 const resolveCookieSameSite = (): SameSiteValue => {
-    const raw = process.env.COOKIE_SAME_SITE?.trim().toLowerCase();
-    if (raw === 'strict' || raw === 'lax' || raw === 'none') {
-        return raw;
+    if (env.COOKIE_SAME_SITE) {
+        return env.COOKIE_SAME_SITE;
     }
-
     return env.NODE_ENV === 'production' ? 'none' : 'lax';
 };
 
 const resolveCookieSecure = (sameSite: SameSiteValue): boolean => {
-    const raw = process.env.COOKIE_SECURE?.trim().toLowerCase();
-    if (raw === 'true') return true;
-    if (raw === 'false') return sameSite === 'none' ? true : false;
-
+    if (env.COOKIE_SECURE === true) return true;
+    if (env.COOKIE_SECURE === false) return sameSite === 'none' ? true : false;
     if (sameSite === 'none') return true;
     return env.NODE_ENV === 'production';
 };

--- a/backend/src/utils/imageProcessor.ts
+++ b/backend/src/utils/imageProcessor.ts
@@ -2,6 +2,7 @@ import { getBucketName, uploadToS3 } from './s3';
 import crypto from 'crypto';
 import sharp from 'sharp';
 import logger from './logger';
+import { env } from '../config/env';
 import imageDomainRegistry from '@shared/constants/image-domain-registry.json';
 
 let hasWarnedMissingS3InTest = false;
@@ -70,7 +71,7 @@ const optimizeWithSharp = async (
 const warnMissingS3BucketOncePerTestRun = (folder: string) => {
     const message = `⚠️ S3_BUCKET_NAME missing. Using placeholder images for '${folder}' to prevent DB BSON crash.`;
 
-    if (process.env.NODE_ENV === 'test') {
+    if (env.NODE_ENV === 'test') {
         if (hasWarnedMissingS3InTest) {
             return;
         }

--- a/backend/src/utils/redisCache.ts
+++ b/backend/src/utils/redisCache.ts
@@ -1,5 +1,6 @@
 import redisClient from '../config/redis';
 import logger from './logger';
+import { env } from '../config/env';
 
 /* ============================================================================
  * 📊 CACHE METRICS (In-Memory)
@@ -16,10 +17,10 @@ export const cacheMetrics = {
 /* ============================================================================
  * 🔌 REDIS CLIENT SETUP (SSOT)
  * ========================================================================== */
-const REDIS_MODE = process.env.REDIS_MODE || 'single';
+const REDIS_MODE = env.REDIS_MODE;
 const isJestRuntime = typeof process.env.JEST_WORKER_ID !== 'undefined';
 const shouldDisableRedis =
-    (process.env.NODE_ENV === 'test' || isJestRuntime) && process.env.ALLOW_REDIS !== 'true';
+    (env.NODE_ENV === 'test' || isJestRuntime) && !env.ALLOW_REDIS;
 
 const client = redisClient;
 
@@ -193,7 +194,7 @@ const checkMemoryHealth = async () => {
             isHighMemoryPressure = false;
         }
 
-        if (process.env.NODE_ENV === 'production') {
+        if (env.NODE_ENV === 'production') {
             const configWarnings: string[] = [];
             if (max <= 0) {
                 configWarnings.push('maxmemory is not configured');

--- a/backend/src/utils/s3.ts
+++ b/backend/src/utils/s3.ts
@@ -2,6 +2,7 @@ import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } fro
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import logger from './logger';
 import imageDomainRegistry from '@shared/constants/image-domain-registry.json';
+import { env } from '../config/env';
 
 const ALLOWED_S3_MIME_TYPES = new Set([
     'image/jpeg',
@@ -24,9 +25,9 @@ const PLACEHOLDER_HOSTS = new Set(['placehold.co']);
 // ─────────────────────────────────────────────────────────────────────────────
 // CONFIGURATION UNIFICATION
 // ─────────────────────────────────────────────────────────────────────────────
-const getAwsRegion = (): string => (process.env.AWS_REGION || 'ap-south-1').trim();
+const getAwsRegion = (): string => (env.AWS_REGION || 'ap-south-1').trim();
 const getS3BaseUrl = (bucket: string): string => {
-    const cloudfrontUrl = process.env.AWS_CLOUDFRONT_URL;
+    const cloudfrontUrl = env.AWS_CLOUDFRONT_URL;
     if (cloudfrontUrl) {
         return cloudfrontUrl.trim().replace(/\/$/, '');
     }
@@ -36,20 +37,20 @@ const getS3BaseUrl = (bucket: string): string => {
 export const s3Client = new S3Client({
     region: getAwsRegion(),
     credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
+        accessKeyId: env.AWS_ACCESS_KEY_ID || '',
+        secretAccessKey: env.AWS_SECRET_ACCESS_KEY || '',
     },
 });
 
 export function getBucketName(): string {
-    return (process.env.S3_BUCKET_NAME || process.env.AWS_S3_BUCKET || '').trim();
+    return (env.S3_BUCKET_NAME || env.AWS_S3_BUCKET || '').trim();
 }
 
 export function getMissingS3UploadConfigKeys(): string[] {
     const requiredConfig = {
-        AWS_ACCESS_KEY_ID: (process.env.AWS_ACCESS_KEY_ID || '').trim(),
-        AWS_SECRET_ACCESS_KEY: (process.env.AWS_SECRET_ACCESS_KEY || '').trim(),
-        AWS_REGION: (process.env.AWS_REGION || '').trim(),
+        AWS_ACCESS_KEY_ID: (env.AWS_ACCESS_KEY_ID || '').trim(),
+        AWS_SECRET_ACCESS_KEY: (env.AWS_SECRET_ACCESS_KEY || '').trim(),
+        AWS_REGION: (env.AWS_REGION || '').trim(),
         S3_BUCKET_NAME: getBucketName(),
     };
 
@@ -173,7 +174,7 @@ export function isValidS3PublicImageUrl(url: string): boolean {
         const pathname = decodeURIComponent(parsed.pathname).replace(/^\/+/, '');
         if (!pathname) return false;
 
-        const cloudfrontStr = process.env.AWS_CLOUDFRONT_URL;
+        const cloudfrontStr = env.AWS_CLOUDFRONT_URL;
         if (cloudfrontStr) {
             try {
                 const cdnHost = new URL(cloudfrontStr).hostname.toLowerCase();
@@ -328,7 +329,7 @@ export function extractS3KeyFromUrl(url: string): string | null {
         const normalizedPath = decodeURIComponent(parsed.pathname).replace(/^\/+/, '');
         if (!normalizedPath) return null;
 
-        const cloudfrontStr = process.env.AWS_CLOUDFRONT_URL;
+        const cloudfrontStr = env.AWS_CLOUDFRONT_URL;
         if (cloudfrontStr) {
             try {
                 const cdnHost = new URL(cloudfrontStr).hostname.toLowerCase();


### PR DESCRIPTION
## Summary
- centralize backend runtime config access through typed env reads
- harden production env validation for auth and runtime safety flags
- align redis, cookie, scheduler, S3, Firebase, and webhook/runtime helpers with the typed env contract
- update backend config tests to reflect stricter env boot behavior

## Scope
- backend config/runtime code only
- no frontend encryption removal included
- no application feature behavior intended beyond stricter config validation

## Verification
- npm run type-check -w backend
- npm test -w backend -- --runTestsByPath src/__tests__/config/validateEnv.spec.ts src/__tests__/config/firebaseAdmin.spec.ts src/__tests__/utils/appUrl.spec.ts
- pre-push full type-check passed
- duplication guard passed