### PR TITLE
refactor(ad): PR-E remove ownership aliases from model contract

### DIFF
--- a/backend/src/models/Ad.ts
+++ b/backend/src/models/Ad.ts
@@ -74,7 +74,6 @@ export interface IAd extends Document, ISoftDeleteDocument {
         timestamp: Date;
         reason?: string;
     }>;
-    userId?: Types.ObjectId;
     reviewVersion: number;
     freshnessScore: number;
 
@@ -239,10 +238,8 @@ const AdSchema: Schema = new Schema({
         virtuals: true,
         versionKey: false,
         transform: function (_doc, ret) {
-            const json = ret as Record<string, unknown> & { _id?: { toString(): string }; id?: string; sellerId?: any };
+            const json = ret as Record<string, unknown> & { _id?: { toString(): string }; id?: string };
             json.id = json._id?.toString();
-            // Harmonization alias
-            json.userId = json.sellerId;
             delete json._id;
             return json;
         }
@@ -537,13 +534,6 @@ AdSchema.post('findOneAndUpdate', async function (doc: IAd | null) {
         },
         (options.session as ClientSession | undefined) || undefined
     );
-});
-
-// Harmonization Virtuals
-AdSchema.virtual('userId').get(function() {
-    return this.sellerId;
-}).set(function(v) {
-    this.sellerId = v;
 });
 
 // POST-SAVE ERROR HOOK implementation removed (duplicate mutation of seoSlug)

--- a/shared/schemas/ad.schema.ts
+++ b/shared/schemas/ad.schema.ts
@@ -26,9 +26,7 @@ export const AdSchema = z.object({
         locationId: z.string().optional(),
         coordinates: coordinatesSchema.optional(),
     }).passthrough(),
-    sellerId: z.string(), // Canonical Ownership Key
-    userId: z.string().optional(), // Legacy Alias (Deprecated)
-    ownerId: z.string().optional(), // Future Canonical Key
+    sellerId: z.string(), // Canonical Ownership Key (SSOT)
     status: z.enum(AD_DISPLAY_STATUS_VALUES),
     sellerType: z.enum(['business', 'user']).optional(),
     createdAt: z.string().datetime({ offset: true }),


### PR DESCRIPTION
## Summary
- remove Ad model userId compatibility alias from IAd interface
- stop emitting userId in Ad toJSON transform
- remove AdSchema virtual userId getter/setter bridge
- remove legacy ad ownership aliases userId and ownerId from shared AdSchema so sellerId is the single ownership key

## Verification
- npm run type-check
- npm run build -w backend
- NEXT_PUBLIC_API_URL=https://example.com/api/v1 npm run test -w frontend -- src/__tests__/listing-normalization.spec.ts
- NODE_ENV=test MONGODB_URI=https://example.com ADMIN_MONGODB_URI=https://example.com JWT_SECRET=abcdefghijklmnopqrstuvwxyzABCDEF12 npm run test -w backend -- src/__tests__/validators/ad.validator.spec.ts

## Notes
- This is PR-E of the ad ownership alias migration.