### PR TITLE
fix(deploy): resolve Render build deprecation errors

### DIFF
--- a/admin-backend/tsconfig.json
+++ b/admin-backend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types",

--- a/admin-backend/tsconfig.json
+++ b/admin-backend/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types",

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "baseUrl": "..",
     "rootDir": "..",
     "outDir": "./dist",

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": "..",
     "rootDir": "..",
     "outDir": "./dist",


### PR DESCRIPTION
Adds ignoreDeprecations: 6.0 to tsconfigs to satisfy Render's newer TypeScript environment and unblock deployment.