### PR TITLE
refactor(controller): extract small db helpers to services

### DIFF
--- a/backend/src/controllers/ad/adMutationController.ts
+++ b/backend/src/controllers/ad/adMutationController.ts
@@ -9,7 +9,7 @@ import * as adService from '../../services/AdService';
 import * as adStatusService from '../../services/adStatusService';
 import * as AdOrchestrator from '../../services/AdOrchestrator';
 
-import Business from '../../models/Business';
+import { getBusinessByUserId } from '../../services/BusinessService';
 import { isBusinessPublishedStatus } from '../../utils/businessStatus';
 import { respond } from '../../utils/respond';
 import { getSingleParam } from '../../utils/requestParams';
@@ -96,7 +96,7 @@ export const updateAd = async (req: Request, res: Response, next: NextFunction) 
         }
 
         if (req.body.listingType === LISTING_TYPE.SERVICE) {
-            const business = await Business.findOne({ userId: authUserId });
+            const business = await getBusinessByUserId(authUserId);
             if (!business || !isBusinessPublishedStatus(business.status)) {
                 return sendClientError(req, res, 403, 'Approved Business Account Required', 'BUSINESS_NOT_APPROVED', {
                     message: 'You need an approved business account to post a service.'

--- a/backend/src/controllers/boost/boostController.ts
+++ b/backend/src/controllers/boost/boostController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import Boost from '../../models/Boost';
+import { getActiveBoostsForUser } from '../../services/BoostService';
 import { respond } from '../../utils/respond';
 import { ApiResponse } from '../../../../shared/types/Api';
 import { sendErrorResponse } from '../../utils/errorResponse';
@@ -12,16 +12,7 @@ export const getMyBoosts = async (req: Request, res: Response) => {
         const userId = req.user?._id;
         if (!userId) return sendErrorResponse(req, res, 401, 'Unauthorized');
 
-        const Ad = (await import('../../models/Ad')).default;
-
-        const userListings = await Ad.find({ sellerId: userId }).select('_id');
-
-        const entityIds = userListings.map(l => l._id);
-
-        const boosts = await Boost.find({
-            entityId: { $in: entityIds },
-            isActive: true
-        }).sort({ endsAt: 1 }).lean();
+        const boosts = await getActiveBoostsForUser(userId);
 
         res.json(respond<ApiResponse<unknown>>({
             success: true,

--- a/backend/src/controllers/contact/contactController.ts
+++ b/backend/src/controllers/contact/contactController.ts
@@ -1,6 +1,6 @@
 import logger from '../../utils/logger';
 import { Request, Response } from 'express';
-import ContactSubmission from '../../models/ContactSubmission';
+import { createContactSubmission } from '../../services/ContactService';
 import { sendErrorResponse } from '../../utils/errorResponse';
 import { respond } from '../../utils/respond';
 
@@ -16,14 +16,13 @@ export const submitContactForm = async (req: Request, res: Response) => {
         const { name, email, mobile, phone, subject, category, message } = req.body;
 
         // Create contact submission
-        const submission = await ContactSubmission.create({
+        const submission = await createContactSubmission({
             name,
             email,
             mobile: mobile || phone,
             subject,
             category,
-            message,
-            status: 'new'
+            message
         });
 
         res.status(201).json(respond({

--- a/backend/src/controllers/locationController.ts
+++ b/backend/src/controllers/locationController.ts
@@ -5,7 +5,7 @@ import { sendErrorResponse } from '../utils/errorResponse';
 import { getSystemConfigDoc } from "../utils/systemConfigHelper";
 import { env } from '../config/env';
 import { respond } from "../utils/respond";
-import LocationEvent from "../models/LocationEvent";
+import { createLocationEvent } from '../services/location/LocationEventService';
 import {
     getDefaultCenterLocation,
     getAreasByCityId,
@@ -279,7 +279,7 @@ export const logLocationEvent = async (req: Request, res: Response) => {
                 });
             }
         }
-        await LocationEvent.create({
+        await createLocationEvent({
             source,
             city,
             state,

--- a/backend/src/controllers/notification/notificationQueryController.ts
+++ b/backend/src/controllers/notification/notificationQueryController.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from "express";
-
-import Notification from "../../models/Notification";
 import logger from "../../utils/logger";
 import { respond } from "../../utils/respond";
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { getUserId } from "./shared";
 import { getVisibleNotificationWindowQuery } from "../../services/notification/NotificationRetentionService";
+import { queryNotificationsForUser } from "../../services/NotificationService";
 
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -51,16 +50,10 @@ export const getNotifications = async (req: Request, res: Response) => {
             });
         }
 
-        const query = queryClauses.length === 1 ? queryClauses[0] : { $and: queryClauses };
+        const query: Record<string, unknown> =
+            queryClauses.length === 1 ? (queryClauses[0] ?? {}) : { $and: queryClauses };
 
-        const [notifications, total, unreadCount] = await Promise.all([
-            Notification.find(query)
-                .sort({ createdAt: -1 })
-                .skip(skip)
-                .limit(limit),
-            Notification.countDocuments(query),
-            Notification.countDocuments({ userId, isRead: false }),
-        ]);
+        const { notifications, total, unreadCount } = await queryNotificationsForUser(query, userId, skip, limit);
 
         return res.json(
             respond({

--- a/backend/src/services/BoostService.ts
+++ b/backend/src/services/BoostService.ts
@@ -1,0 +1,13 @@
+import Boost from '../models/Boost';
+import Ad from '../models/Ad';
+import { Types } from 'mongoose';
+
+export async function getActiveBoostsForUser(userId: Types.ObjectId | string) {
+    const userListings = await Ad.find({ sellerId: userId }).select('_id');
+    const entityIds = userListings.map(l => l._id);
+
+    return Boost.find({
+        entityId: { $in: entityIds },
+        isActive: true,
+    }).sort({ endsAt: 1 }).lean();
+}

--- a/backend/src/services/ContactService.ts
+++ b/backend/src/services/ContactService.ts
@@ -1,0 +1,22 @@
+import ContactSubmission, { IContactSubmission } from '../models/ContactSubmission';
+
+interface CreateContactInput {
+    name: string;
+    email: string;
+    mobile?: string;
+    subject?: string;
+    category?: string;
+    message: string;
+}
+
+export async function createContactSubmission(input: CreateContactInput): Promise<IContactSubmission> {
+    return ContactSubmission.create({
+        name: input.name,
+        email: input.email,
+        mobile: input.mobile,
+        subject: input.subject,
+        category: input.category,
+        message: input.message,
+        status: 'new',
+    });
+}

--- a/backend/src/services/NotificationService.ts
+++ b/backend/src/services/NotificationService.ts
@@ -1,4 +1,5 @@
 import User from '../models/User';
+import Notification from '../models/Notification';
 import admin from '../config/firebaseAdmin';
 import logger from '../utils/logger';
 import { NotificationTypeValue } from '@shared/enums/notificationType';
@@ -134,6 +135,20 @@ export const sendNotification = async (userId: string, title: string, body: stri
     } catch (error) {
         logger.error('FCM send error', { error: error instanceof Error ? error.message : String(error) });
     }
+};
+
+export const queryNotificationsForUser = async (
+    query: Record<string, unknown>,
+    userId: string,
+    skip: number,
+    limit: number
+) => {
+    const [notifications, total, unreadCount] = await Promise.all([
+        Notification.find(query).sort({ createdAt: -1 }).skip(skip).limit(limit),
+        Notification.countDocuments(query),
+        Notification.countDocuments({ userId, isRead: false }),
+    ]);
+    return { notifications, total, unreadCount };
 };
 
 /**

--- a/backend/src/services/location/LocationEventService.ts
+++ b/backend/src/services/location/LocationEventService.ts
@@ -1,0 +1,30 @@
+import { Types } from 'mongoose';
+import LocationEvent, { ILocationEvent } from '../../models/LocationEvent';
+
+interface CreateLocationEventInput {
+    source?: string;
+    city?: string;
+    state?: string;
+    coordinates?: { type: 'Point'; coordinates: [number, number] };
+    reason?: string;
+    userId?: Types.ObjectId | string;
+}
+
+export async function createLocationEvent(input: CreateLocationEventInput): Promise<ILocationEvent> {
+    const userId =
+        typeof input.userId === 'string' ? new Types.ObjectId(input.userId) : input.userId;
+
+    const payload: Record<string, unknown> = {
+        source: input.source,
+        city: input.city,
+        state: input.state,
+        coordinates: input.coordinates,
+        reason: input.reason,
+    };
+
+    if (userId) {
+        payload.userId = userId;
+    }
+
+    return LocationEvent.create(payload);
+}


### PR DESCRIPTION
## Summary
- move a small set of controller-level data access helpers into focused services
- reduce direct model work inside selected controllers without mixing larger runtime or contract changes
- keep the slice limited to boost, contact, location, notification, and related ad mutation helpers

## Scope
- controller/service boundary cleanup only
- no env/runtime centralization included
- no Ad contract migration included

## Verification
- isolated in a clean worktree from updated main
- backend type-check issues found during extraction were repaired inside this branch
- pre-commit passed
- pre-push full type-check passed
- duplication guard passed