### PR TITLE
chore(ad): add legacy userId alias telemetry

### DIFF
--- a/backend/src/controllers/ad/adMutationController.ts
+++ b/backend/src/controllers/ad/adMutationController.ts
@@ -18,6 +18,7 @@ import { ApiResponse } from '../../../../shared/types/Api';
 import { sendErrorResponse } from '../../utils/errorResponse';
 import { IAuthUser } from '../../types/auth';
 import { LISTING_TYPE } from '../../../../shared/enums/listingType';
+import { warnIfLegacyAdUserIdAliasUsed } from '../../utils/legacyOwnerAliasTelemetry';
 
 const sendClientError = (
     req: Request,
@@ -37,6 +38,7 @@ const sendClientError = (
  */
 export const createAd = async (req: Request, res: Response, next: NextFunction) => {
     try {
+        warnIfLegacyAdUserIdAliasUsed(req, 'body');
         const authUserId = (req.user as IAuthUser)._id.toString();
         const sellerId = req.body.sellerId || req.body.userId || authUserId;
 
@@ -83,6 +85,7 @@ export const createAd = async (req: Request, res: Response, next: NextFunction) 
  */
 export const updateAd = async (req: Request, res: Response, next: NextFunction) => {
     try {
+        warnIfLegacyAdUserIdAliasUsed(req, 'body');
         const id = getSingleParam(req, res, 'id', { error: 'Invalid Ad ID' });
         if (!id) return;
         const authUserId = (req.user as IAuthUser)._id.toString();

--- a/backend/src/controllers/ad/adQueryController.ts
+++ b/backend/src/controllers/ad/adQueryController.ts
@@ -17,6 +17,7 @@ import { IAuthUser } from '../../types/auth';
 import { sendErrorResponse } from '../../utils/errorResponse';
 import { AD_STATUS } from '../../../../shared/enums/adStatus';
 import { LISTING_TYPE } from '../../../../shared/enums/listingType';
+import { warnIfLegacyAdUserIdAliasUsed } from '../../utils/legacyOwnerAliasTelemetry';
 
 const asControllerError = (error: unknown): any => error as any;
 const getViewerIdForFeed = (req: Request): string | undefined => {
@@ -31,6 +32,7 @@ const getViewerIdForFeed = (req: Request): string | undefined => {
  */
 export const getAds = async (req: Request, res: Response, next: NextFunction) => {
     try {
+        warnIfLegacyAdUserIdAliasUsed(req, 'query');
         const viewerId = getViewerIdForFeed(req);
         const query = getAdsQuerySchema.parse(req.query);
         const requestedPage = Number(query.page ?? 1);
@@ -129,6 +131,7 @@ export const getAds = async (req: Request, res: Response, next: NextFunction) =>
  */
 export const getNearbyAds = async (req: Request, res: Response, next: NextFunction) => {
     try {
+        warnIfLegacyAdUserIdAliasUsed(req, 'query');
         const viewerId = getViewerIdForFeed(req);
         const query = getAdsQuerySchema.parse({
             ...req.query,

--- a/backend/src/utils/legacyOwnerAliasTelemetry.ts
+++ b/backend/src/utils/legacyOwnerAliasTelemetry.ts
@@ -1,0 +1,34 @@
+import { Request } from 'express';
+import logger from './logger';
+
+type AliasSource = 'body' | 'query';
+
+const hasOwn = (value: unknown, key: string): boolean =>
+    Boolean(value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, key));
+
+/**
+ * Telemetry-only logger for deprecated ownership aliases.
+ * This must never mutate request state or alter response behavior.
+ */
+export const warnIfLegacyAdUserIdAliasUsed = (
+    req: Request,
+    source: AliasSource
+): void => {
+    const container = source === 'body' ? req.body : req.query;
+    if (!hasOwn(container, 'userId')) return;
+
+    const hasSellerId = hasOwn(container, 'sellerId');
+    const rawAliasValue = (container as Record<string, unknown>).userId;
+
+    logger.warn('Deprecated ad ownership alias detected', {
+        alias: 'userId',
+        canonical: 'sellerId',
+        source,
+        method: req.method,
+        route: req.originalUrl || req.url,
+        requestId: req.requestId,
+        hasSellerId,
+        userIdAliasType: Array.isArray(rawAliasValue) ? 'array' : typeof rawAliasValue,
+    });
+};
+


### PR DESCRIPTION
## Summary
- add telemetry-only warning helper for deprecated Ad ownership alias usage (userId)
- emit warning logs when ad mutation endpoints receive userId in request body
- emit warning logs when ad query endpoints receive userId in query params

## Scope
- observability only
- no request coercion changes
- no response shape changes
- no DB schema/model behavior changes

## Files
- backend/src/utils/legacyOwnerAliasTelemetry.ts
- backend/src/controllers/ad/adMutationController.ts
- backend/src/controllers/ad/adQueryController.ts

## Verification
- behavior-preserving diff review completed
- no alias resolution logic was modified
- backend type-check in this isolated temp worktree is blocked because local tsc is unavailable in that environment