### PR TITLE
chore(runtime): finalize Node 22 runtime governance SSOT

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+engine-strict=true
+fund=false
+audit=false

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": ">=22.0.0 <23"
   },
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": ">=22.0.0 <23"
   },
   "scripts": {
     "dev": "NODE_OPTIONS='--disable-warning=DEP0169' next dev -p 3000",

--- a/backend/user/package.json
+++ b/backend/user/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": ">=22.0.0 <23"
   },
   "scripts": {
     "clean": "lsof -ti:5001 | xargs kill -9 || true",

--- a/core/package.json
+++ b/core/package.json
@@ -2,6 +2,9 @@
   "name": "@esparex/core",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0 <23"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": ">=22.0.0 <23"
   },
+  "packageManager": "npm@10.9.7",
   "workspaces": [
     "apps/admin",
     "apps/web",

--- a/scripts/guard-runtime-parity.js
+++ b/scripts/guard-runtime-parity.js
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 
-const runtimeVersion = process.versions.node || process.version.replace(/^v/, '');
-const [major] = runtimeVersion.split('.');
-const allowedMajors = new Set(['20', '22']);
-const recommendedMajor = '22';
+const runtimeVersion =
+  process.versions.node || process.version.replace(/^v/, '');
 
-if (!allowedMajors.has(major)) {
+const [major] = runtimeVersion.split('.');
+
+const requiredMajor = '22';
+const policy = '>=22.0.0 <23';
+
+if (major !== requiredMajor) {
   console.error('[guard:runtime-parity] Unsupported Node.js runtime detected.');
   console.error(`[guard:runtime-parity] Current: v${runtimeVersion}`);
-  console.error('[guard:runtime-parity] Allowed policy: ^20 || ^22');
-  console.error(`[guard:runtime-parity] Recommended standard: ${recommendedMajor}.x`);
+  console.error(`[guard:runtime-parity] Required policy: ${policy}`);
   process.exit(1);
 }
 
 console.log(
-  `[guard:runtime-parity] Runtime parity check passed on Node v${runtimeVersion} (policy: ^20 || ^22).`
+  `[guard:runtime-parity] Runtime parity check passed on Node v${runtimeVersion} (policy: ${policy}).`
 );

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,6 +2,9 @@
   "name": "@esparex/shared",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0 <23"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/shared/src/observability/package.json
+++ b/shared/src/observability/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": ">=22.0.0 <23"
   },
   "scripts": {
     "type-check": "tsc --noEmit --esModuleInterop --skipLibCheck"


### PR DESCRIPTION
## What does this PR do?

Finalizes the Node.js 22 runtime Single Source of Truth (SSOT) governance across the Esparex monorepo.

This PR:

* standardizes all workspace engine policies to `>=22.0.0 <23`
* removes the final legacy `^20 || ^22` runtime allowance
* aligns `guard-runtime-parity.js` with the enforced Node 22 runtime policy
* preserves deterministic npm/runtime governance across local, CI, and Vercel environments

---

## Type of change

* [x] `chore` — refactor / cleanup / tooling

---

## Packages affected

* [x] `shared`

---

## Runtime / Infrastructure Impact

* No Redis changes
* No BullMQ behavioral changes
* No queue architecture changes
* No API or database changes

This PR only affects runtime governance enforcement and parity validation.

---

## Validation plan

Validated successfully with:

```bash
node scripts/guard-runtime-parity.js
npm run guard:platform-governance
npm run guard:env-contracts
npm run type-check
npm run build
```

---

## Rollback plan

Low-risk rollback:

* revert runtime engine policy updates
* revert parity script enforcement changes

No data migration or infrastructure rollback required.