### PR TITLE
refactor(payment): extract order and plan admin helpers

### DIFF
--- a/backend/src/controllers/payment/paymentMutationController.ts
+++ b/backend/src/controllers/payment/paymentMutationController.ts
@@ -1,7 +1,11 @@
 import logger from '../../utils/logger';
 import { Request, Response } from 'express';
 import crypto from 'crypto';
-import Transaction from '../../models/Transaction';
+import {
+    checkTransactionVelocity,
+    findPendingTransaction,
+    createPaymentTransaction,
+} from '../../services/PaymentProcessingService';
 import Plan from '../../models/Plan';
 import User from '../../models/User';
 import { respond } from '../../utils/respond';
@@ -32,11 +36,7 @@ export const createPaymentOrder = async (req: Request, res: Response) => {
             return sendErrorResponse(req, res, 503, 'Payments are currently unavailable');
         }
 
-        const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-        const velocityCount = await Transaction.countDocuments({
-            userId: user._id,
-            createdAt: { $gte: oneHourAgo }
-        });
+        const velocityCount = await checkTransactionVelocity(user._id, 60 * 60 * 1000);
 
         if (velocityCount >= 5) {
             logSecurity('payment_purchase_velocity_limit_exceeded', 'high', {
@@ -46,14 +46,7 @@ export const createPaymentOrder = async (req: Request, res: Response) => {
             return sendErrorResponse(req, res, 429, 'Purchase rate limit exceeded. Please try again later.');
         }
 
-        const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
-        const existingPendingTransaction = await Transaction.findOne({
-            userId: user._id,
-            planId: plan._id,
-            status: 'INITIATED',
-            applied: false,
-            createdAt: { $gte: tenMinutesAgo }
-        }).sort({ createdAt: -1 });
+        const existingPendingTransaction = await findPendingTransaction(user._id, plan._id, 10 * 60 * 1000);
 
         if (existingPendingTransaction?.gatewayOrderId) {
             logBusiness('order_created', {
@@ -92,7 +85,7 @@ export const createPaymentOrder = async (req: Request, res: Response) => {
             });
         }
 
-        const transaction = await Transaction.create({
+        const transaction = await createPaymentTransaction({
             userId: user._id,
             planId: plan._id,
             planSnapshot: {

--- a/backend/src/controllers/plan/planAdminController.ts
+++ b/backend/src/controllers/plan/planAdminController.ts
@@ -4,15 +4,21 @@ import { respond } from '../../utils/respond';
 import { sendErrorResponse } from '../../utils/errorResponse';
 import { AppError } from '../../utils/AppError';
 import { escapeRegExp } from '../../utils/stringUtils';
-import { buildPlanPayload, getErrorMessage, getRequiredPlanId, PlanModel } from './shared';
+import { buildPlanPayload, getErrorMessage, getRequiredPlanId } from './shared';
+import {
+    adminCreatePlan,
+    adminUpdatePlan,
+    adminGetPlans,
+    adminGetPlanById,
+} from '../../services/PlanService';
 
 export const createPlan = async (req: Request, res: Response) => {
     try {
         const adminId = req.user?._id ? String(req.user._id) : undefined;
         const safeBody = buildPlanPayload(req.body as Record<string, unknown>, adminId);
 
-        const plan = await PlanModel.create(safeBody);
-        const planId = Array.isArray(plan) ? plan[0]?._id : (plan as Record<string, unknown>)?._id;
+        const plan = await adminCreatePlan(safeBody);
+        const planId = plan._id;
         await logAdminAction(req, 'CREATE_PLAN', 'Plan', planId == null ? undefined : String(planId));
         res.status(201).json(respond({ success: true, data: plan }));
     } catch (error: unknown) {
@@ -26,7 +32,7 @@ export const updatePlan = async (req: Request, res: Response) => {
         const planId = getRequiredPlanId(req);
         const safeBody = buildPlanPayload(req.body as Record<string, unknown>);
 
-        const plan = await PlanModel.findByIdAndUpdate(planId, safeBody, { new: true });
+        const plan = await adminUpdatePlan(planId, safeBody);
         if (!plan) {
             throw new AppError('Plan not found', 404, 'PLAN_NOT_FOUND');
         }
@@ -57,7 +63,7 @@ export const getPlans = async (req: Request, res: Response) => {
             ];
         }
 
-        const plans = await PlanModel.find(query).sort({ createdAt: -1 });
+        const plans = await adminGetPlans(query);
         res.json(respond({ success: true, data: plans }));
     } catch (error: unknown) {
         sendErrorResponse(req, res, 500, getErrorMessage(error));
@@ -67,7 +73,7 @@ export const getPlans = async (req: Request, res: Response) => {
 export const togglePlan = async (req: Request, res: Response) => {
     try {
         const planId = getRequiredPlanId(req);
-        const plan = await PlanModel.findById(planId);
+        const plan = await adminGetPlanById(planId);
         if (!plan) throw new AppError('Plan not found', 404, 'PLAN_NOT_FOUND');
         plan.active = !plan.active;
         await plan.save();

--- a/backend/src/services/PaymentProcessingService.ts
+++ b/backend/src/services/PaymentProcessingService.ts
@@ -506,3 +506,41 @@ export async function recoverPendingPayment(tx: ITransaction): Promise<ProcessPa
 
     return { result: "missing", transactionId: tx._id.toString(), reason: gatewayResult.reason };
 }
+
+// ─── Order-initiation helpers (used by paymentMutationController) ─────────────
+
+export async function checkTransactionVelocity(
+    userId: ITransaction['userId'],
+    windowMs: number
+): Promise<number> {
+    const since = new Date(Date.now() - windowMs);
+    const filter = {
+        userId,
+        createdAt: { $gte: since },
+    } as unknown as Parameters<typeof Transaction.countDocuments>[0];
+    return Transaction.countDocuments(filter);
+}
+
+export async function findPendingTransaction(
+    userId: ITransaction['userId'],
+    planId: NonNullable<ITransaction['planId']>,
+    windowMs: number
+): Promise<ITransaction | null> {
+    const since = new Date(Date.now() - windowMs);
+    const filter = {
+        userId,
+        planId,
+        status: 'INITIATED',
+        applied: false,
+        createdAt: { $gte: since },
+    } as unknown as Parameters<typeof Transaction.findOne>[0];
+    return Transaction.findOne(filter).sort({ createdAt: -1 });
+}
+
+export async function createPaymentTransaction(
+    payload: Record<string, unknown>
+): Promise<ITransaction> {
+    return Transaction.create(payload);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/services/PlanService.ts
+++ b/backend/src/services/PlanService.ts
@@ -1,4 +1,5 @@
 import UserPlan from '../models/UserPlan';
+import Plan, { type IPlan } from '../models/Plan';
 import { SERVICE_STATUS } from '../../../shared/enums/serviceStatus';
 import { LISTING_TYPE } from '../../../shared/enums/listingType';
 import { INVENTORY_STATUS } from '../../../shared/enums/inventoryStatus';
@@ -15,6 +16,22 @@ import UserWallet from '../models/UserWallet';
 import { withUserPostingLock } from './AdSlotService'; // Import the lock
 
 export type UserPlanWithPlanId = { planId: unknown };
+
+// ─── Admin Plan CRUD ─────────────────────────────────────────────────────────
+
+export const adminCreatePlan = (payload: Record<string, unknown>): Promise<IPlan> =>
+    Plan.create(payload);
+
+export const adminUpdatePlan = (planId: string, payload: Record<string, unknown>): Promise<IPlan | null> =>
+    Plan.findByIdAndUpdate(planId, payload, { new: true });
+
+export const adminGetPlans = (query: Record<string, unknown>): Promise<IPlan[]> =>
+    Plan.find(query).sort({ createdAt: -1 });
+
+export const adminGetPlanById = (planId: string): Promise<IPlan | null> =>
+    Plan.findById(planId);
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export const resetWalletsForNewCycle = async (now: Date = new Date()) => {
     const cycleStart = getMonthlyCycleStart(now);
@@ -125,4 +142,3 @@ export const checkPostLimit = async (
     return true;
     });
 };
-


### PR DESCRIPTION
## Summary
- move payment transaction helper queries and plan admin CRUD helpers into service layer methods
- keep the slice limited to controller-service extraction without mixing payment route env changes
- preserve existing behavior while tightening types around the extracted helpers

## Scope
- payment and plan controller/service cleanup only
- no env/runtime centralization included
- no Ad contract migration included

## Verification
- paymentRoutes.ts intentionally kept out to avoid env/runtime drift
- npm run type-check -w backend passed in the isolated branch
- targeted backend service specs passed: PaymentProcessingService.spec.ts and PlanService.spec.ts
- pre-commit passed
- pre-push full type-check passed
- duplication guard passed