### PR TITLE
chore(ad): PR-D remove userId request alias acceptance

### DIFF
--- a/backend/src/__tests__/validators/ad.validator.spec.ts
+++ b/backend/src/__tests__/validators/ad.validator.spec.ts
@@ -1,4 +1,31 @@
-import { markAsSoldSchema } from '../../validators/ad.validator';
+import {
+    getAdsQuerySchema,
+    markAsSoldSchema,
+} from '../../validators/ad.validator';
+
+const validObjectId = '507f1f77bcf86cd799439011';
+
+describe('getAdsQuerySchema', () => {
+    it('accepts canonical sellerId query filter', () => {
+        const parsed = getAdsQuerySchema.parse({
+            page: '1',
+            limit: '20',
+            sellerId: validObjectId,
+        });
+
+        expect(parsed.sellerId).toBe(validObjectId);
+    });
+
+    it('rejects deprecated userId alias query filter', () => {
+        expect(() =>
+            getAdsQuerySchema.parse({
+                page: '1',
+                limit: '20',
+                userId: validObjectId,
+            })
+        ).toThrow(/userId/i);
+    });
+});
 
 describe('markAsSoldSchema', () => {
     it('accepts soldReason payload from profile sold flow', () => {
@@ -19,4 +46,3 @@ describe('markAsSoldSchema', () => {
         ).toThrow();
     });
 });
-

--- a/backend/src/controllers/ad/adMutationController.ts
+++ b/backend/src/controllers/ad/adMutationController.ts
@@ -20,6 +20,17 @@ import { IAuthUser } from '../../types/auth';
 import { LISTING_TYPE } from '../../../../shared/enums/listingType';
 import { warnIfLegacyAdUserIdAliasUsed } from '../../utils/legacyOwnerAliasTelemetry';
 
+const LEGACY_AD_OWNER_ALIAS_CODE = 'LEGACY_AD_USER_ID_ALIAS_REMOVED';
+const hasLegacyAdUserIdAlias = (value: unknown): boolean =>
+    Boolean(value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'userId'));
+
+const buildLegacyAliasDetails = (source: 'body') => ({
+    alias: 'userId',
+    canonical: 'sellerId',
+    source,
+    rolloutPhase: 'PR-D',
+});
+
 const sendClientError = (
     req: Request,
     res: Response,
@@ -39,8 +50,18 @@ const sendClientError = (
 export const createAd = async (req: Request, res: Response, next: NextFunction) => {
     try {
         warnIfLegacyAdUserIdAliasUsed(req, 'body');
+        if (hasLegacyAdUserIdAlias(req.body)) {
+            return sendClientError(
+                req,
+                res,
+                400,
+                '`userId` alias is no longer accepted in ad write payloads. Use `sellerId` or authenticated owner context.',
+                LEGACY_AD_OWNER_ALIAS_CODE,
+                buildLegacyAliasDetails('body')
+            );
+        }
         const authUserId = (req.user as IAuthUser)._id.toString();
-        const sellerId = req.body.sellerId || req.body.userId || authUserId;
+        const sellerId = req.body.sellerId || authUserId;
 
         // 🛡️ Strict listingType guard — requireListingType middleware coerces to LISTING_TYPE.AD
         // but double-check here as defense-in-depth against direct controller calls.
@@ -86,10 +107,20 @@ export const createAd = async (req: Request, res: Response, next: NextFunction) 
 export const updateAd = async (req: Request, res: Response, next: NextFunction) => {
     try {
         warnIfLegacyAdUserIdAliasUsed(req, 'body');
+        if (hasLegacyAdUserIdAlias(req.body)) {
+            return sendClientError(
+                req,
+                res,
+                400,
+                '`userId` alias is no longer accepted in ad write payloads. Use `sellerId` or authenticated owner context.',
+                LEGACY_AD_OWNER_ALIAS_CODE,
+                buildLegacyAliasDetails('body')
+            );
+        }
         const id = getSingleParam(req, res, 'id', { error: 'Invalid Ad ID' });
         if (!id) return;
         const authUserId = (req.user as IAuthUser)._id.toString();
-        const sellerId = req.body.sellerId || req.body.userId || authUserId;
+        const sellerId = req.body.sellerId || authUserId;
 
         // Defense-in-depth: strip immutable identity fields — mirrors listingController.editListing
         const PROTECTED_FIELDS = ['categoryId', 'brandId', 'modelId', 'listingType', 'sellerId',

--- a/backend/src/controllers/ad/adQueryController.ts
+++ b/backend/src/controllers/ad/adQueryController.ts
@@ -20,6 +20,27 @@ import { LISTING_TYPE } from '../../../../shared/enums/listingType';
 import { warnIfLegacyAdUserIdAliasUsed } from '../../utils/legacyOwnerAliasTelemetry';
 
 const asControllerError = (error: unknown): any => error as any;
+const LEGACY_AD_OWNER_ALIAS_CODE = 'LEGACY_AD_USER_ID_ALIAS_REMOVED';
+const hasLegacyAdUserIdAlias = (value: unknown): boolean =>
+    Boolean(value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'userId'));
+
+const sendLegacyAliasError = (req: Request, res: Response, source: 'query') =>
+    sendErrorResponse(
+        req,
+        res,
+        400,
+        '`userId` alias is no longer accepted in ad filters. Use `sellerId` instead.',
+        {
+            code: LEGACY_AD_OWNER_ALIAS_CODE,
+            details: {
+                alias: 'userId',
+                canonical: 'sellerId',
+                source,
+                rolloutPhase: 'PR-D',
+            },
+        }
+    );
+
 const getViewerIdForFeed = (req: Request): string | undefined => {
     const user = req.user as IAuthUser | undefined;
     if (!user) return undefined;
@@ -33,6 +54,9 @@ const getViewerIdForFeed = (req: Request): string | undefined => {
 export const getAds = async (req: Request, res: Response, next: NextFunction) => {
     try {
         warnIfLegacyAdUserIdAliasUsed(req, 'query');
+        if (hasLegacyAdUserIdAlias(req.query)) {
+            return sendLegacyAliasError(req, res, 'query');
+        }
         const viewerId = getViewerIdForFeed(req);
         const query = getAdsQuerySchema.parse(req.query);
         const requestedPage = Number(query.page ?? 1);
@@ -132,6 +156,9 @@ export const getAds = async (req: Request, res: Response, next: NextFunction) =>
 export const getNearbyAds = async (req: Request, res: Response, next: NextFunction) => {
     try {
         warnIfLegacyAdUserIdAliasUsed(req, 'query');
+        if (hasLegacyAdUserIdAlias(req.query)) {
+            return sendLegacyAliasError(req, res, 'query');
+        }
         const viewerId = getViewerIdForFeed(req);
         const query = getAdsQuerySchema.parse({
             ...req.query,

--- a/backend/src/routes/adRoutes.ts
+++ b/backend/src/routes/adRoutes.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 import * as adController from "../controllers/ad";
 import * as listingController from "../controllers/listingController";
 import { protect, extractUser } from "../middleware/authMiddleware";
@@ -8,8 +8,7 @@ import { validateObjectId } from "../middleware/validateObjectId";
 import { validateRequest } from "../middleware/validateRequest";
 import { enforceCreateAdIdempotency, idempotencyMiddleware } from "../middleware/idempotency";
 import { fraudMiddleware } from "../middleware/fraudMiddleware";
-import { AdPayloadSchema } from "../../../shared/schemas/adPayload.schema";
-import { updateAdSchema } from "../validators/ad.validator";
+import { createAdSchema, updateAdSchema } from "../validators/ad.validator";
 import type { ZodTypeAny } from "zod";
 
 import { duplicateCooldownMiddleware } from "../middleware/duplicateCooldownMiddleware";
@@ -17,8 +16,32 @@ import { createListingValidator } from "../validators/listing.validator";
 import { requireVerifiedBusinessForServiceParts } from "../middleware/requireVerifiedBusiness";
 import { requireListingType } from "../middleware/requireListingType";
 import { LISTING_TYPE } from "../../../shared/enums/listingType";
+import { sendErrorResponse } from "../utils/errorResponse";
 
 const router = express.Router();
+const LEGACY_AD_OWNER_ALIAS_CODE = "LEGACY_AD_USER_ID_ALIAS_REMOVED";
+
+const hasOwn = (value: unknown, key: string): boolean =>
+    Boolean(value && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key));
+
+const rejectLegacyAdUserIdAlias = (req: Request, res: Response, next: NextFunction) => {
+    if (!hasOwn(req.body, "userId")) return next();
+    return sendErrorResponse(
+        req,
+        res,
+        400,
+        "`userId` alias is no longer accepted in ad write payloads. Use `sellerId` or authenticated owner context.",
+        {
+            code: LEGACY_AD_OWNER_ALIAS_CODE,
+            details: {
+                alias: "userId",
+                canonical: "sellerId",
+                source: "body",
+                rolloutPhase: "PR-D",
+            },
+        }
+    );
+};
 
 /* -------------------------------------------------------------------------- */
 /* Public Routes                                                              */
@@ -42,12 +65,13 @@ router.get("/suggestions", searchLimiter, adController.getSuggestions);
 router.post(
     "/",
     protect,
+    rejectLegacyAdUserIdAlias,
     adPostLimiter,
     requireVerifiedBusinessForServiceParts,
     requireListingType(LISTING_TYPE.AD),   // 🛡️ Rejects service/spare_part submitted via ad route
     duplicateCooldownMiddleware('ad'),
     fraudMiddleware,
-    validateRequest(AdPayloadSchema as unknown as ZodTypeAny),
+    validateRequest(createAdSchema as unknown as ZodTypeAny),
     createListingValidator,
     enforceCreateAdIdempotency,
     adController.createAd
@@ -77,7 +101,15 @@ router.get("/:id/phone", validateObjectId, searchLimiter, listingController.getL
 
 // Update ad
 // D1: PATCH update uses partial schema (updateAdSchema = PartialAdPayloadSchema.passthrough())
-router.patch("/:id", validateObjectId, protect, mutationLimiter, validateRequest(updateAdSchema as unknown as ZodTypeAny), adController.updateAd);
+router.patch(
+    "/:id",
+    validateObjectId,
+    protect,
+    rejectLegacyAdUserIdAlias,
+    mutationLimiter,
+    validateRequest(updateAdSchema as unknown as ZodTypeAny),
+    adController.updateAd
+);
 
 
 

--- a/backend/src/validators/ad.validator.ts
+++ b/backend/src/validators/ad.validator.ts
@@ -23,6 +23,20 @@ const adStatusEnum = z.enum(AD_STATUS_VALUES);
  * Seller type enum
  */
 const sellerTypeEnum = z.enum(['user', 'business']);
+const LEGACY_AD_USER_ID_ALIAS = 'userId';
+const LEGACY_AD_USER_ID_ALIAS_MESSAGE = '`userId` is no longer accepted in ad query filters. Use `sellerId` instead.';
+
+const hasOwn = (value: unknown, key: string): boolean =>
+    Boolean(value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, key));
+
+const throwIfLegacyAdUserIdAliasPresent = (raw: unknown): void => {
+    if (!hasOwn(raw, LEGACY_AD_USER_ID_ALIAS)) return;
+    throw new z.ZodError([{
+        code: z.ZodIssueCode.custom,
+        path: [LEGACY_AD_USER_ID_ALIAS],
+        message: LEGACY_AD_USER_ID_ALIAS_MESSAGE,
+    }]);
+};
 
 
 
@@ -40,9 +54,9 @@ import { normalizeStatus } from '../../../shared/utils/statusNormalization';
 
 /**
  * Get Ads Query Schema
- * Implements Naming Coercion (Clean-At-Gate)
+ * Canonical ownership query key is sellerId.
  */
-export const getAdsQuerySchema = commonSchemas.pagination.extend({
+const getAdsQuerySchemaBase = commonSchemas.pagination.extend({
     ...commonSchemas.sort.shape,
     ...commonSchemas.search.shape,
     // Legacy alias kept for backward compatibility with older clients.
@@ -57,9 +71,8 @@ export const getAdsQuerySchema = commonSchemas.pagination.extend({
     locationId: commonSchemas.objectId.optional(),
     level: z.enum(['country', 'state', 'district', 'city', 'area', 'village']).optional(),
     
-    // Naming Coercion: sellerId vs userId
+    // Canonical ownership filter
     sellerId: commonSchemas.objectId.optional(),
-    userId: commonSchemas.objectId.optional(),
     
     sellerType: sellerTypeEnum.optional(),
 
@@ -82,13 +95,12 @@ export const getAdsQuerySchema = commonSchemas.pagination.extend({
     lng: z.string().transform(Number).pipe(z.number().min(-180).max(180)).optional(),
     coordinates: z.any().optional(),
     cursor: commonSchemas.objectId.optional(),
-}).transform((data: any) => {
-    // Coerce userId -> sellerId if sellerId is missing
-    if (data.userId && !data.sellerId) {
-        data.sellerId = data.userId;
-    }
-    return data;
 });
+
+export const getAdsQuerySchema = z.preprocess((raw) => {
+    throwIfLegacyAdUserIdAliasPresent(raw);
+    return raw;
+}, getAdsQuerySchemaBase);
 
 /**
  * Ad ID Param Schema


### PR DESCRIPTION
## Summary
- remove userId to sellerId coercion from ad query validator
- add explicit request rejection and deprecation metadata for legacy userId alias in ad write/query entrypoints
- keep canonical ownership handling on sellerId/authenticated user context only
- add focused validator coverage for canonical sellerId query and legacy alias rejection

## Verification
- npm run type-check -w backend
- npm run build -w backend
- NODE_ENV=test MONGODB_URI=https://example.com ADMIN_MONGODB_URI=https://example.com JWT_SECRET=abcdefghijklmnopqrstuvwxyzABCDEF12 npm run test -w backend -- src/__tests__/validators/ad.validator.spec.ts