### PR TITLE
refactor(payment): use env SSOT for mock order mode

### DIFF
--- a/backend/src/controllers/payment/paymentMutationController.ts
+++ b/backend/src/controllers/payment/paymentMutationController.ts
@@ -1,4 +1,5 @@
 import logger from '../../utils/logger';
+import { env } from '../../config/env';
 import { Request, Response } from 'express';
 import crypto from 'crypto';
 import {
@@ -70,7 +71,7 @@ export const createPaymentOrder = async (req: Request, res: Response) => {
             }));
         }
 
-        const isMock = process.env.NODE_ENV === 'development'
+        const isMock = env.NODE_ENV === 'development'
             && (razorpayConfig.keyId === 'rzp_test_placeholder' || req.headers['x-mock-payment'] === 'true');
 
         let rzpOrder;


### PR DESCRIPTION
## Summary
- port slice-1 low-risk subset from recovery branch
- replace direct `process.env.NODE_ENV` check with centralized `env.NODE_ENV` in payment mutation controller
- keep behavior unchanged while aligning runtime env access with SSOT pattern

## Verification
- npm run type-check -w backend
- npm run build -w backend