### PR TITLE
fix(web): correct shared image domain registry paths

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const imageDomainRegistryPath = path.resolve(__dirname, '../../shared/constants/image-domain-registry.json');
+const imageDomainRegistryPath = path.resolve(__dirname, '../../shared/src/constants/image-domain-registry.json');
 const imageDomainRegistry = JSON.parse(fs.readFileSync(imageDomainRegistryPath, 'utf8'));
 const staticRemotePatterns = Array.isArray(imageDomainRegistry.nextRemotePatterns)
     ? imageDomainRegistry.nextRemotePatterns

--- a/apps/web/scripts/validate-image-domains.cjs
+++ b/apps/web/scripts/validate-image-domains.cjs
@@ -3,7 +3,7 @@ const path = require('path');
 
 const projectRoot = path.resolve(__dirname, '..');
 const srcRoot = path.join(projectRoot, 'src');
-const registryPath = path.resolve(projectRoot, '../shared/constants/image-domain-registry.json');
+const registryPath = path.resolve(projectRoot, '../../shared/src/constants/image-domain-registry.json');
 const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
 
 const nextRemotePatterns = Array.isArray(registry.nextRemotePatterns) ? registry.nextRemotePatterns : [];
@@ -68,7 +68,7 @@ const suspiciousImageMemberRegex =
 for (const filePath of files) {
   const content = fs.readFileSync(filePath, 'utf8');
   let match;
-  while ((match = imageLiteralRegex.exec(content)) !== undefined) {
+  while ((match = imageLiteralRegex.exec(content)) !== null) {
     const rawUrl = match[2];
     if (!rawUrl) continue;
 
@@ -87,7 +87,7 @@ for (const filePath of files) {
   }
 
   let tagMatch;
-  while ((tagMatch = imageTagRegex.exec(content)) !== undefined) {
+  while ((tagMatch = imageTagRegex.exec(content)) !== null) {
     const tagSource = tagMatch[0];
     const dynamicSrc = tagSource.match(dynamicSrcRegex);
     if (!dynamicSrc || !dynamicSrc[1]) continue;

--- a/shared/constants/image-domain-registry.json
+++ b/shared/constants/image-domain-registry.json
@@ -1,3 +1,0 @@
-{
-  "nextRemotePatterns": []
-}


### PR DESCRIPTION
## Problem
The image validation script `validate-image-domains.cjs` crashes with `ENOENT` because it resolves to a non-existent `apps/shared` directory. Additionally, the Next.js bundler config imports an empty baseline domain registry JSON from `shared/constants/`, disabling optimized remote image patterns in production.

## Solution
1. Update `validate-image-domains.cjs` path resolution to target the root `shared/src/constants/` registry.
2. Correct `next.config.mjs` to import the populated `shared/src/constants/image-domain-registry.json` registry.
3. Remove the duplicate empty JSON file.
4. Correct loop conditionals in `validate-image-domains.cjs` to check `!== null` instead of `!== undefined` to prevent a loop crash (validation blocker fix).

## Verification
- Executed `npm run lint:image-domains -w @esparex/apps-web` successfully (validation script scanned files and reported pre-existing issues without crashing).
- Executed `npm run build -w @esparex/apps-web` successfully (compiled with the proxy middleware and generated static pages).
