### PR TITLE
refactor(frontend): canonicalize listing ownership to sellerId

### DIFF
--- a/frontend/src/__tests__/listing-normalization.spec.ts
+++ b/frontend/src/__tests__/listing-normalization.spec.ts
@@ -36,6 +36,7 @@ describe("normalizeListing", () => {
         expect(listing.businessName).toBe("Esparex Repairs");
         expect(listing.verified).toBe(true);
         expect(listing.views).toBe(24);
+        expect((listing as { userId?: unknown }).userId).toBeUndefined();
     });
 
     it("preserves explicit sellerName from detail payloads for individual sellers", () => {
@@ -57,5 +58,6 @@ describe("normalizeListing", () => {
         expect(listing.sellerName).toBe("Rakesh Kumar");
         expect(listing.isBusiness).toBe(false);
         expect(listing.verified).toBe(true);
+        expect((listing as { userId?: unknown }).userId).toBeUndefined();
     });
 });

--- a/frontend/src/lib/api/user/listings/normalizer.ts
+++ b/frontend/src/lib/api/user/listings/normalizer.ts
@@ -139,9 +139,14 @@ function toListingSchemaCompatible(data: unknown): unknown {
 
     const rawSellerId = record.sellerId;
     const normalizedSellerId = extractId(rawSellerId);
-    const normalizedUserId = extractId(record.userId) ?? '';
     if (normalizedSellerId) record.sellerId = normalizedSellerId;
-    record.userId = normalizedUserId;
+    // Keep inbound legacy alias readable, but never synthesize/write it.
+    const normalizedUserId = extractId(record.userId);
+    if (normalizedUserId) {
+        record.userId = normalizedUserId;
+    } else {
+        delete record.userId;
+    }
 
     if (record.verified === undefined && rawSellerId && typeof rawSellerId === 'object') {
         const sellerRecord = rawSellerId as Record<string, unknown>;
@@ -218,9 +223,8 @@ function coerceListingFallback(data: unknown): Listing {
         price: Number.isFinite(price) ? price : 0,
         images: Array.isArray(record.images) ? record.images.filter((img): img is string => typeof img === 'string').map(normalizeImageUrl) : [],
         location: fallbackLocation,
-        userId: extractId(record.userId) ?? extractId(record.sellerId) ?? '',
         status: normalizeAdStatus(typeof record.status === 'string' ? record.status : 'pending'),
-        sellerId: extractId(record.sellerId) || '',
+        sellerId: extractId(record.sellerId) ?? extractId(record.userId) ?? '',
         createdAt,
         updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : (record.updatedAt instanceof Date ? record.updatedAt.toISOString() : undefined),
         views: typeof record.views === 'number' ? record.views : 0,
@@ -241,6 +245,8 @@ export function normalizeListing(data: unknown): Listing {
     const compatible = toListingSchemaCompatible(unwrapListingPayload(data));
     const parsed = AdSchema.safeParse(compatible);
     const validated = parsed.success ? parsed.data : coerceListingFallback(compatible);
+    const { userId: _legacyUserId, ...validatedWithoutLegacyUserId } =
+        validated as Listing & { userId?: string };
     
     const location = normalizeLocation(validated.location);
     
@@ -283,18 +289,18 @@ export function normalizeListing(data: unknown): Listing {
         || validated.verified === true;
 
     return {
-        ...validated,
-        status: normalizeAdStatus(validated.status),
-        id: String(validated.id || ''),
-        images: toSafeImageArray(Array.isArray(validated.images) ? validated.images.map((image) => normalizeImageUrl(String(image))) : validated.images),
-        image: toSafeImageSrc(Array.isArray(validated.images) && validated.images.length > 0 ? normalizeImageUrl(String(validated.images[0])) : (typeof validated.image === 'string' ? normalizeImageUrl(validated.image) : validated.image)),
-        time: typeof validated.createdAt === 'string' ? new Date(validated.createdAt).toLocaleDateString() : '',
+        ...validatedWithoutLegacyUserId,
+        status: normalizeAdStatus(validatedWithoutLegacyUserId.status),
+        id: String(validatedWithoutLegacyUserId.id || ''),
+        images: toSafeImageArray(Array.isArray(validatedWithoutLegacyUserId.images) ? validatedWithoutLegacyUserId.images.map((image) => normalizeImageUrl(String(image))) : validatedWithoutLegacyUserId.images),
+        image: toSafeImageSrc(Array.isArray(validatedWithoutLegacyUserId.images) && validatedWithoutLegacyUserId.images.length > 0 ? normalizeImageUrl(String(validatedWithoutLegacyUserId.images[0])) : (typeof validatedWithoutLegacyUserId.image === 'string' ? normalizeImageUrl(validatedWithoutLegacyUserId.image) : validatedWithoutLegacyUserId.image)),
+        time: typeof validatedWithoutLegacyUserId.createdAt === 'string' ? new Date(validatedWithoutLegacyUserId.createdAt).toLocaleDateString() : '',
         isBusiness,
         verified,
         sellerName,
-        sellerId: extractId(validated.sellerId) || '',
+        sellerId: extractId(validatedWithoutLegacyUserId.sellerId) || '',
         views: normalizedViews,
-        location: (location || { city: "" }) as Listing['location']
+        location: (location || { city: "" }) as Listing['location'],
     } as Listing;
 }
 

--- a/frontend/tests/listing-chat-smoke.spec.ts
+++ b/frontend/tests/listing-chat-smoke.spec.ts
@@ -56,7 +56,7 @@ function extractItems(payload: unknown): Record<string, unknown>[] {
 
 function toCandidate(item: Record<string, unknown>): ListingCandidate | null {
   const id = String(item.id || item._id || "").trim();
-  const sellerId = String(item.sellerId || item.userId || "").trim();
+  const sellerId = String(item.sellerId || "").trim();
 
   if (!id || !sellerId) return null;
 


### PR DESCRIPTION
## Summary
- stop emitting synthetic legacy userId in frontend listing normalization
- preserve compatibility by still reading inbound legacy userId when deriving sellerId fallback
- update listing smoke and normalization tests to assert sellerId-first canonical ownership

## Scope
- frontend only
- no backend model/schema/controller changes
- no API contract mutation from server side

## Files
- frontend/src/lib/api/user/listings/normalizer.ts
- frontend/tests/listing-chat-smoke.spec.ts
- frontend/src/__tests__/listing-normalization.spec.ts

## Verification
- behavior-preserving diff review completed
- legacy inbound payloads still map to sellerId fallback in frontend normalizer
- note: local frontend type-check/tests were not executed in this temp worktree because dependencies/toolchain are not installed there