### PR TITLE
chore(deps): upgrade github action versions across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
       NEXT_PUBLIC_FIREBASE_VAPID_KEY: placeholder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: npm
@@ -77,7 +77,7 @@ jobs:
         run: cp -r apps/web/.next apps/web/next-build
 
       - name: Upload Web Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-build-artifacts
           path: apps/web/next-build
@@ -107,10 +107,10 @@ jobs:
       NEXT_PUBLIC_LOCAL_DEV_AUTH: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: npm
@@ -124,7 +124,7 @@ jobs:
         working-directory: apps/web
 
       - name: Download Web Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-build-artifacts
           path: apps/web/next-build
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-listing-edit
           path: apps/web/test-results/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,15 +27,15 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: npm


### PR DESCRIPTION
## Overview
This PR consolidates and cleanly upgrades the version of standard GitHub Actions used in our workflows. It resolves stale and conflicting action versions while preserving full repository stability.

## Changes
- **`.github/workflows/ci.yml`**:
  - Upgraded `actions/checkout` from `@v4` -> `@v7`
  - Upgraded `actions/setup-node` from `@v4` -> `@v6`
  - Upgraded `actions/upload-artifact` from `@v4` -> `@v7`
  - Upgraded `actions/download-artifact` from `@v4` -> `@v8`
- **`.github/workflows/codeql.yml`**:
  - Upgraded `actions/checkout` from `@v4` -> `@v7`
  - Upgraded `github/codeql-action` from `@v3` -> `@v4` (init and analyze steps)
- **`.github/workflows/release.yml`**:
  - Upgraded `actions/checkout` from `@v4` -> `@v7`
  - Upgraded `actions/setup-node` from `@v4` -> `@v6`

## Verification & Validation
The following validation pipeline was run and passed successfully:
- [x] Type checking (`npm run type-check`)
- [x] Lint checks (`npm run lint`)
- [x] Backend & Core test suites (`npm test`)
- [x] Monorepo production build (`npm run build`)
- [x] Platform governance and boundaries (`npm run governance:all`)
