### PR TITLE
refactor(catalog): migrate Catalog Bounded Context to DDD Ports & Adapters Architecture

### DIFF
--- a/backend/api/src/controllers/admin/catalog/catalogCategoryController.ts
+++ b/backend/api/src/controllers/admin/catalog/catalogCategoryController.ts
@@ -244,7 +244,7 @@ export const updateCategory = async (req: Request, res: Response) => {
 
         clearCategoryCanonicalCache();
 
-        void logAdminAction(req, 'CATEGORY_RENAME', 'Category', updatedCategory._id, {
+        void logAdminAction(req, 'CATEGORY_RENAME', 'Category', updatedCategory.id, {
             before: { name: oldCategory.name, slug: oldCategory.slug },
             after: { name: updatedCategory.name, slug: updatedCategory.slug }
         });

--- a/core/src/__tests__/services/CatalogValidationService.spec.ts
+++ b/core/src/__tests__/services/CatalogValidationService.spec.ts
@@ -1,5 +1,5 @@
 import { CatalogValidationService } from '../../services/catalog/CatalogValidationService';
-import { CategoryRepositoryPort, BrandRepositoryPort } from '../../domains/catalog';
+import { CategoryRepositoryPort, BrandRepositoryPort, ModelRepositoryPort, SparePartRepositoryPort } from '../../domains/catalog';
 
 describe('CatalogValidationService Mock-Based Testing', () => {
     const mockCategoryRepository = {
@@ -15,7 +15,22 @@ describe('CatalogValidationService Mock-Based Testing', () => {
         exists: jest.fn(),
     } as unknown as jest.Mocked<BrandRepositoryPort>;
 
-    const service = new CatalogValidationService(mockCategoryRepository, mockBrandRepository);
+    const mockModelRepository = {
+        findById: jest.fn(),
+        exists: jest.fn(),
+    } as unknown as jest.Mocked<ModelRepositoryPort>;
+
+    const mockSparePartRepository = {
+        findById: jest.fn(),
+        exists: jest.fn(),
+    } as unknown as jest.Mocked<SparePartRepositoryPort>;
+
+    const service = new CatalogValidationService(
+        mockCategoryRepository, 
+        mockBrandRepository,
+        mockModelRepository,
+        mockSparePartRepository
+    );
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/core/src/adapters/outbound/database/catalog/MongoBrandRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoBrandRepositoryAdapter.ts
@@ -26,23 +26,63 @@ export class MongoBrandRepositoryAdapter implements BrandRepositoryPort {
         };
     }
 
-    async findById(id: string): Promise<Brand | null> {
+    async findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Brand | null> {
         const safeId = typeof id === 'string' ? id : String(id);
-        const doc = await BrandModel.findById(safeId).lean<DbBrand | null>().exec();
+        const query = BrandModel.findById(safeId).lean<DbBrand | null>();
+        if (includeDeleted) query.setOptions({ withDeleted: true });
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async findByNameAndCategory(name: string, categoryId: string): Promise<Brand | null> {
+    async findByNameAndCategory(name: string, categoryId: string, tx?: unknown): Promise<Brand | null> {
         const canonicalName = name.trim().toLowerCase().replace(/\s+/g, ' ');
-        const doc = await BrandModel.findOne({
+        const query = BrandModel.findOne({
             canonicalName,
             categoryIds: categoryId
-        }).lean<DbBrand | null>().exec();
+        }).lean<DbBrand | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async exists(id: string): Promise<boolean> {
-        const doc = await BrandModel.findById(id).select('_id').lean().exec();
+    async findByCategory(categoryId: string, tx?: unknown): Promise<Brand[]> {
+        const query = BrandModel.find({ categoryIds: categoryId }).lean<DbBrand[]>();
+        if (tx) query.session(tx as any);
+        const docs = await query.exec();
+        return docs.map(doc => this.toDomain(doc));
+    }
+
+    async exists(id: string, tx?: unknown): Promise<boolean> {
+        const query = BrandModel.findById(id).select('_id').lean();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc !== null;
+    }
+
+    async updateCategoryIds(brandId: string, categoryIds: string[], tx?: unknown): Promise<boolean> {
+        const query = BrandModel.updateOne(
+            { _id: brandId },
+            { $set: { categoryIds: categoryIds } }
+        );
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount > 0;
+    }
+
+    async softDelete(brandId: string, tx?: unknown): Promise<boolean> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = BrandModel.findByIdAndUpdate(brandId, update, { new: true });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return !!res;
+    }
+
+    async softDeleteMany(brandIds: string[], tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = BrandModel.updateMany({ _id: { $in: brandIds } }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
     }
 }

--- a/core/src/adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter.ts
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+import { CatalogUnitOfWorkPort, TransactionContext } from '../../../../domains/catalog/ports/CatalogUnitOfWorkPort';
+import { getUserConnection } from '../../../../config/db';
+import logger from '../../../../utils/logger';
+
+export class MongoCatalogUnitOfWorkAdapter implements CatalogUnitOfWorkPort {
+    async executeTransaction<T>(work: (context: TransactionContext) => Promise<T>): Promise<T> {
+        let session: mongoose.ClientSession | null = null;
+        try {
+            session = await getUserConnection().startSession();
+            if (session) {
+                session.startTransaction();
+                const result = await work(session);
+                await session.commitTransaction();
+                return result;
+            }
+            // Fallback if session creation fails (e.g., non-replica set local db)
+            return await work(null);
+        } catch (e: unknown) {
+            if (session) {
+                try { await session.abortTransaction(); } catch { /* ignore */ }
+                
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const isSessionError = /session|transaction|mongoclient/i.test(errorMessage);
+                
+                if (isSessionError) {
+                    logger.warn(`Transaction session failed (${errorMessage}). Retrying sequential sessionless...`);
+                    try { await session.endSession(); } catch { /* ignore */ }
+                    session = null;
+                    return await work(null);
+                }
+            }
+            throw e;
+        } finally {
+            if (session) {
+                try { await session.endSession(); } catch { /* ignore */ }
+            }
+        }
+    }
+}

--- a/core/src/adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { CatalogUnitOfWorkPort, TransactionContext } from '../../../../domains/catalog/ports/CatalogUnitOfWorkPort';
+import { CatalogUnitOfWorkPort, TransactionContext } from '../../../../domains/catalog';
 import { getUserConnection } from '../../../../config/db';
 import logger from '../../../../utils/logger';
 

--- a/core/src/adapters/outbound/database/catalog/MongoCategoryRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoCategoryRepositoryAdapter.ts
@@ -42,33 +42,61 @@ export class MongoCategoryRepositoryAdapter implements CategoryRepositoryPort {
         };
     }
 
-    async findById(id: string): Promise<Category | null> {
+    async findById(id: string, tx?: unknown): Promise<Category | null> {
         const safeId = typeof id === 'string' ? id : String(id);
-        const doc = await CategoryModel.findById(safeId).lean<DbCategory | null>().exec();
+        const query = CategoryModel.findById(safeId).lean<DbCategory | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async findBySlug(slug: string): Promise<Category | null> {
+    async findBySlug(slug: string, tx?: unknown): Promise<Category | null> {
         const safeSlug = typeof slug === 'string' ? slug : String(slug ?? '');
-        const doc = await CategoryModel.findOne({ slug: safeSlug }).lean<DbCategory | null>().exec();
+        const query = CategoryModel.findOne({ slug: safeSlug }).lean<DbCategory | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async exists(id: string): Promise<boolean> {
-        const doc = await CategoryModel.findById(id).select('_id').lean().exec();
+    async exists(id: string, tx?: unknown): Promise<boolean> {
+        const query = CategoryModel.findById(id).select('_id').lean();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc !== null;
     }
 
-    async resolveActiveCategoryIds(categoryIds?: readonly CategoryId[]): Promise<readonly CategoryId[]> {
-        const query: Record<string, unknown> = {
+    async resolveActiveCategoryIds(categoryIds?: readonly CategoryId[], tx?: unknown): Promise<readonly CategoryId[]> {
+        const filter: Record<string, unknown> = {
             isActive: true,
             isDeleted: { $ne: true },
             approvalStatus: CATALOG_APPROVAL_STATUS.APPROVED
         };
         if (categoryIds && categoryIds.length > 0) {
-            query._id = { $in: categoryIds };
+            filter._id = { $in: categoryIds };
         }
-        const docs = await CategoryModel.find(query).select('_id').lean().exec();
+        const query = CategoryModel.find(filter).select('_id').lean();
+        if (tx) query.session(tx as any);
+        const docs = await query.exec();
         return docs.map(doc => String(doc._id));
+    }
+
+    async create(data: Partial<Category> | any, tx?: unknown): Promise<Category> {
+        const docs = await CategoryModel.create([data], { session: tx as any });
+        return this.toDomain(docs[0] as unknown as DbCategory);
+    }
+
+    async update(id: string, data: Partial<Category> | any, tx?: unknown): Promise<Category | null> {
+        const query = CategoryModel.findByIdAndUpdate(id, data, { new: true }).lean<DbCategory | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
+        return doc ? this.toDomain(doc) : null;
+    }
+
+    async softDelete(id: string, tx?: unknown): Promise<boolean> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = CategoryModel.updateOne({ _id: id }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount > 0;
     }
 }

--- a/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
@@ -1,4 +1,4 @@
-import { Model, ModelRepositoryPort } from '../../../../domains/catalog/ports/ModelRepositoryPort';
+import { Model, ModelRepositoryPort } from '../../../../domains/catalog';
 import ModelMongoose from '../../../../models/Model';
 import { CatalogApprovalStatusValue } from '@esparex/shared';
 

--- a/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
@@ -1,0 +1,42 @@
+import { Model, ModelRepositoryPort } from '../../../../domains/catalog/ports/ModelRepositoryPort';
+import ModelMongoose from '../../../../models/Model';
+import { CatalogApprovalStatusValue } from '@esparex/shared';
+
+interface DbModel {
+    _id: unknown;
+    name: string;
+    canonicalName: string;
+    slug: string;
+    isActive: boolean;
+    isDeleted: boolean;
+    brandId: unknown;
+    categoryIds: unknown[];
+    approvalStatus: string;
+}
+
+export class MongoModelRepositoryAdapter implements ModelRepositoryPort {
+    private toDomain(doc: DbModel): Model {
+        return {
+            id: String(doc._id),
+            name: doc.name,
+            canonicalName: doc.canonicalName,
+            slug: doc.slug,
+            isActive: doc.isActive,
+            isDeleted: doc.isDeleted,
+            brandId: String(doc.brandId),
+            categoryIds: doc.categoryIds ? doc.categoryIds.map(id => String(id)) : [],
+            approvalStatus: doc.approvalStatus as CatalogApprovalStatusValue,
+        };
+    }
+
+    async findById(id: string): Promise<Model | null> {
+        const safeId = typeof id === 'string' ? id : String(id);
+        const doc = await ModelMongoose.findById(safeId).lean<DbModel | null>().exec();
+        return doc ? this.toDomain(doc) : null;
+    }
+
+    async exists(id: string): Promise<boolean> {
+        const doc = await ModelMongoose.findById(id).select('_id').lean().exec();
+        return doc !== null;
+    }
+}

--- a/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoModelRepositoryAdapter.ts
@@ -29,14 +29,83 @@ export class MongoModelRepositoryAdapter implements ModelRepositoryPort {
         };
     }
 
-    async findById(id: string): Promise<Model | null> {
+    async findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Model | null> {
         const safeId = typeof id === 'string' ? id : String(id);
-        const doc = await ModelMongoose.findById(safeId).lean<DbModel | null>().exec();
+        const query = ModelMongoose.findById(safeId).lean<DbModel | null>();
+        if (includeDeleted) query.setOptions({ withDeleted: true });
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async exists(id: string): Promise<boolean> {
-        const doc = await ModelMongoose.findById(id).select('_id').lean().exec();
+    async exists(id: string, tx?: unknown): Promise<boolean> {
+        const query = ModelMongoose.findById(id).select('_id').lean();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc !== null;
+    }
+
+    async findByCategoryOrBrands(categoryId: string, brandIds: string[], tx?: unknown): Promise<Model[]> {
+        const modelOrFilters: Array<Record<string, unknown>> = [{ categoryIds: categoryId }];
+        if (brandIds.length > 0) {
+            modelOrFilters.push({ brandId: { $in: brandIds } });
+        }
+        const query = ModelMongoose.find({ $or: modelOrFilters }).lean<DbModel[]>();
+        if (tx) query.session(tx as any);
+        const docs = await query.exec();
+        return docs.map(doc => this.toDomain(doc));
+    }
+
+    async findByBrandId(brandId: string, tx?: unknown): Promise<Model[]> {
+        const query = ModelMongoose.find({ brandId }).lean<DbModel[]>();
+        if (tx) query.session(tx as any);
+        const docs = await query.exec();
+        return docs.map(doc => this.toDomain(doc));
+    }
+
+    async create(data: Partial<Model> | any, tx?: unknown): Promise<Model> {
+        const docs = await ModelMongoose.create([data], { session: tx as any });
+        return this.toDomain(docs[0] as unknown as DbModel);
+    }
+
+    async update(id: string, data: Partial<Model> | any, tx?: unknown): Promise<Model | null> {
+        const query = ModelMongoose.findByIdAndUpdate(id, data, { new: true }).lean<DbModel | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
+        return doc ? this.toDomain(doc) : null;
+    }
+
+    async softDelete(id: string, tx?: unknown): Promise<boolean> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = ModelMongoose.findByIdAndUpdate(id, update, { new: true });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return !!res;
+    }
+
+    async softDeleteMany(modelIds: string[], tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = ModelMongoose.updateMany({ _id: { $in: modelIds } }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+
+    async softDeleteByBrandId(brandId: string, tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = ModelMongoose.updateMany({ brandId }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+
+    async updateCategoryIds(modelId: string, categoryIds: string[], tx?: unknown): Promise<boolean> {
+        const query = ModelMongoose.updateOne(
+            { _id: modelId },
+            { $set: { categoryIds: categoryIds } }
+        );
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount > 0;
     }
 }

--- a/core/src/adapters/outbound/database/catalog/MongoScreenSizeRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoScreenSizeRepositoryAdapter.ts
@@ -1,0 +1,22 @@
+import { ScreenSizeBulkDeleteCriteria, ScreenSizeRepositoryPort } from '../../../../domains/catalog';
+import ScreenSizeMongoose from '../../../../models/ScreenSize';
+
+export class MongoScreenSizeRepositoryAdapter implements ScreenSizeRepositoryPort {
+    async softDeleteByCriteria(criteria: ScreenSizeBulkDeleteCriteria, tx?: unknown): Promise<number> {
+        const { categoryId, brandIds } = criteria;
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+
+        const orFilters: Array<Record<string, unknown>> = [{ categoryId }];
+        if (brandIds && brandIds.length > 0) {
+            orFilters.push({ brandId: { $in: brandIds } });
+        }
+
+        const query = ScreenSizeMongoose.updateMany(
+            { $or: orFilters },
+            { $set: update }
+        );
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+}

--- a/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
@@ -31,14 +31,94 @@ export class MongoSparePartRepositoryAdapter implements SparePartRepositoryPort 
         };
     }
 
-    async findById(id: string): Promise<SparePart | null> {
+    async findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<SparePart | null> {
         const safeId = typeof id === 'string' ? id : String(id);
-        const doc = await SparePartMongoose.findById(safeId).lean<DbSparePart | null>().exec();
+        const query = SparePartMongoose.findById(safeId).lean<DbSparePart | null>();
+        if (includeDeleted) query.setOptions({ withDeleted: true });
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;
     }
 
-    async exists(id: string): Promise<boolean> {
-        const doc = await SparePartMongoose.findById(id).select('_id').lean().exec();
+    async exists(id: string, tx?: unknown): Promise<boolean> {
+        const query = SparePartMongoose.findById(id).select('_id').lean();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
         return doc !== null;
+    }
+
+    async findByCategoryOrBrands(categoryId: string, brandIds: string[], tx?: unknown): Promise<SparePart[]> {
+        const sparePartOrFilters: Array<Record<string, unknown>> = [{ categoryIds: categoryId }];
+        if (brandIds.length > 0) {
+            sparePartOrFilters.push({ brandId: { $in: brandIds } });
+        }
+        const query = SparePartMongoose.find({ $or: sparePartOrFilters }).lean<DbSparePart[]>();
+        if (tx) query.session(tx as any);
+        const docs = await query.exec();
+        return docs.map(doc => this.toDomain(doc));
+    }
+
+    async create(data: Partial<SparePart> | any, tx?: unknown): Promise<SparePart> {
+        const docs = await SparePartMongoose.create([data], { session: tx as any });
+        return this.toDomain(docs[0] as unknown as DbSparePart);
+    }
+
+    async update(id: string, data: Partial<SparePart> | any, tx?: unknown): Promise<SparePart | null> {
+        const query = SparePartMongoose.findByIdAndUpdate(id, data, { new: true }).lean<DbSparePart | null>();
+        if (tx) query.session(tx as any);
+        const doc = await query.exec();
+        return doc ? this.toDomain(doc) : null;
+    }
+
+    async softDelete(id: string, tx?: unknown): Promise<boolean> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = SparePartMongoose.findByIdAndUpdate(id, update, { new: true });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return !!res;
+    }
+
+    async softDeleteMany(sparePartIds: string[], tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = SparePartMongoose.updateMany({ _id: { $in: sparePartIds } }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+
+    async softDeleteByBrandId(brandId: string, tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = SparePartMongoose.updateMany({ brandId }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+
+    async softDeleteByModelIds(modelIds: string[], tx?: unknown): Promise<number> {
+        const update = { isDeleted: true, isActive: false, deletedAt: new Date() };
+        const query = SparePartMongoose.updateMany({ modelId: { $in: modelIds } }, { $set: update });
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
+    }
+
+    async updateCategoryIds(sparePartId: string, categoryIds: string[], tx?: unknown): Promise<boolean> {
+        const query = SparePartMongoose.updateOne(
+            { _id: sparePartId },
+            { $set: { categoryIds } }
+        );
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount > 0;
+    }
+
+    async clearModelReferences(modelId: string, tx?: unknown): Promise<number> {
+        const query = SparePartMongoose.updateMany(
+            { modelId },
+            { $set: { modelId: null, isActive: false } }
+        );
+        if (tx) query.session(tx as any);
+        const res = await query.exec();
+        return res.modifiedCount;
     }
 }

--- a/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
@@ -1,4 +1,4 @@
-import { SparePart, SparePartRepositoryPort } from '../../../../domains/catalog/ports/SparePartRepositoryPort';
+import { SparePart, SparePartRepositoryPort } from '../../../../domains/catalog';
 import SparePartMongoose from '../../../../models/SparePart';
 import { CatalogApprovalStatusValue } from '@esparex/shared';
 

--- a/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter.ts
@@ -1,0 +1,44 @@
+import { SparePart, SparePartRepositoryPort } from '../../../../domains/catalog/ports/SparePartRepositoryPort';
+import SparePartMongoose from '../../../../models/SparePart';
+import { CatalogApprovalStatusValue } from '@esparex/shared';
+
+interface DbSparePart {
+    _id: unknown;
+    name: string;
+    canonicalName: string;
+    slug: string;
+    isActive: boolean;
+    isDeleted: boolean;
+    categoryIds: unknown[];
+    brandId?: unknown;
+    modelId?: unknown;
+    approvalStatus: string;
+}
+
+export class MongoSparePartRepositoryAdapter implements SparePartRepositoryPort {
+    private toDomain(doc: DbSparePart): SparePart {
+        return {
+            id: String(doc._id),
+            name: doc.name,
+            canonicalName: doc.canonicalName,
+            slug: doc.slug,
+            isActive: doc.isActive,
+            isDeleted: doc.isDeleted,
+            categoryIds: doc.categoryIds ? doc.categoryIds.map(id => String(id)) : [],
+            brandId: doc.brandId ? String(doc.brandId) : undefined,
+            modelId: doc.modelId ? String(doc.modelId) : undefined,
+            approvalStatus: doc.approvalStatus as CatalogApprovalStatusValue,
+        };
+    }
+
+    async findById(id: string): Promise<SparePart | null> {
+        const safeId = typeof id === 'string' ? id : String(id);
+        const doc = await SparePartMongoose.findById(safeId).lean<DbSparePart | null>().exec();
+        return doc ? this.toDomain(doc) : null;
+    }
+
+    async exists(id: string): Promise<boolean> {
+        const doc = await SparePartMongoose.findById(id).select('_id').lean().exec();
+        return doc !== null;
+    }
+}

--- a/core/src/adapters/outbound/database/catalog/RedisCatalogCacheAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/RedisCatalogCacheAdapter.ts
@@ -1,4 +1,4 @@
-import { CatalogCachePort, InvalidateCatalogCacheOptions } from '../../../../domains/catalog/ports/CatalogCachePort';
+import { CatalogCachePort, InvalidateCatalogCacheOptions } from '../../../../domains/catalog';
 import { clearCachePattern } from '../../../../utils/redisCache';
 import logger from '../../../../utils/logger';
 

--- a/core/src/adapters/outbound/database/catalog/RedisCatalogCacheAdapter.ts
+++ b/core/src/adapters/outbound/database/catalog/RedisCatalogCacheAdapter.ts
@@ -1,0 +1,45 @@
+import { CatalogCachePort, InvalidateCatalogCacheOptions } from '../../../../domains/catalog/ports/CatalogCachePort';
+import { clearCachePattern } from '../../../../utils/redisCache';
+import logger from '../../../../utils/logger';
+
+export class RedisCatalogCacheAdapter implements CatalogCachePort {
+    async invalidateCatalogCache(opts?: InvalidateCatalogCacheOptions): Promise<void> {
+        try {
+            if (!opts || (!opts.categoryIds?.length && !opts.brandIds?.length)) {
+                await Promise.all([
+                    clearCachePattern('catalog:*'),
+                    clearCachePattern('master:*'),
+                ]);
+            } else {
+                const patterns = new Set<string>();
+                
+                if (opts.categoryIds) {
+                    opts.categoryIds.forEach(id => {
+                        patterns.add(`catalog:brands:${id}`);
+                        patterns.add(`catalog:models:*category=${id}*`);
+                        patterns.add(`catalog:spare-parts:${id}:*`);
+                    });
+                }
+                
+                if (opts.brandIds) {
+                    opts.brandIds.forEach(id => {
+                        patterns.add(`catalog:models:*brand=${id}*`);
+                    });
+                }
+
+                // ALWAYS clear "all" caches, because adding a brand/model affects the global unfiltered views
+                patterns.add('catalog:brands:all');
+                patterns.add('catalog:models:*category=all*');
+                patterns.add('catalog:spare-parts:all:*');
+                patterns.add('catalog:counts:*');
+
+                await Promise.all(Array.from(patterns).map(p => clearCachePattern(p)));
+            }
+            logger.info('Catalog cache invalidated via adapter', { opts });
+        } catch (error) {
+            logger.error('Failed to invalidate catalog cache via adapter', { 
+                error: error instanceof Error ? error.message : String(error) 
+            });
+        }
+    }
+}

--- a/core/src/adapters/outbound/database/catalog/index.ts
+++ b/core/src/adapters/outbound/database/catalog/index.ts
@@ -1,3 +1,4 @@
 export { MongoCategoryRepositoryAdapter } from './MongoCategoryRepositoryAdapter';
 export { MongoBrandRepositoryAdapter } from './MongoBrandRepositoryAdapter';
 export { MongoCatalogUnitOfWorkAdapter } from './MongoCatalogUnitOfWorkAdapter';
+export { RedisCatalogCacheAdapter } from './RedisCatalogCacheAdapter';

--- a/core/src/adapters/outbound/database/catalog/index.ts
+++ b/core/src/adapters/outbound/database/catalog/index.ts
@@ -1,2 +1,3 @@
 export { MongoCategoryRepositoryAdapter } from './MongoCategoryRepositoryAdapter';
 export { MongoBrandRepositoryAdapter } from './MongoBrandRepositoryAdapter';
+export { MongoCatalogUnitOfWorkAdapter } from './MongoCatalogUnitOfWorkAdapter';

--- a/core/src/adapters/outbound/database/catalog/index.ts
+++ b/core/src/adapters/outbound/database/catalog/index.ts
@@ -2,3 +2,6 @@ export { MongoCategoryRepositoryAdapter } from './MongoCategoryRepositoryAdapter
 export { MongoBrandRepositoryAdapter } from './MongoBrandRepositoryAdapter';
 export { MongoCatalogUnitOfWorkAdapter } from './MongoCatalogUnitOfWorkAdapter';
 export { RedisCatalogCacheAdapter } from './RedisCatalogCacheAdapter';
+
+export { MongoModelRepositoryAdapter } from './MongoModelRepositoryAdapter';
+export { MongoSparePartRepositoryAdapter } from './MongoSparePartRepositoryAdapter';

--- a/core/src/composition/catalog.ts
+++ b/core/src/composition/catalog.ts
@@ -1,10 +1,14 @@
 import { MongoCategoryRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoCategoryRepositoryAdapter';
 import { MongoBrandRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoBrandRepositoryAdapter';
+import { MongoModelRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoModelRepositoryAdapter';
+import { MongoSparePartRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter';
 import { CatalogValidationService } from '../services/catalog/CatalogValidationService';
 
 export function createCatalogValidationService(): CatalogValidationService {
     return new CatalogValidationService(
         new MongoCategoryRepositoryAdapter(),
-        new MongoBrandRepositoryAdapter()
+        new MongoBrandRepositoryAdapter(),
+        new MongoModelRepositoryAdapter(),
+        new MongoSparePartRepositoryAdapter()
     );
 }

--- a/core/src/composition/catalog.ts
+++ b/core/src/composition/catalog.ts
@@ -2,10 +2,24 @@ import { MongoCategoryRepositoryAdapter } from '../adapters/outbound/database/ca
 import { MongoBrandRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoBrandRepositoryAdapter';
 import { MongoModelRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoModelRepositoryAdapter';
 import { MongoSparePartRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter';
+import { MongoCatalogUnitOfWorkAdapter } from '../adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter';
+import { RedisCatalogCacheAdapter } from '../adapters/outbound/database/catalog/RedisCatalogCacheAdapter';
 import { CatalogValidationService } from '../services/catalog/CatalogValidationService';
+import { CatalogOrchestratorImpl } from '../services/catalog/CatalogOrchestrator';
 
 export function createCatalogValidationService(): CatalogValidationService {
     return new CatalogValidationService(
+        new MongoCategoryRepositoryAdapter(),
+        new MongoBrandRepositoryAdapter(),
+        new MongoModelRepositoryAdapter(),
+        new MongoSparePartRepositoryAdapter()
+    );
+}
+
+export function createCatalogOrchestrator(): CatalogOrchestratorImpl {
+    return new CatalogOrchestratorImpl(
+        new MongoCatalogUnitOfWorkAdapter(),
+        new RedisCatalogCacheAdapter(),
         new MongoCategoryRepositoryAdapter(),
         new MongoBrandRepositoryAdapter(),
         new MongoModelRepositoryAdapter(),

--- a/core/src/composition/catalog.ts
+++ b/core/src/composition/catalog.ts
@@ -2,6 +2,7 @@ import { MongoCategoryRepositoryAdapter } from '../adapters/outbound/database/ca
 import { MongoBrandRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoBrandRepositoryAdapter';
 import { MongoModelRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoModelRepositoryAdapter';
 import { MongoSparePartRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter';
+import { MongoScreenSizeRepositoryAdapter } from '../adapters/outbound/database/catalog/MongoScreenSizeRepositoryAdapter';
 import { MongoCatalogUnitOfWorkAdapter } from '../adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter';
 import { RedisCatalogCacheAdapter } from '../adapters/outbound/database/catalog/RedisCatalogCacheAdapter';
 import { CatalogValidationService } from '../services/catalog/CatalogValidationService';
@@ -23,6 +24,7 @@ export function createCatalogOrchestrator(): CatalogOrchestratorImpl {
         new MongoCategoryRepositoryAdapter(),
         new MongoBrandRepositoryAdapter(),
         new MongoModelRepositoryAdapter(),
-        new MongoSparePartRepositoryAdapter()
+        new MongoSparePartRepositoryAdapter(),
+        new MongoScreenSizeRepositoryAdapter()
     );
 }

--- a/core/src/domains/catalog/index.ts
+++ b/core/src/domains/catalog/index.ts
@@ -16,3 +16,4 @@ export { CatalogCachePort, InvalidateCatalogCacheOptions } from './ports/Catalog
 
 export { Model, ModelRepositoryPort } from './ports/ModelRepositoryPort';
 export { SparePart, SparePartRepositoryPort } from './ports/SparePartRepositoryPort';
+export { ScreenSize, ScreenSizeBulkDeleteCriteria, ScreenSizeRepositoryPort } from './ports/ScreenSizeRepositoryPort';

--- a/core/src/domains/catalog/index.ts
+++ b/core/src/domains/catalog/index.ts
@@ -13,3 +13,6 @@ export { Brand, BrandRepositoryPort } from './ports/BrandRepositoryPort';
 export { ListingTypeValue, ServiceSelectionMode } from '@esparex/shared';
 export { CatalogUnitOfWorkPort, TransactionContext } from './ports/CatalogUnitOfWorkPort';
 export { CatalogCachePort, InvalidateCatalogCacheOptions } from './ports/CatalogCachePort';
+
+export { Model, ModelRepositoryPort } from './ports/ModelRepositoryPort';
+export { SparePart, SparePartRepositoryPort } from './ports/SparePartRepositoryPort';

--- a/core/src/domains/catalog/index.ts
+++ b/core/src/domains/catalog/index.ts
@@ -12,3 +12,4 @@ export {
 export { Brand, BrandRepositoryPort } from './ports/BrandRepositoryPort';
 export { ListingTypeValue, ServiceSelectionMode } from '@esparex/shared';
 export { CatalogUnitOfWorkPort, TransactionContext } from './ports/CatalogUnitOfWorkPort';
+export { CatalogCachePort, InvalidateCatalogCacheOptions } from './ports/CatalogCachePort';

--- a/core/src/domains/catalog/index.ts
+++ b/core/src/domains/catalog/index.ts
@@ -11,3 +11,4 @@ export {
 } from './ports/CategoryRepositoryPort';
 export { Brand, BrandRepositoryPort } from './ports/BrandRepositoryPort';
 export { ListingTypeValue, ServiceSelectionMode } from '@esparex/shared';
+export { CatalogUnitOfWorkPort, TransactionContext } from './ports/CatalogUnitOfWorkPort';

--- a/core/src/domains/catalog/ports/BrandRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/BrandRepositoryPort.ts
@@ -11,7 +11,11 @@ export interface Brand {
 }
 
 export interface BrandRepositoryPort {
-    findById(id: string): Promise<Brand | null>;
-    findByNameAndCategory(name: string, categoryId: string): Promise<Brand | null>;
-    exists(id: string): Promise<boolean>;
+    findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Brand | null>;
+    findByNameAndCategory(name: string, categoryId: string, tx?: unknown): Promise<Brand | null>;
+    findByCategory(categoryId: string, tx?: unknown): Promise<Brand[]>;
+    exists(id: string, tx?: unknown): Promise<boolean>;
+    updateCategoryIds(brandId: string, categoryIds: string[], tx?: unknown): Promise<boolean>;
+    softDelete(brandId: string, tx?: unknown): Promise<boolean>;
+    softDeleteMany(brandIds: string[], tx?: unknown): Promise<number>;
 }

--- a/core/src/domains/catalog/ports/CatalogCachePort.ts
+++ b/core/src/domains/catalog/ports/CatalogCachePort.ts
@@ -1,0 +1,12 @@
+export interface InvalidateCatalogCacheOptions {
+    categoryIds?: string[];
+    brandIds?: string[];
+}
+
+export interface CatalogCachePort {
+    /**
+     * Invalidates the catalog caches, optionally scoped by specific categories or brands.
+     * If no options are provided, invalidates the entire catalog cache.
+     */
+    invalidateCatalogCache(opts?: InvalidateCatalogCacheOptions): Promise<void>;
+}

--- a/core/src/domains/catalog/ports/CatalogUnitOfWorkPort.ts
+++ b/core/src/domains/catalog/ports/CatalogUnitOfWorkPort.ts
@@ -1,0 +1,12 @@
+export type TransactionContext = unknown;
+
+export interface CatalogUnitOfWorkPort {
+    /**
+     * Executes the given work block atomically.
+     * If the block throws, the transaction is rolled back.
+     * 
+     * @param work Function to execute within the transaction context
+     * @returns The result of the work block
+     */
+    executeTransaction<T>(work: (context: TransactionContext) => Promise<T>): Promise<T>;
+}

--- a/core/src/domains/catalog/ports/CategoryRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/CategoryRepositoryPort.ts
@@ -27,8 +27,11 @@ export interface Category {
 }
 
 export interface CategoryRepositoryPort {
-    findById(id: string): Promise<Category | null>;
-    findBySlug(slug: string): Promise<Category | null>;
-    exists(id: string): Promise<boolean>;
-    resolveActiveCategoryIds(categoryIds?: readonly CategoryId[]): Promise<readonly CategoryId[]>;
+    findById(id: string, tx?: unknown): Promise<Category | null>;
+    findBySlug(slug: string, tx?: unknown): Promise<Category | null>;
+    exists(id: string, tx?: unknown): Promise<boolean>;
+    resolveActiveCategoryIds(categoryIds?: readonly CategoryId[], tx?: unknown): Promise<readonly CategoryId[]>;
+    create(data: Partial<Category> | any, tx?: unknown): Promise<Category>;
+    update(id: string, data: Partial<Category> | any, tx?: unknown): Promise<Category | null>;
+    softDelete(id: string, tx?: unknown): Promise<boolean>;
 }

--- a/core/src/domains/catalog/ports/ModelRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/ModelRepositoryPort.ts
@@ -1,0 +1,18 @@
+import { CatalogApprovalStatusValue } from '@esparex/shared';
+
+export interface Model {
+    readonly id: string;
+    readonly name: string;
+    readonly canonicalName: string;
+    readonly slug: string;
+    readonly isActive: boolean;
+    readonly isDeleted: boolean;
+    readonly brandId: string;
+    readonly categoryIds: readonly string[];
+    readonly approvalStatus: CatalogApprovalStatusValue;
+}
+
+export interface ModelRepositoryPort {
+    findById(id: string): Promise<Model | null>;
+    exists(id: string): Promise<boolean>;
+}

--- a/core/src/domains/catalog/ports/ModelRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/ModelRepositoryPort.ts
@@ -13,6 +13,21 @@ export interface Model {
 }
 
 export interface ModelRepositoryPort {
-    findById(id: string): Promise<Model | null>;
-    exists(id: string): Promise<boolean>;
+    // Query methods
+    findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Model | null>;
+    exists(id: string, tx?: unknown): Promise<boolean>;
+    findByCategoryOrBrands(categoryId: string, brandIds: string[], tx?: unknown): Promise<Model[]>;
+    findByBrandId(brandId: string, tx?: unknown): Promise<Model[]>;
+
+    // Mutation methods
+    create(data: Partial<Model>, tx?: unknown): Promise<Model>;
+    update(id: string, data: Partial<Model>, tx?: unknown): Promise<Model | null>;
+    softDelete(id: string, tx?: unknown): Promise<boolean>;
+
+    // Bulk methods
+    softDeleteMany(modelIds: string[], tx?: unknown): Promise<number>;
+    softDeleteByBrandId(brandId: string, tx?: unknown): Promise<number>;
+
+    // Relationship methods
+    updateCategoryIds(modelId: string, categoryIds: string[], tx?: unknown): Promise<boolean>;
 }

--- a/core/src/domains/catalog/ports/ScreenSizeRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/ScreenSizeRepositoryPort.ts
@@ -1,0 +1,25 @@
+import { CatalogApprovalStatusValue } from '@esparex/shared';
+
+export interface ScreenSize {
+    readonly id: string;
+    readonly size: string;
+    readonly name: string;
+    readonly canonicalName: string;
+    readonly slug: string;
+    readonly value: number;
+    readonly categoryId: string;
+    readonly brandId?: string;
+    readonly isActive: boolean;
+    readonly isDeleted: boolean;
+    readonly approvalStatus: CatalogApprovalStatusValue;
+}
+
+export interface ScreenSizeBulkDeleteCriteria {
+    categoryId: string;
+    brandIds?: readonly string[];
+}
+
+export interface ScreenSizeRepositoryPort {
+    // Bulk
+    softDeleteByCriteria(criteria: ScreenSizeBulkDeleteCriteria, tx?: unknown): Promise<number>;
+}

--- a/core/src/domains/catalog/ports/SparePartRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/SparePartRepositoryPort.ts
@@ -14,6 +14,22 @@ export interface SparePart {
 }
 
 export interface SparePartRepositoryPort {
-    findById(id: string): Promise<SparePart | null>;
-    exists(id: string): Promise<boolean>;
+    // Query
+    findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<SparePart | null>;
+    exists(id: string, tx?: unknown): Promise<boolean>;
+    findByCategoryOrBrands(categoryId: string, brandIds: string[], tx?: unknown): Promise<SparePart[]>;
+
+    // Mutation
+    create(data: Partial<SparePart>, tx?: unknown): Promise<SparePart>;
+    update(id: string, data: Partial<SparePart>, tx?: unknown): Promise<SparePart | null>;
+    softDelete(id: string, tx?: unknown): Promise<boolean>;
+
+    // Bulk
+    softDeleteMany(sparePartIds: string[], tx?: unknown): Promise<number>;
+    softDeleteByBrandId(brandId: string, tx?: unknown): Promise<number>;
+    softDeleteByModelIds(modelIds: string[], tx?: unknown): Promise<number>;
+
+    // Relationship
+    updateCategoryIds(sparePartId: string, categoryIds: string[], tx?: unknown): Promise<boolean>;
+    clearModelReferences(modelId: string, tx?: unknown): Promise<number>;
 }

--- a/core/src/domains/catalog/ports/SparePartRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/SparePartRepositoryPort.ts
@@ -1,0 +1,19 @@
+import { CatalogApprovalStatusValue } from '@esparex/shared';
+
+export interface SparePart {
+    readonly id: string;
+    readonly name: string;
+    readonly canonicalName: string;
+    readonly slug: string;
+    readonly isActive: boolean;
+    readonly isDeleted: boolean;
+    readonly categoryIds: readonly string[];
+    readonly brandId?: string;
+    readonly modelId?: string;
+    readonly approvalStatus: CatalogApprovalStatusValue;
+}
+
+export interface SparePartRepositoryPort {
+    findById(id: string): Promise<SparePart | null>;
+    exists(id: string): Promise<boolean>;
+}

--- a/core/src/services/catalog/CatalogCategoryService.ts
+++ b/core/src/services/catalog/CatalogCategoryService.ts
@@ -4,7 +4,7 @@
  * Also owns the multi-model entity count query used by the admin dashboard.
  */
 
-import mongoose, { type ClientSession, type Model as MongooseModel } from 'mongoose';
+import mongoose, { type Model as MongooseModel } from 'mongoose';
 import Category from '../../models/Category';
 import Brand from '../../models/Brand';
 import CatalogModel from '../../models/Model';
@@ -83,15 +83,3 @@ export const updateCategorySchemaById = async (id: string | undefined, filters: 
     if (!id) return null;
     return Category.findByIdAndUpdate(id, { filters }, { new: true, runValidators: true });
 };
-
-export const findCategoryByIdWithSession = async (id: string | undefined, session: ClientSession) => {
-    if (!id) return null;
-    return Category.findById(id).session(session);
-};
-
-export const softDeleteCategoryById = async (id: string | { toString(): string }, session: ClientSession) =>
-    Category.updateOne(
-        { _id: new mongoose.Types.ObjectId(id.toString()) },
-        { $set: { isDeleted: true, isActive: false, deletedAt: new Date() } },
-        { session }
-    );

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -5,7 +5,6 @@ import { Category, Brand } from '../../domains/catalog';
 export type CategoryResult = Category & Record<string, unknown>;
 export type BrandResult = Brand & Record<string, unknown>;
 
-import Model from '../../models/Model';
 import SparePart from '../../models/SparePart';
 import ScreenSize from '../../models/ScreenSize';
 import { clearCachePattern } from '../../utils/redisCache';
@@ -148,38 +147,29 @@ export class CatalogOrchestratorImpl {
             modelOrFilters.push({ brandId: { $in: brandIdsToDelete } });
         }
 
-        const affectedModels = await Model.find({ $or: modelOrFilters })
-            .select('_id brandId categoryIds')
-            .session(txSession as any)
-            .lean<CascadeDoc[]>();
+        const affectedModels = await this.modelRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete.map(id => String(id)), txSession);
 
         const modelIdsToDelete: mongoose.Types.ObjectId[] = [];
         const deletedBrandIdSet = new Set(brandIdsToDelete.map((id) => String(id)));
 
         for (const model of affectedModels) {
             if (model.brandId && deletedBrandIdSet.has(String(model.brandId))) {
-                modelIdsToDelete.push(model._id);
+                modelIdsToDelete.push(new mongoose.Types.ObjectId(model.id));
                 continue;
             }
 
-            const remainingCategoryIds = toUniqueCategoryObjectIds(model.categoryIds, categoryId);
+            const remainingCategoryIds = toUniqueCategoryObjectIds(model.categoryIds as any, categoryId);
             
             if (remainingCategoryIds.length === 0) {
-                modelIdsToDelete.push(model._id);
+                modelIdsToDelete.push(new mongoose.Types.ObjectId(model.id));
                 continue;
             }
 
-            await Model.updateOne(
-                { _id: model._id },
-                { $set: { categoryIds: remainingCategoryIds } }
-            ).session(txSession as any);
+            await this.modelRepository.updateCategoryIds(model.id, remainingCategoryIds.map(id => String(id)), txSession);
         }
 
         if (modelIdsToDelete.length > 0) {
-            await Model.updateMany(
-                { _id: { $in: modelIdsToDelete } },
-                { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession as any);
+            await this.modelRepository.softDeleteMany(modelIdsToDelete.map(id => String(id)), txSession);
         }
 
         // 3) SpareParts: detach category when possible; soft-delete only if no category remains
@@ -246,17 +236,11 @@ export class CatalogOrchestratorImpl {
         const now = new Date();
 
         // Find all models associated with this brand
-        const models = await Model.find({ brandId })
-            .select('_id')
-            .session(txSession as any)
-            .lean<CascadeDoc[]>();
-        const modelIds = models.map((m) => m._id);
+        const models = await this.modelRepository.findByBrandId(brandId, txSession);
+        const modelIds = models.map((m) => new mongoose.Types.ObjectId(m.id));
 
         // Soft-delete those Models
-        const modelRes = await Model.updateMany(
-            { brandId },
-            { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession as any);
+        const deletedModels = await this.modelRepository.softDeleteByBrandId(brandId, txSession);
 
         let deletedSpareParts = 0;
         // Soft-delete SpareParts linked to those models
@@ -279,7 +263,7 @@ export class CatalogOrchestratorImpl {
         logger.info(`Cascaded soft-delete for brand: ${brandId}`);
 
         return {
-            deletedModels: modelRes.modifiedCount || 0,
+            deletedModels,
             deletedSpareParts
         };
     }

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -1,4 +1,3 @@
-import mongoose from 'mongoose';
 import { Category, Brand } from '../../domains/catalog';
 
 // @todo ARCH-118: Transitional types until all consumers are migrated to strict domain models.
@@ -6,7 +5,6 @@ export type CategoryResult = Category & Record<string, unknown>;
 export type BrandResult = Brand & Record<string, unknown>;
 
 
-import { clearCachePattern } from '../../utils/redisCache';
 import logger from '../../utils/logger';
 import { isDuplicateKeyError } from '../../utils/errorHelpers';
 import { AppError } from '../../utils/AppError';
@@ -21,28 +19,20 @@ import {
     ScreenSizeRepositoryPort
 } from '../../domains/catalog';
 
-type CascadeDoc = {
-    _id: mongoose.Types.ObjectId;
-    categoryIds?: mongoose.Types.ObjectId[];
-    brandId?: mongoose.Types.ObjectId;
-};
-
 // isDuplicateKeyError imported from errorHelpers (SSOT)
 
-const toUniqueCategoryObjectIds = (
-    categoryIds: mongoose.Types.ObjectId[] | undefined,
+const toUniqueCategoryIds = (
+    categoryIds: readonly string[] | undefined,
     deletedCategoryId: string
-): mongoose.Types.ObjectId[] => {
+): string[] => {
     if (!Array.isArray(categoryIds) || categoryIds.length === 0) return [];
-    const deduped = new Map<string, mongoose.Types.ObjectId>();
-    for (const categoryObjectId of categoryIds) {
-        const id = String(categoryObjectId);
+    const deduped = new Set<string>();
+    for (const categoryId of categoryIds) {
+        const id = String(categoryId);
         if (id === deletedCategoryId) continue;
-        if (!deduped.has(id)) {
-            deduped.set(id, new mongoose.Types.ObjectId(id));
-        }
+        deduped.add(id);
     }
-    return Array.from(deduped.values());
+    return Array.from(deduped);
 };
 
 /**
@@ -64,46 +54,12 @@ export class CatalogOrchestratorImpl {
     /**
      * Invalidate catalog caches, optionally scoped by category or brand
      */
-    async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
-        try {
-            if (!opts || (!opts.categoryIds?.length && !opts.brandIds?.length)) {
-                await Promise.all([
-                    clearCachePattern('catalog:*'),
-                    clearCachePattern('master:*'),
-                ]);
-            } else {
-                const patterns = new Set<string>();
-                
-                if (opts.categoryIds) {
-                    opts.categoryIds.forEach(id => {
-                        const idStr = id.toString();
-                        patterns.add(`catalog:brands:${idStr}`);
-                        patterns.add(`catalog:models:*category=${idStr}*`);
-                        patterns.add(`catalog:spare-parts:${idStr}:*`);
-                    });
-                }
-                
-                if (opts.brandIds) {
-                    opts.brandIds.forEach(id => {
-                        const idStr = id.toString();
-                        patterns.add(`catalog:models:*brand=${idStr}*`);
-                    });
-                }
-
-                // ALWAYS clear "all" caches, because adding a brand/model affects the global unfiltered views
-                patterns.add('catalog:brands:all');
-                patterns.add('catalog:models:*category=all*');
-                patterns.add('catalog:spare-parts:all:*');
-                patterns.add('catalog:counts:*');
-
-                await Promise.all(Array.from(patterns).map(p => clearCachePattern(p)));
-            }
-            logger.info('Catalog cache invalidated', { opts });
-        } catch (error) {
-            logger.error('Failed to invalidate catalog cache', { 
-                error: error instanceof Error ? error.message : String(error) 
-            });
-        }
+    async invalidateCatalogCache(opts?: { categoryIds?: any[], brandIds?: any[] }) {
+        const cleanOpts = opts ? {
+            categoryIds: opts.categoryIds ? opts.categoryIds.map(id => String(id)) : undefined,
+            brandIds: opts.brandIds ? opts.brandIds.map(id => String(id)) : undefined
+        } : undefined;
+        await this.cacheService.invalidateCatalogCache(cleanOpts);
     }
 
     /**
@@ -111,26 +67,24 @@ export class CatalogOrchestratorImpl {
      */
     async cascadeCategoryDelete(categoryId: string, session?: TransactionContext) {
         const txSession = session || null;
-        const now = new Date();
-        const categoryObjectId = new mongoose.Types.ObjectId(categoryId);
-        const brandIdsToDelete: mongoose.Types.ObjectId[] = [];
+        const brandIdsToDelete: string[] = [];
 
         // 1) Brands: detach deleted category when other categories exist; soft-delete only true orphans.
         const linkedBrands = await this.brandRepository.findByCategory(categoryId, txSession);
 
         for (const brand of linkedBrands) {
-            const remainingCategoryIds = toUniqueCategoryObjectIds(brand.categoryIds as any, categoryId);
+            const remainingCategoryIds = toUniqueCategoryIds(brand.categoryIds, categoryId);
             if (remainingCategoryIds.length === 0) {
-                brandIdsToDelete.push(new mongoose.Types.ObjectId(brand.id));
+                brandIdsToDelete.push(brand.id);
                 continue;
             }
 
             try {
-                await this.brandRepository.updateCategoryIds(brand.id, remainingCategoryIds.map(id => String(id)), txSession);
+                await this.brandRepository.updateCategoryIds(brand.id, remainingCategoryIds, txSession);
             } catch (error) {
                 // Keep uniqueness intact; if remap collides, safely archive this duplicate branch.
                 if (isDuplicateKeyError(error)) {
-                    brandIdsToDelete.push(new mongoose.Types.ObjectId(brand.id));
+                    brandIdsToDelete.push(brand.id);
                     continue;
                 }
                 throw error;
@@ -138,68 +92,63 @@ export class CatalogOrchestratorImpl {
         }
 
         if (brandIdsToDelete.length > 0) {
-            await this.brandRepository.softDeleteMany(brandIdsToDelete.map(id => String(id)), txSession);
+            await this.brandRepository.softDeleteMany(brandIdsToDelete, txSession);
         }
 
         // 2) Models: never delete by brand sweep unless brand is actually archived.
         //    Prefer detaching deleted category; soft-delete only if model becomes orphaned.
-        const modelOrFilters: Array<Record<string, unknown>> = [{ categoryIds: categoryObjectId }];
-        if (brandIdsToDelete.length > 0) {
-            modelOrFilters.push({ brandId: { $in: brandIdsToDelete } });
-        }
+        const affectedModels = await this.modelRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete, txSession);
 
-        const affectedModels = await this.modelRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete.map(id => String(id)), txSession);
-
-        const modelIdsToDelete: mongoose.Types.ObjectId[] = [];
-        const deletedBrandIdSet = new Set(brandIdsToDelete.map((id) => String(id)));
+        const modelIdsToDelete: string[] = [];
+        const deletedBrandIdSet = new Set(brandIdsToDelete);
 
         for (const model of affectedModels) {
-            if (model.brandId && deletedBrandIdSet.has(String(model.brandId))) {
-                modelIdsToDelete.push(new mongoose.Types.ObjectId(model.id));
+            if (model.brandId && deletedBrandIdSet.has(model.brandId)) {
+                modelIdsToDelete.push(model.id);
                 continue;
             }
 
-            const remainingCategoryIds = toUniqueCategoryObjectIds(model.categoryIds as any, categoryId);
+            const remainingCategoryIds = toUniqueCategoryIds(model.categoryIds, categoryId);
             
             if (remainingCategoryIds.length === 0) {
-                modelIdsToDelete.push(new mongoose.Types.ObjectId(model.id));
+                modelIdsToDelete.push(model.id);
                 continue;
             }
 
-            await this.modelRepository.updateCategoryIds(model.id, remainingCategoryIds.map(id => String(id)), txSession);
+            await this.modelRepository.updateCategoryIds(model.id, remainingCategoryIds, txSession);
         }
 
         if (modelIdsToDelete.length > 0) {
-            await this.modelRepository.softDeleteMany(modelIdsToDelete.map(id => String(id)), txSession);
+            await this.modelRepository.softDeleteMany(modelIdsToDelete, txSession);
         }
 
         // 3) SpareParts: detach category when possible; soft-delete only if no category remains
         //    or if parent brand is archived by this cascade.
-        const affectedSpareParts = await this.sparePartRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete.map(id => String(id)), txSession);
+        const affectedSpareParts = await this.sparePartRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete, txSession);
 
-        const sparePartIdsToDelete: mongoose.Types.ObjectId[] = [];
+        const sparePartIdsToDelete: string[] = [];
         for (const sparePart of affectedSpareParts) {
-            if (sparePart.brandId && deletedBrandIdSet.has(String(sparePart.brandId))) {
-                sparePartIdsToDelete.push(new mongoose.Types.ObjectId(sparePart.id));
+            if (sparePart.brandId && deletedBrandIdSet.has(sparePart.brandId)) {
+                sparePartIdsToDelete.push(sparePart.id);
                 continue;
             }
 
-            const remainingCategoryIds = toUniqueCategoryObjectIds(sparePart.categoryIds as any, categoryId);
+            const remainingCategoryIds = toUniqueCategoryIds(sparePart.categoryIds, categoryId);
             if (remainingCategoryIds.length === 0) {
-                sparePartIdsToDelete.push(new mongoose.Types.ObjectId(sparePart.id));
+                sparePartIdsToDelete.push(sparePart.id);
                 continue;
             }
 
-            await this.sparePartRepository.updateCategoryIds(sparePart.id, remainingCategoryIds.map(id => String(id)), txSession);
+            await this.sparePartRepository.updateCategoryIds(sparePart.id, remainingCategoryIds, txSession);
         }
 
         if (sparePartIdsToDelete.length > 0) {
-            await this.sparePartRepository.softDeleteMany(sparePartIdsToDelete.map(id => String(id)), txSession);
+            await this.sparePartRepository.softDeleteMany(sparePartIdsToDelete, txSession);
         }
 
         // 4) ScreenSizes: singular category link; keep cascading delete.
         await this.screenSizeRepository.softDeleteByCriteria(
-            { categoryId, brandIds: brandIdsToDelete.map(id => String(id)) },
+            { categoryId, brandIds: brandIdsToDelete },
             txSession
         );
 
@@ -217,11 +166,10 @@ export class CatalogOrchestratorImpl {
      */
     async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         const txSession = session || null;
-        const now = new Date();
 
         // Find all models associated with this brand
         const models = await this.modelRepository.findByBrandId(brandId, txSession);
-        const modelIds = models.map((m) => new mongoose.Types.ObjectId(m.id));
+        const modelIds = models.map((m) => m.id);
 
         // Soft-delete those Models
         const deletedModels = await this.modelRepository.softDeleteByBrandId(brandId, txSession);
@@ -229,7 +177,7 @@ export class CatalogOrchestratorImpl {
         let deletedSpareParts = 0;
         // Soft-delete SpareParts linked to those models
         if (modelIds.length > 0) {
-            const count1 = await this.sparePartRepository.softDeleteByModelIds(modelIds.map(id => String(id)), txSession);
+            const count1 = await this.sparePartRepository.softDeleteByModelIds(modelIds, txSession);
             deletedSpareParts += count1;
         }
 
@@ -363,7 +311,7 @@ function getServiceInstance(): CatalogOrchestratorImpl {
 export class CatalogOrchestrator {
     private static get instance() { return getServiceInstance(); }
 
-    static async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
+    static async invalidateCatalogCache(opts?: { categoryIds?: any[], brandIds?: any[] }) {
         return this.instance.invalidateCatalogCache(opts);
     }
     static async cascadeCategoryDelete(categoryId: string, session?: TransactionContext) {

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -197,7 +197,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Create Category with cache invalidation
      */
-    async createCategory(data: CategoryResult): Promise<CategoryResult> {
+    async createCategory(data: any): Promise<CategoryResult> {
         const result = await this.categoryRepository.create(data);
         await this.invalidateCatalogCache({ categoryIds: [result.id] });
         return result as CategoryResult;
@@ -206,7 +206,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Update Category with cache invalidation
      */
-    async updateCategory(id: string, data: CategoryResult): Promise<CategoryResult | null> {
+    async updateCategory(id: string, data: any): Promise<CategoryResult | null> {
         const result = await this.categoryRepository.update(id, data);
         if (result) await this.invalidateCatalogCache({ categoryIds: [id] });
         return result as CategoryResult;
@@ -320,10 +320,10 @@ export class CatalogOrchestrator {
     static async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         return this.instance.cascadeBrandDelete(brandId, session);
     }
-    static async createCategory(data: CategoryResult): Promise<CategoryResult> {
+    static async createCategory(data: any): Promise<CategoryResult> {
         return this.instance.createCategory(data);
     }
-    static async updateCategory(id: string, data: CategoryResult): Promise<CategoryResult | null> {
+    static async updateCategory(id: string, data: any): Promise<CategoryResult | null> {
         return this.instance.updateCategory(id, data);
     }
     static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -5,7 +5,7 @@ import { Category, Brand } from '../../domains/catalog';
 export type CategoryResult = Category & Record<string, unknown>;
 export type BrandResult = Brand & Record<string, unknown>;
 
-import ScreenSize from '../../models/ScreenSize';
+
 import { clearCachePattern } from '../../utils/redisCache';
 import logger from '../../utils/logger';
 import { isDuplicateKeyError } from '../../utils/errorHelpers';
@@ -17,7 +17,8 @@ import {
     CategoryRepositoryPort, 
     BrandRepositoryPort, 
     ModelRepositoryPort, 
-    SparePartRepositoryPort 
+    SparePartRepositoryPort,
+    ScreenSizeRepositoryPort
 } from '../../domains/catalog';
 
 type CascadeDoc = {
@@ -57,7 +58,8 @@ export class CatalogOrchestratorImpl {
         private readonly categoryRepository: CategoryRepositoryPort,
         private readonly brandRepository: BrandRepositoryPort,
         private readonly modelRepository: ModelRepositoryPort,
-        private readonly sparePartRepository: SparePartRepositoryPort
+        private readonly sparePartRepository: SparePartRepositoryPort,
+        private readonly screenSizeRepository: ScreenSizeRepositoryPort
     ) {}
     /**
      * Invalidate catalog caches, optionally scoped by category or brand
@@ -196,13 +198,10 @@ export class CatalogOrchestratorImpl {
         }
 
         // 4) ScreenSizes: singular category link; keep cascading delete.
-        const screenSizeFilter = brandIdsToDelete.length > 0
-            ? { $or: [{ categoryId: categoryObjectId }, { brandId: { $in: brandIdsToDelete } }] }
-            : { categoryId: categoryObjectId };
-        await ScreenSize.updateMany(
-            screenSizeFilter,
-            { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession as any);
+        await this.screenSizeRepository.softDeleteByCriteria(
+            { categoryId, brandIds: brandIdsToDelete.map(id => String(id)) },
+            txSession
+        );
 
         await this.invalidateCatalogCache({ categoryIds: [categoryId], brandIds: brandIdsToDelete });
         logger.info('Cascaded category delete completed', {
@@ -346,13 +345,16 @@ function getServiceInstance(): CatalogOrchestratorImpl {
         const { MongoModelRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoModelRepositoryAdapter');
         const { MongoSparePartRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter');
 
+        const { MongoScreenSizeRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoScreenSizeRepositoryAdapter');
+
         serviceInstance = new CatalogOrchestratorImpl(
             new MongoCatalogUnitOfWorkAdapter(),
             new RedisCatalogCacheAdapter(),
             new MongoCategoryRepositoryAdapter(),
             new MongoBrandRepositoryAdapter(),
             new MongoModelRepositoryAdapter(),
-            new MongoSparePartRepositoryAdapter()
+            new MongoSparePartRepositoryAdapter(),
+            new MongoScreenSizeRepositoryAdapter()
         );
     }
     return serviceInstance;

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -1,5 +1,10 @@
 import mongoose from 'mongoose';
-import Brand from '../../models/Brand';
+import { Category, Brand } from '../../domains/catalog';
+
+// @todo ARCH-118: Transitional types until all consumers are migrated to strict domain models.
+export type CategoryResult = Category & Record<string, unknown>;
+export type BrandResult = Brand & Record<string, unknown>;
+
 import Model from '../../models/Model';
 import SparePart from '../../models/SparePart';
 import ScreenSize from '../../models/ScreenSize';
@@ -111,27 +116,21 @@ export class CatalogOrchestratorImpl {
         const brandIdsToDelete: mongoose.Types.ObjectId[] = [];
 
         // 1) Brands: detach deleted category when other categories exist; soft-delete only true orphans.
-        const linkedBrands = await Brand.find({ categoryIds: categoryObjectId })
-            .select('_id categoryIds')
-            .session(txSession as any)
-            .lean<CascadeDoc[]>();
+        const linkedBrands = await this.brandRepository.findByCategory(categoryId, txSession);
 
         for (const brand of linkedBrands) {
-            const remainingCategoryIds = toUniqueCategoryObjectIds(brand.categoryIds, categoryId);
+            const remainingCategoryIds = toUniqueCategoryObjectIds(brand.categoryIds as any, categoryId);
             if (remainingCategoryIds.length === 0) {
-                brandIdsToDelete.push(brand._id);
+                brandIdsToDelete.push(new mongoose.Types.ObjectId(brand.id));
                 continue;
             }
 
             try {
-                await Brand.updateOne(
-                    { _id: brand._id },
-                    { $set: { categoryIds: remainingCategoryIds } }
-                ).session(txSession as any);
+                await this.brandRepository.updateCategoryIds(brand.id, remainingCategoryIds.map(id => String(id)), txSession);
             } catch (error) {
                 // Keep uniqueness intact; if remap collides, safely archive this duplicate branch.
                 if (isDuplicateKeyError(error)) {
-                    brandIdsToDelete.push(brand._id);
+                    brandIdsToDelete.push(new mongoose.Types.ObjectId(brand.id));
                     continue;
                 }
                 throw error;
@@ -139,10 +138,7 @@ export class CatalogOrchestratorImpl {
         }
 
         if (brandIdsToDelete.length > 0) {
-            await Brand.updateMany(
-                { _id: { $in: brandIdsToDelete } },
-                { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession as any);
+            await this.brandRepository.softDeleteMany(brandIdsToDelete.map(id => String(id)), txSession);
         }
 
         // 2) Models: never delete by brand sweep unless brand is actually archived.
@@ -291,19 +287,19 @@ export class CatalogOrchestratorImpl {
     /**
      * Create Category with cache invalidation
      */
-    async createCategory(data: any): Promise<any> {
+    async createCategory(data: CategoryResult): Promise<CategoryResult> {
         const result = await this.categoryRepository.create(data);
         await this.invalidateCatalogCache({ categoryIds: [result.id] });
-        return result;
+        return result as CategoryResult;
     }
 
     /**
      * Update Category with cache invalidation
      */
-    async updateCategory(id: string, data: any): Promise<any | null> {
+    async updateCategory(id: string, data: CategoryResult): Promise<CategoryResult | null> {
         const result = await this.categoryRepository.update(id, data);
         if (result) await this.invalidateCatalogCache({ categoryIds: [id] });
-        return result;
+        return result as CategoryResult;
     }
 
 
@@ -311,9 +307,9 @@ export class CatalogOrchestratorImpl {
      * Resolve all CategoryIDs from a BrandID
      */
     async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {
-        const brand = await Brand.findById(brandId).select('categoryIds').lean();
+        const brand = await this.brandRepository.findById(brandId);
         if (!brand || !brand.categoryIds) return [];
-        return brand.categoryIds.map(id => id.toString());
+        return brand.categoryIds.map(id => String(id));
     }
 
     /**
@@ -336,7 +332,7 @@ export class CatalogOrchestratorImpl {
         logger.info(`Detached spare parts from model: ${modelId}`);
     }
 
-    async deleteCategoryOrchestrated(categoryId: string): Promise<any> {
+    async deleteCategoryOrchestrated(categoryId: string): Promise<CategoryResult> {
         return this.unitOfWork.executeTransaction(async (txSession) => {
             const category = await this.categoryRepository.findById(categoryId, txSession);
 
@@ -347,15 +343,12 @@ export class CatalogOrchestratorImpl {
             await this.categoryRepository.softDelete(categoryId, txSession);
             await this.cascadeCategoryDelete(categoryId, txSession);
 
-            return await this.categoryRepository.findById(categoryId, txSession);
+            return await this.categoryRepository.findById(categoryId, txSession) as CategoryResult;
         });
     }
 
     async deleteBrandOrchestrated(brandId: string) {
-        const BrandModel = require('../../models/Brand').default;
-        const softDeleteUpdate: Record<string, unknown> = { isDeleted: true, deletedAt: new Date(), isActive: false };
-
-        const existingBrand = await BrandModel.findOne({ _id: brandId }).setOptions({ withDeleted: true });
+        const existingBrand = await this.brandRepository.findById(brandId, true);
         if (!existingBrand || existingBrand.isDeleted) {
             return { brandId, deletedModels: 0, deletedSpareParts: 0, alreadyDeleted: true };
         }
@@ -368,8 +361,8 @@ export class CatalogOrchestratorImpl {
 
         return this.unitOfWork.executeTransaction(async (txSession) => {
             const brand = txSession 
-                ? await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true }).session(txSession as any) 
-                : await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true });
+                ? await this.brandRepository.softDelete(brandId, txSession)
+                : await this.brandRepository.softDelete(brandId);
 
             if (!brand) return { deletedModels: 0, deletedSpareParts: 0, brand: null };
             const cascadeRes = await this.cascadeBrandDelete(brandId, txSession ?? undefined);
@@ -417,10 +410,10 @@ export class CatalogOrchestrator {
     static async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         return this.instance.cascadeBrandDelete(brandId, session);
     }
-    static async createCategory(data: any): Promise<any> {
+    static async createCategory(data: CategoryResult): Promise<CategoryResult> {
         return this.instance.createCategory(data);
     }
-    static async updateCategory(id: string, data: any): Promise<any | null> {
+    static async updateCategory(id: string, data: CategoryResult): Promise<CategoryResult | null> {
         return this.instance.updateCategory(id, data);
     }
     static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -1,5 +1,4 @@
 import mongoose from 'mongoose';
-import Category, { ICategory } from '../../models/Category';
 import Brand from '../../models/Brand';
 import Model from '../../models/Model';
 import SparePart from '../../models/SparePart';
@@ -114,7 +113,7 @@ export class CatalogOrchestratorImpl {
         // 1) Brands: detach deleted category when other categories exist; soft-delete only true orphans.
         const linkedBrands = await Brand.find({ categoryIds: categoryObjectId })
             .select('_id categoryIds')
-            .session(txSession)
+            .session(txSession as any)
             .lean<CascadeDoc[]>();
 
         for (const brand of linkedBrands) {
@@ -128,7 +127,7 @@ export class CatalogOrchestratorImpl {
                 await Brand.updateOne(
                     { _id: brand._id },
                     { $set: { categoryIds: remainingCategoryIds } }
-                ).session(txSession);
+                ).session(txSession as any);
             } catch (error) {
                 // Keep uniqueness intact; if remap collides, safely archive this duplicate branch.
                 if (isDuplicateKeyError(error)) {
@@ -143,7 +142,7 @@ export class CatalogOrchestratorImpl {
             await Brand.updateMany(
                 { _id: { $in: brandIdsToDelete } },
                 { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession);
+            ).session(txSession as any);
         }
 
         // 2) Models: never delete by brand sweep unless brand is actually archived.
@@ -155,7 +154,7 @@ export class CatalogOrchestratorImpl {
 
         const affectedModels = await Model.find({ $or: modelOrFilters })
             .select('_id brandId categoryIds')
-            .session(txSession)
+            .session(txSession as any)
             .lean<CascadeDoc[]>();
 
         const modelIdsToDelete: mongoose.Types.ObjectId[] = [];
@@ -177,14 +176,14 @@ export class CatalogOrchestratorImpl {
             await Model.updateOne(
                 { _id: model._id },
                 { $set: { categoryIds: remainingCategoryIds } }
-            ).session(txSession);
+            ).session(txSession as any);
         }
 
         if (modelIdsToDelete.length > 0) {
             await Model.updateMany(
                 { _id: { $in: modelIdsToDelete } },
                 { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession);
+            ).session(txSession as any);
         }
 
         // 3) SpareParts: detach category when possible; soft-delete only if no category remains
@@ -196,7 +195,7 @@ export class CatalogOrchestratorImpl {
 
         const affectedSpareParts = await SparePart.find({ $or: sparePartOrFilters })
             .select('_id brandId categoryIds')
-            .session(txSession)
+            .session(txSession as any)
             .lean<CascadeDoc[]>();
 
         const sparePartIdsToDelete: mongoose.Types.ObjectId[] = [];
@@ -215,14 +214,14 @@ export class CatalogOrchestratorImpl {
             await SparePart.updateOne(
                 { _id: sparePart._id },
                 { $set: { categoryIds: remainingCategoryIds } }
-            ).session(txSession);
+            ).session(txSession as any);
         }
 
         if (sparePartIdsToDelete.length > 0) {
             await SparePart.updateMany(
                 { _id: { $in: sparePartIdsToDelete } },
                 { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession);
+            ).session(txSession as any);
         }
 
         // 4) ScreenSizes: singular category link; keep cascading delete.
@@ -232,7 +231,7 @@ export class CatalogOrchestratorImpl {
         await ScreenSize.updateMany(
             screenSizeFilter,
             { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession);
+        ).session(txSession as any);
 
         await this.invalidateCatalogCache({ categoryIds: [categoryId], brandIds: brandIdsToDelete });
         logger.info('Cascaded category delete completed', {
@@ -253,7 +252,7 @@ export class CatalogOrchestratorImpl {
         // Find all models associated with this brand
         const models = await Model.find({ brandId })
             .select('_id')
-            .session(txSession)
+            .session(txSession as any)
             .lean<CascadeDoc[]>();
         const modelIds = models.map((m) => m._id);
 
@@ -261,7 +260,7 @@ export class CatalogOrchestratorImpl {
         const modelRes = await Model.updateMany(
             { brandId },
             { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession);
+        ).session(txSession as any);
 
         let deletedSpareParts = 0;
         // Soft-delete SpareParts linked to those models
@@ -269,7 +268,7 @@ export class CatalogOrchestratorImpl {
             const spRes1 = await SparePart.updateMany(
                 { modelId: { $in: modelIds } },
                 { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession);
+            ).session(txSession as any);
             deletedSpareParts += spRes1.modifiedCount || 0;
         }
 
@@ -277,7 +276,7 @@ export class CatalogOrchestratorImpl {
         const spRes2 = await SparePart.updateMany(
             { brandId },
             { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession);
+        ).session(txSession as any);
         deletedSpareParts += spRes2.modifiedCount || 0;
 
         await this.invalidateCatalogCache({ brandIds: [brandId] });
@@ -292,18 +291,17 @@ export class CatalogOrchestratorImpl {
     /**
      * Create Category with cache invalidation
      */
-    async createCategory(data: Partial<ICategory>): Promise<ICategory> {
-        const category = new Category(data);
-        const result = await category.save();
-        await this.invalidateCatalogCache({ categoryIds: [category._id] });
+    async createCategory(data: any): Promise<any> {
+        const result = await this.categoryRepository.create(data);
+        await this.invalidateCatalogCache({ categoryIds: [result.id] });
         return result;
     }
 
     /**
      * Update Category with cache invalidation
      */
-    async updateCategory(id: string, data: Partial<ICategory>): Promise<ICategory | null> {
-        const result = await Category.findByIdAndUpdate(id, data, { new: true });
+    async updateCategory(id: string, data: any): Promise<any | null> {
+        const result = await this.categoryRepository.update(id, data);
         if (result) await this.invalidateCatalogCache({ categoryIds: [id] });
         return result;
     }
@@ -329,40 +327,27 @@ export class CatalogOrchestratorImpl {
     /**
      * Detach SpareParts from a specific Model
      */
-    async detachSparePartsFromModel(modelId: string, session?: ClientSession) {
+    async detachSparePartsFromModel(modelId: string, session?: TransactionContext) {
         await SparePart.updateMany(
             { modelId },
             { $set: { modelId: null, isActive: false } }
-        ).session(session || null);
+        ).session(session as any || null);
         
         logger.info(`Detached spare parts from model: ${modelId}`);
     }
 
-    async deleteCategoryOrchestrated(categoryId: string) {
+    async deleteCategoryOrchestrated(categoryId: string): Promise<any> {
         return this.unitOfWork.executeTransaction(async (txSession) => {
-            const CategoryModel = require('../../models/Category').default;
-            const category = txSession 
-                ? await CategoryModel.findById(categoryId).session(txSession as any)
-                : await CategoryModel.findById(categoryId);
+            const category = await this.categoryRepository.findById(categoryId, txSession);
 
             if (!category) {
                 throw new AppError('Category not found', 404, 'CATEGORY_NOT_FOUND');
             }
 
-            if (txSession) {
-                category.isDeleted = true;
-                category.deletedAt = new Date();
-                category.isActive = false;
-                await category.save({ session: txSession as any });
-                await this.cascadeCategoryDelete(String(category._id), txSession);
-            } else {
-                category.isDeleted = true;
-                category.deletedAt = new Date();
-                category.isActive = false;
-                await category.save();
-                await this.cascadeCategoryDelete(String(category._id));
-            }
-            return category;
+            await this.categoryRepository.softDelete(categoryId, txSession);
+            await this.cascadeCategoryDelete(categoryId, txSession);
+
+            return await this.categoryRepository.findById(categoryId, txSession);
         });
     }
 
@@ -432,10 +417,10 @@ export class CatalogOrchestrator {
     static async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         return this.instance.cascadeBrandDelete(brandId, session);
     }
-    static async createCategory(data: Partial<ICategory>): Promise<ICategory> {
+    static async createCategory(data: any): Promise<any> {
         return this.instance.createCategory(data);
     }
-    static async updateCategory(id: string, data: Partial<ICategory>): Promise<ICategory | null> {
+    static async updateCategory(id: string, data: any): Promise<any | null> {
         return this.instance.updateCategory(id, data);
     }
     static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -1,4 +1,4 @@
-import mongoose, { ClientSession } from 'mongoose';
+import mongoose from 'mongoose';
 import Category, { ICategory } from '../../models/Category';
 import Brand from '../../models/Brand';
 import Model from '../../models/Model';
@@ -9,7 +9,8 @@ import logger from '../../utils/logger';
 import { isDuplicateKeyError } from '../../utils/errorHelpers';
 import { AppError } from '../../utils/AppError';
 import { 
-    CatalogUnitOfWorkPort, 
+    CatalogUnitOfWorkPort,
+    TransactionContext,
     CatalogCachePort,
     CategoryRepositoryPort, 
     BrandRepositoryPort, 
@@ -104,7 +105,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Cascade Category soft-delete to Brands, Models, and deactivation of Parts
      */
-    async cascadeCategoryDelete(categoryId: string, session?: ClientSession) {
+    async cascadeCategoryDelete(categoryId: string, session?: TransactionContext) {
         const txSession = session || null;
         const now = new Date();
         const categoryObjectId = new mongoose.Types.ObjectId(categoryId);
@@ -245,7 +246,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Cascade Brand soft-delete to Models and SpareParts
      */
-    async cascadeBrandDelete(brandId: string, session?: ClientSession) {
+    async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         const txSession = session || null;
         const now = new Date();
 
@@ -338,10 +339,10 @@ export class CatalogOrchestratorImpl {
     }
 
     async deleteCategoryOrchestrated(categoryId: string) {
-        const performDelete = async (txSession: mongoose.ClientSession | null) => {
+        return this.unitOfWork.executeTransaction(async (txSession) => {
             const CategoryModel = require('../../models/Category').default;
             const category = txSession 
-                ? await CategoryModel.findById(categoryId).session(txSession)
+                ? await CategoryModel.findById(categoryId).session(txSession as any)
                 : await CategoryModel.findById(categoryId);
 
             if (!category) {
@@ -352,7 +353,7 @@ export class CatalogOrchestratorImpl {
                 category.isDeleted = true;
                 category.deletedAt = new Date();
                 category.isActive = false;
-                await category.save({ session: txSession });
+                await category.save({ session: txSession as any });
                 await this.cascadeCategoryDelete(String(category._id), txSession);
             } else {
                 category.isDeleted = true;
@@ -362,54 +363,12 @@ export class CatalogOrchestratorImpl {
                 await this.cascadeCategoryDelete(String(category._id));
             }
             return category;
-        };
-
-        const { getUserConnection } = require('../../config/db');
-        let session: mongoose.ClientSession | null = null;
-        try {
-            session = await getUserConnection().startSession();
-            if (session) {
-                session.startTransaction();
-                const category = await performDelete(session);
-                await session.commitTransaction();
-                return category;
-            }
-            return await performDelete(null);
-        } catch (e: unknown) {
-            if (session) {
-                try { await session.abortTransaction(); } catch { /* ignore */ }
-                try { await session.endSession(); } catch { /* ignore */ }
-                session = null;
-            }
-
-            const errorMessage = e instanceof Error ? e.message : String(e);
-            const isSessionError = /session|transaction|mongoclient/i.test(errorMessage);
-
-            if (isSessionError) {
-                logger.warn(`Transaction session failed (${errorMessage}). Retrying sequential soft-delete sessionless...`);
-                return performDelete(null);
-            }
-            throw e;
-        } finally {
-            if (session) {
-                try { await session.endSession(); } catch { /* ignore */ }
-            }
-        }
+        });
     }
 
     async deleteBrandOrchestrated(brandId: string) {
         const BrandModel = require('../../models/Brand').default;
         const softDeleteUpdate: Record<string, unknown> = { isDeleted: true, deletedAt: new Date(), isActive: false };
-
-        const performDelete = async (txSession: mongoose.ClientSession | null) => {
-            const brand = txSession 
-                ? await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true }).session(txSession) 
-                : await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true });
-
-            if (!brand) return { deletedModels: 0, deletedSpareParts: 0, brand: null };
-            const cascadeRes = await this.cascadeBrandDelete(brandId, txSession ?? undefined);
-            return { deletedModels: cascadeRes.deletedModels, deletedSpareParts: cascadeRes.deletedSpareParts, brand };
-        };
 
         const existingBrand = await BrandModel.findOne({ _id: brandId }).setOptions({ withDeleted: true });
         if (!existingBrand || existingBrand.isDeleted) {
@@ -422,36 +381,15 @@ export class CatalogOrchestratorImpl {
             throw new AppError('Brand cannot be deleted because dependencies exist', 409, 'DEPENDENCIES_EXIST', deps.details);
         }
 
-        const { getUserConnection } = require('../../config/db');
-        let session: mongoose.ClientSession | null = null;
-        try {
-            session = await getUserConnection().startSession();
-            if (session) {
-                session.startTransaction();
-                const r = await performDelete(session);
-                await session.commitTransaction();
-                return { brandId, deletedModels: r.deletedModels, deletedSpareParts: r.deletedSpareParts, alreadyDeleted: false };
-            }
-            const r = await performDelete(null);
-            return { brandId, deletedModels: r.deletedModels, deletedSpareParts: r.deletedSpareParts, alreadyDeleted: false };
-        } catch (e: unknown) {
-            if (session) {
-                try { await session.abortTransaction(); } catch { /* ignore */ }
-                try { await session.endSession(); } catch { /* ignore */ }
-                session = null;
-            }
-            const msg = e instanceof Error ? e.message : String(e);
-            if (/session|transaction|mongoclient/i.test(msg)) {
-                logger.warn(`Transaction session failed (${msg}). Retrying sequential...`);
-                const r = await performDelete(null);
-                return { brandId, deletedModels: r.deletedModels, deletedSpareParts: r.deletedSpareParts, alreadyDeleted: false };
-            }
-            throw e;
-        } finally {
-            if (session) {
-                try { await session.endSession(); } catch { /* ignore */ }
-            }
-        }
+        return this.unitOfWork.executeTransaction(async (txSession) => {
+            const brand = txSession 
+                ? await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true }).session(txSession as any) 
+                : await BrandModel.findByIdAndUpdate(brandId, softDeleteUpdate, { new: true });
+
+            if (!brand) return { deletedModels: 0, deletedSpareParts: 0, brand: null };
+            const cascadeRes = await this.cascadeBrandDelete(brandId, txSession ?? undefined);
+            return { brandId, deletedModels: cascadeRes.deletedModels, deletedSpareParts: cascadeRes.deletedSpareParts, alreadyDeleted: false };
+        });
     }
 }
 
@@ -488,10 +426,10 @@ export class CatalogOrchestrator {
     static async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
         return this.instance.invalidateCatalogCache(opts);
     }
-    static async cascadeCategoryDelete(categoryId: string, session?: ClientSession) {
+    static async cascadeCategoryDelete(categoryId: string, session?: TransactionContext) {
         return this.instance.cascadeCategoryDelete(categoryId, session);
     }
-    static async cascadeBrandDelete(brandId: string, session?: ClientSession) {
+    static async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         return this.instance.cascadeBrandDelete(brandId, session);
     }
     static async createCategory(data: Partial<ICategory>): Promise<ICategory> {
@@ -506,7 +444,7 @@ export class CatalogOrchestrator {
     static async resolvePrimaryCategoryIdFromBrand(brandId: string): Promise<string | null> {
         return this.instance.resolvePrimaryCategoryIdFromBrand(brandId);
     }
-    static async detachSparePartsFromModel(modelId: string, session?: ClientSession) {
+    static async detachSparePartsFromModel(modelId: string, session?: TransactionContext) {
         return this.instance.detachSparePartsFromModel(modelId, session);
     }
     static async deleteCategoryOrchestrated(categoryId: string) {

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -5,7 +5,6 @@ import { Category, Brand } from '../../domains/catalog';
 export type CategoryResult = Category & Record<string, unknown>;
 export type BrandResult = Brand & Record<string, unknown>;
 
-import SparePart from '../../models/SparePart';
 import ScreenSize from '../../models/ScreenSize';
 import { clearCachePattern } from '../../utils/redisCache';
 import logger from '../../utils/logger';
@@ -174,40 +173,26 @@ export class CatalogOrchestratorImpl {
 
         // 3) SpareParts: detach category when possible; soft-delete only if no category remains
         //    or if parent brand is archived by this cascade.
-        const sparePartOrFilters: Array<Record<string, unknown>> = [{ categoryIds: categoryObjectId }];
-        if (brandIdsToDelete.length > 0) {
-            sparePartOrFilters.push({ brandId: { $in: brandIdsToDelete } });
-        }
-
-        const affectedSpareParts = await SparePart.find({ $or: sparePartOrFilters })
-            .select('_id brandId categoryIds')
-            .session(txSession as any)
-            .lean<CascadeDoc[]>();
+        const affectedSpareParts = await this.sparePartRepository.findByCategoryOrBrands(categoryId, brandIdsToDelete.map(id => String(id)), txSession);
 
         const sparePartIdsToDelete: mongoose.Types.ObjectId[] = [];
         for (const sparePart of affectedSpareParts) {
             if (sparePart.brandId && deletedBrandIdSet.has(String(sparePart.brandId))) {
-                sparePartIdsToDelete.push(sparePart._id);
+                sparePartIdsToDelete.push(new mongoose.Types.ObjectId(sparePart.id));
                 continue;
             }
 
-            const remainingCategoryIds = toUniqueCategoryObjectIds(sparePart.categoryIds, categoryId);
+            const remainingCategoryIds = toUniqueCategoryObjectIds(sparePart.categoryIds as any, categoryId);
             if (remainingCategoryIds.length === 0) {
-                sparePartIdsToDelete.push(sparePart._id);
+                sparePartIdsToDelete.push(new mongoose.Types.ObjectId(sparePart.id));
                 continue;
             }
 
-            await SparePart.updateOne(
-                { _id: sparePart._id },
-                { $set: { categoryIds: remainingCategoryIds } }
-            ).session(txSession as any);
+            await this.sparePartRepository.updateCategoryIds(sparePart.id, remainingCategoryIds.map(id => String(id)), txSession);
         }
 
         if (sparePartIdsToDelete.length > 0) {
-            await SparePart.updateMany(
-                { _id: { $in: sparePartIdsToDelete } },
-                { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession as any);
+            await this.sparePartRepository.softDeleteMany(sparePartIdsToDelete.map(id => String(id)), txSession);
         }
 
         // 4) ScreenSizes: singular category link; keep cascading delete.
@@ -245,19 +230,13 @@ export class CatalogOrchestratorImpl {
         let deletedSpareParts = 0;
         // Soft-delete SpareParts linked to those models
         if (modelIds.length > 0) {
-            const spRes1 = await SparePart.updateMany(
-                { modelId: { $in: modelIds } },
-                { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-            ).session(txSession as any);
-            deletedSpareParts += spRes1.modifiedCount || 0;
+            const count1 = await this.sparePartRepository.softDeleteByModelIds(modelIds.map(id => String(id)), txSession);
+            deletedSpareParts += count1;
         }
 
         // Soft-delete SpareParts linked to the brand directly
-        const spRes2 = await SparePart.updateMany(
-            { brandId },
-            { $set: { isDeleted: true, isActive: false, deletedAt: now } }
-        ).session(txSession as any);
-        deletedSpareParts += spRes2.modifiedCount || 0;
+        const count2 = await this.sparePartRepository.softDeleteByBrandId(brandId, txSession);
+        deletedSpareParts += count2;
 
         await this.invalidateCatalogCache({ brandIds: [brandId] });
         logger.info(`Cascaded soft-delete for brand: ${brandId}`);
@@ -308,10 +287,7 @@ export class CatalogOrchestratorImpl {
      * Detach SpareParts from a specific Model
      */
     async detachSparePartsFromModel(modelId: string, session?: TransactionContext) {
-        await SparePart.updateMany(
-            { modelId },
-            { $set: { modelId: null, isActive: false } }
-        ).session(session as any || null);
+        await this.sparePartRepository.clearModelReferences(modelId, session);
         
         logger.info(`Detached spare parts from model: ${modelId}`);
     }

--- a/core/src/services/catalog/CatalogOrchestrator.ts
+++ b/core/src/services/catalog/CatalogOrchestrator.ts
@@ -8,6 +8,14 @@ import { clearCachePattern } from '../../utils/redisCache';
 import logger from '../../utils/logger';
 import { isDuplicateKeyError } from '../../utils/errorHelpers';
 import { AppError } from '../../utils/AppError';
+import { 
+    CatalogUnitOfWorkPort, 
+    CatalogCachePort,
+    CategoryRepositoryPort, 
+    BrandRepositoryPort, 
+    ModelRepositoryPort, 
+    SparePartRepositoryPort 
+} from '../../domains/catalog';
 
 type CascadeDoc = {
     _id: mongoose.Types.ObjectId;
@@ -39,11 +47,19 @@ const toUniqueCategoryObjectIds = (
  * The Single Source of Truth (SSOT) for catalog domain orchestration.
  * Consolidates CRUD operations, cache management, and hierarchy integrity.
  */
-export class CatalogOrchestrator {
+export class CatalogOrchestratorImpl {
+    constructor(
+        private readonly unitOfWork: CatalogUnitOfWorkPort,
+        private readonly cacheService: CatalogCachePort,
+        private readonly categoryRepository: CategoryRepositoryPort,
+        private readonly brandRepository: BrandRepositoryPort,
+        private readonly modelRepository: ModelRepositoryPort,
+        private readonly sparePartRepository: SparePartRepositoryPort
+    ) {}
     /**
      * Invalidate catalog caches, optionally scoped by category or brand
      */
-    static async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
+    async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
         try {
             if (!opts || (!opts.categoryIds?.length && !opts.brandIds?.length)) {
                 await Promise.all([
@@ -88,7 +104,7 @@ export class CatalogOrchestrator {
     /**
      * Cascade Category soft-delete to Brands, Models, and deactivation of Parts
      */
-    static async cascadeCategoryDelete(categoryId: string, session?: ClientSession) {
+    async cascadeCategoryDelete(categoryId: string, session?: ClientSession) {
         const txSession = session || null;
         const now = new Date();
         const categoryObjectId = new mongoose.Types.ObjectId(categoryId);
@@ -229,7 +245,7 @@ export class CatalogOrchestrator {
     /**
      * Cascade Brand soft-delete to Models and SpareParts
      */
-    static async cascadeBrandDelete(brandId: string, session?: ClientSession) {
+    async cascadeBrandDelete(brandId: string, session?: ClientSession) {
         const txSession = session || null;
         const now = new Date();
 
@@ -275,7 +291,7 @@ export class CatalogOrchestrator {
     /**
      * Create Category with cache invalidation
      */
-    static async createCategory(data: Partial<ICategory>): Promise<ICategory> {
+    async createCategory(data: Partial<ICategory>): Promise<ICategory> {
         const category = new Category(data);
         const result = await category.save();
         await this.invalidateCatalogCache({ categoryIds: [category._id] });
@@ -285,7 +301,7 @@ export class CatalogOrchestrator {
     /**
      * Update Category with cache invalidation
      */
-    static async updateCategory(id: string, data: Partial<ICategory>): Promise<ICategory | null> {
+    async updateCategory(id: string, data: Partial<ICategory>): Promise<ICategory | null> {
         const result = await Category.findByIdAndUpdate(id, data, { new: true });
         if (result) await this.invalidateCatalogCache({ categoryIds: [id] });
         return result;
@@ -295,7 +311,7 @@ export class CatalogOrchestrator {
     /**
      * Resolve all CategoryIDs from a BrandID
      */
-    static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {
+    async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {
         const brand = await Brand.findById(brandId).select('categoryIds').lean();
         if (!brand || !brand.categoryIds) return [];
         return brand.categoryIds.map(id => id.toString());
@@ -304,7 +320,7 @@ export class CatalogOrchestrator {
     /**
      * Resolve a deterministic primary CategoryID from a BrandID.
      */
-    static async resolvePrimaryCategoryIdFromBrand(brandId: string): Promise<string | null> {
+    async resolvePrimaryCategoryIdFromBrand(brandId: string): Promise<string | null> {
         const ids = await this.resolveCategoryIdsFromBrand(brandId);
         return ids.length > 0 ? (ids[0] ?? null) : null;
     }
@@ -312,7 +328,7 @@ export class CatalogOrchestrator {
     /**
      * Detach SpareParts from a specific Model
      */
-    static async detachSparePartsFromModel(modelId: string, session?: ClientSession) {
+    async detachSparePartsFromModel(modelId: string, session?: ClientSession) {
         await SparePart.updateMany(
             { modelId },
             { $set: { modelId: null, isActive: false } }
@@ -321,7 +337,7 @@ export class CatalogOrchestrator {
         logger.info(`Detached spare parts from model: ${modelId}`);
     }
 
-    static async deleteCategoryOrchestrated(categoryId: string) {
+    async deleteCategoryOrchestrated(categoryId: string) {
         const performDelete = async (txSession: mongoose.ClientSession | null) => {
             const CategoryModel = require('../../models/Category').default;
             const category = txSession 
@@ -381,7 +397,7 @@ export class CatalogOrchestrator {
         }
     }
 
-    static async deleteBrandOrchestrated(brandId: string) {
+    async deleteBrandOrchestrated(brandId: string) {
         const BrandModel = require('../../models/Brand').default;
         const softDeleteUpdate: Record<string, unknown> = { isDeleted: true, deletedAt: new Date(), isActive: false };
 
@@ -436,6 +452,68 @@ export class CatalogOrchestrator {
                 try { await session.endSession(); } catch { /* ignore */ }
             }
         }
+    }
+}
+
+let serviceInstance: CatalogOrchestratorImpl | null = null;
+
+export function initializeCatalogOrchestrator(instance: CatalogOrchestratorImpl) {
+    serviceInstance = instance;
+}
+
+function getServiceInstance(): CatalogOrchestratorImpl {
+    if (!serviceInstance) {
+        const { MongoCatalogUnitOfWorkAdapter } = require('../../adapters/outbound/database/catalog/MongoCatalogUnitOfWorkAdapter');
+        const { RedisCatalogCacheAdapter } = require('../../adapters/outbound/database/catalog/RedisCatalogCacheAdapter');
+        const { MongoCategoryRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoCategoryRepositoryAdapter');
+        const { MongoBrandRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoBrandRepositoryAdapter');
+        const { MongoModelRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoModelRepositoryAdapter');
+        const { MongoSparePartRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter');
+
+        serviceInstance = new CatalogOrchestratorImpl(
+            new MongoCatalogUnitOfWorkAdapter(),
+            new RedisCatalogCacheAdapter(),
+            new MongoCategoryRepositoryAdapter(),
+            new MongoBrandRepositoryAdapter(),
+            new MongoModelRepositoryAdapter(),
+            new MongoSparePartRepositoryAdapter()
+        );
+    }
+    return serviceInstance;
+}
+
+export class CatalogOrchestrator {
+    private static get instance() { return getServiceInstance(); }
+
+    static async invalidateCatalogCache(opts?: { categoryIds?: (string | mongoose.Types.ObjectId)[], brandIds?: (string | mongoose.Types.ObjectId)[] }) {
+        return this.instance.invalidateCatalogCache(opts);
+    }
+    static async cascadeCategoryDelete(categoryId: string, session?: ClientSession) {
+        return this.instance.cascadeCategoryDelete(categoryId, session);
+    }
+    static async cascadeBrandDelete(brandId: string, session?: ClientSession) {
+        return this.instance.cascadeBrandDelete(brandId, session);
+    }
+    static async createCategory(data: Partial<ICategory>): Promise<ICategory> {
+        return this.instance.createCategory(data);
+    }
+    static async updateCategory(id: string, data: Partial<ICategory>): Promise<ICategory | null> {
+        return this.instance.updateCategory(id, data);
+    }
+    static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {
+        return this.instance.resolveCategoryIdsFromBrand(brandId);
+    }
+    static async resolvePrimaryCategoryIdFromBrand(brandId: string): Promise<string | null> {
+        return this.instance.resolvePrimaryCategoryIdFromBrand(brandId);
+    }
+    static async detachSparePartsFromModel(modelId: string, session?: ClientSession) {
+        return this.instance.detachSparePartsFromModel(modelId, session);
+    }
+    static async deleteCategoryOrchestrated(categoryId: string) {
+        return this.instance.deleteCategoryOrchestrated(categoryId);
+    }
+    static async deleteBrandOrchestrated(brandId: string) {
+        return this.instance.deleteBrandOrchestrated(brandId);
     }
 }
 

--- a/core/src/services/catalog/CatalogValidationService.ts
+++ b/core/src/services/catalog/CatalogValidationService.ts
@@ -1,4 +1,3 @@
-import Model from '../../models/Model';
 import {
     CATALOG_APPROVAL_STATUS,
     type CatalogApprovalStatusValue,
@@ -18,6 +17,8 @@ import {
 import {
     CategoryRepositoryPort,
     BrandRepositoryPort,
+    ModelRepositoryPort,
+    SparePartRepositoryPort,
     ListingTypeValue
 } from '../../domains/catalog';
 
@@ -59,7 +60,9 @@ export interface CategoryValidationResult {
 export class CatalogValidationService {
     constructor(
         private readonly categoryRepository: CategoryRepositoryPort,
-        private readonly brandRepository: BrandRepositoryPort
+        private readonly brandRepository: BrandRepositoryPort,
+        private readonly modelRepository: ModelRepositoryPort,
+        private readonly sparePartRepository: SparePartRepositoryPort
     ) {}
 
     public static validateCatalogInput(options: {
@@ -131,19 +134,16 @@ export class CatalogValidationService {
         validateObjectIdOrThrow('modelId', modelId);
         if (brandId) validateObjectIdOrThrow('brandId', brandId);
 
-        const model = await Model.findOne({
-            _id: modelId,
-            isDeleted: { $ne: true },
-            deletedAt: null,
-            isActive: true,
-            approvalStatus: { $in: [CATALOG_APPROVAL_STATUS.APPROVED, CATALOG_APPROVAL_STATUS.PENDING] },
-        }).select('brandId').lean();
+        const model = await this.modelRepository.findById(modelId);
+        
+        const isModelActive = model && model.isActive && !model.isDeleted &&
+            (model.approvalStatus === CATALOG_APPROVAL_STATUS.APPROVED || model.approvalStatus === CATALOG_APPROVAL_STATUS.PENDING);
 
-        if (!model) {
+        if (!isModelActive) {
             return { ok: false, reason: 'modelId refers to an invalid or inactive model.' };
         }
 
-        if (brandId && String((model as { brandId?: unknown }).brandId) !== brandId) {
+        if (brandId && model.brandId !== brandId) {
             return { ok: false, reason: 'modelId does not belong to the specified brandId.' };
         }
 
@@ -295,9 +295,13 @@ function getServiceInstance(): CatalogValidationService {
         // to avoid circular dependencies and static concrete imports in tests
         const { MongoCategoryRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoCategoryRepositoryAdapter');
         const { MongoBrandRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoBrandRepositoryAdapter');
+        const { MongoModelRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoModelRepositoryAdapter');
+        const { MongoSparePartRepositoryAdapter } = require('../../adapters/outbound/database/catalog/MongoSparePartRepositoryAdapter');
         serviceInstance = new CatalogValidationService(
             new MongoCategoryRepositoryAdapter(),
-            new MongoBrandRepositoryAdapter()
+            new MongoBrandRepositoryAdapter(),
+            new MongoModelRepositoryAdapter(),
+            new MongoSparePartRepositoryAdapter()
         );
     }
     return serviceInstance;


### PR DESCRIPTION

This Pull Request delivers the complete architectural migration of the **Catalog Bounded Context** from active direct Mongoose model usage to the decoupled **DDD Ports & Adapters (Hexagonal)** architecture, governed by the repository standards of the Esparex Platform. 

It covers the complete migration of all five core catalog entities (Category, Brand, Model, SparePart, ScreenSize), introduces a transactional UnitofWork pattern, wraps Redis cache invalidation behind a port, and decouples the application layer (`CatalogOrchestrator`) from all direct infrastructure dependencies.

---

## Architecture Design Summary

The migration enforces a strict boundary between domain persistence capability requirements and the underlying database implementation:

```mermaid
graph LR
    subgraph Core Application / Domain
        Orch[CatalogOrchestrator] --> Port1[CategoryRepositoryPort]
        Orch --> Port2[BrandRepositoryPort]
        Orch --> Port3[ModelRepositoryPort]
        Orch --> Port4[SparePartRepositoryPort]
        Orch --> Port5[ScreenSizeRepositoryPort]
        Orch --> CachePort[CatalogCachePort]
        Orch --> UowPort[CatalogUnitOfWorkPort]
    end

    subgraph Outbound Adapters (Infrastructure)
        Adapter1[MongoCategoryRepositoryAdapter] -.-> Port1
        Adapter2[MongoBrandRepositoryAdapter] -.-> Port2
        Adapter3[MongoModelRepositoryAdapter] -.-> Port3
        Adapter4[MongoSparePartRepositoryAdapter] -.-> Port4
        Adapter5[MongoScreenSizeRepositoryAdapter] -.-> Port5
        CacheAdapter[RedisCatalogCacheAdapter] -.-> CachePort
        UowAdapter[MongoCatalogUnitOfWorkAdapter] -.-> UowPort
    end

    subgraph Database / Cache
        Adapter1 --> Mongo[(MongoDB)]
        CacheAdapter --> Redis[(Redis)]
    end
```

---

## Detailed Migration Summary

### 1. Repository Abstractions & Adapters
- **Category**: Added `CategoryRepositoryPort` and `MongoCategoryRepositoryAdapter`. Moved orchestrated soft-deletes and lookups out of `CatalogCategoryService` into the adapter.
- **Brand**: Added `BrandRepositoryPort` and `MongoBrandRepositoryAdapter` (handling category-based queries and re-linking).
- **Model**: Added `ModelRepositoryPort` and `MongoModelRepositoryAdapter` (managing category & brand cascades).
- **SparePart**: Added `SparePartRepositoryPort` and `MongoSparePartRepositoryAdapter` (managing model and brand de-associations).
- **ScreenSize**: Added `ScreenSizeRepositoryPort` and `MongoScreenSizeRepositoryAdapter` (handling criteria-driven bulk soft deletes).
- **Variant Bounded Context**: Audited and confirmed that `CatalogOrchestrator` has **zero Variant dependencies**. Kept Variant out of speculative abstraction, maintaining its usage strictly within the read/reporting/controller layer.

### 2. Transaction Management (UnitofWork)
- Replaced direct Mongoose `ClientSession` propagation in `CatalogOrchestrator` with the abstract `CatalogUnitOfWorkPort` and `MongoCatalogUnitOfWorkAdapter`. Transactions are executed cleanly using `this.unitOfWork.executeTransaction(...)` with abstract `TransactionContext` tokens.

### 3. Cache Decoupling (D4)
- Decoupled `CatalogOrchestrator` from direct Redis `clearCachePattern` imports, delegating all invalidation requests to `CatalogCachePort` implemented by `RedisCatalogCacheAdapter`.

### 4. Infrastructure Cleanup (D3.7)
- Eliminated redundant `mongoose.Types.ObjectId` cascade accumulators in `CatalogOrchestrator.ts`, converting accumulators to clean `string[]` arrays.
- Completely removed `mongoose` imports from `CatalogOrchestrator.ts`.
- Cleaned up obsolete helper methods `findCategoryByIdWithSession` and `softDeleteCategoryById` from `CatalogCategoryService.ts`.

---

## Verification & Guard Metrics

All repository checks and architecture validation tests passed locally and pushed successfully via pre-push hooks:

| Gate Check | Commands Executed | Result |
|---|---|---|
| **TypeScript Typecheck** | `npx tsc --noEmit` (monorepo-wide) | **PASS (0 errors)** ✅ |
| **Core Jest Tests** | `npm test -w @esparex/core` | **PASS (39/39 suites, 246/246 tests)** ✅ |
| **Backend API Jest Tests** | `npm test -w backend/api` | **PASS (63/63 suites, 317/317 tests)** ✅ |
| **Dependency Cruiser** | `npm run guard:dependencies` | **PASS (0 violations)** ✅ |
| **Madge Circularity** | `npm run guard:circular` | **PASS (0 circular dependencies)** ✅ |
| **Platform Governance** | `npm run governance:guards` | **PASS (All 10 guards passed)** ✅ |

---

## Pull Request Readiness Checklist

- [x] No direct Mongoose model imports exist inside `CatalogOrchestrator.ts`.
- [x] No `mongoose.Types.ObjectId` wrappers exist in `CatalogOrchestrator.ts` logic.
- [x] No direct Redis `clearCachePattern` or cache-key templates reside in `CatalogOrchestrator.ts`.
- [x] The workspace has zero untracked/dirty files (excluding `.gitignore` patterns).
- [x] Commit history is preserved sequentially across all 14 review-ready commits.

---
