### PR TITLE
fix(perf-auth): add HTTP caching to home feed and throttle notification refetches

### DIFF
--- a/apps/web/src/hooks/queries/useNotificationsQuery.ts
+++ b/apps/web/src/hooks/queries/useNotificationsQuery.ts
@@ -24,6 +24,7 @@ export const useNotificationsQuery = ({
         queryKey: queryKeys.notifications.list({ page, limit, filter, type, q }),
         queryFn: () => notificationApi.getAll({ page, limit, filter, type, q }),
         enabled, // Restored enabled usage to respect SSR rules
-        refetchOnWindowFocus: true, // Keep manual fallback refresh
-        refetchOnReconnect: true    // Keep network reconnect refresh
+        staleTime: 5 * 60 * 1000,  // 5 min — throttles refetchOnWindowFocus so it only fires after data is actually stale
+        refetchOnWindowFocus: true, // Intentional: refreshes unread badge when user returns to the tab
+        refetchOnReconnect: true    // Intentional: refreshes after network reconnect
     });

--- a/backend/api/src/controllers/listing/getListings.controller.ts
+++ b/backend/api/src/controllers/listing/getListings.controller.ts
@@ -314,6 +314,7 @@ export const getHomeFeed = async (req: Request, res: Response, next: NextFunctio
         });
         const etagValue = `W/"${Buffer.from(JSON.stringify(payload)).toString('base64').substring(0, 24)}"`;
         res.setHeader('ETag', etagValue);
+        res.setHeader('Cache-Control', 'public, max-age=60, stale-while-revalidate=300');
         if (req.headers['if-none-match'] === etagValue) {
             return res.status(304).end();
         }


### PR DESCRIPTION
## Summary

Part of the Performance & Authentication Remediation audit. Two targeted fixes to reduce unnecessary network traffic and enable HTTP-level caching on the home feed.

## Changes

### `backend/api/src/controllers/listing/getListings.controller.ts`

Added `Cache-Control: public, max-age=60, stale-while-revalidate=300` to `GET /api/v1/listings/home`.

The home feed already had Redis caching (300s TTL) and ETag support for 304 responses, but without a `Cache-Control` header, CDNs and reverse proxies could not cache responses at the HTTP layer. With this change:
- CDNs serve the feed directly for 60 seconds without hitting the origin
- `stale-while-revalidate=300` allows background revalidation, eliminating cold-cache latency spikes for users

### `apps/web/src/hooks/queries/useNotificationsQuery.ts`

Added explicit `staleTime: 5 * 60 * 1000` to the notifications query.

`refetchOnWindowFocus: true` is intentional — it refreshes the unread badge in the header when the user returns to the tab. However, without an explicit `staleTime`, React Query was firing a network request on every tab focus event even when the data was still fresh. The `staleTime` throttles this so refetches only occur when data is actually stale (older than 5 minutes).

## Audit Findings (No Code Change Required)

| Item | Result |
|------|--------|
| OTP 503 | Env-only fix (`USE_DEFAULT_OTP=true` in Render). Guard logic is correct. |
| Duplicate `UserAppProviders` | Not structurally duplicated. Next.js parallel route groups are mutually exclusive — only one instance mounts per navigation. Dev double-effects are React 18 Strict Mode behavior. |
| `/catalog/categories` caching | Intentionally prevented by existing route middleware — skipped. |
| MongoDB indexes on `mobile` | All confirmed present: `idx_user_mobile_unique_idx`, `idx_otp_mobile_idx`, `idx_otp_mobile_createdAt_idx`, `idx_otp_expiresAt_ttl_idx`. |

## Testing

- [x] Pre-push type-check passes across all workspaces
- [x] All unit tests pass (314 backend-api + 215 core = 529 total)
- [x] `/listings/home` response now includes `Cache-Control` and `ETag` headers
- [x] Notifications refetch is throttled to at most once per 5 minutes on tab focus

## Type

- [x] Performance
- [x] Bug Fix
