### PR TITLE
feat(catalog): refactor dynamic brand/model creation to 3-layer architecture (#102)

### DIFF
--- a/apps/web/src/__tests__/business-registration.schema.spec.ts
+++ b/apps/web/src/__tests__/business-registration.schema.spec.ts
@@ -19,6 +19,7 @@ const validRegistrationPayload = {
     idProof: "https://example.com/id-proof.pdf",
     businessProof: "https://example.com/business-proof.pdf",
     certificates: [],
+    images: ["https://example.com/shop-1.jpg"],
     shopImages: ["https://example.com/shop-1.jpg"],
 };
 

--- a/apps/web/src/components/user/BrandSearchSelect.tsx
+++ b/apps/web/src/components/user/BrandSearchSelect.tsx
@@ -18,6 +18,8 @@ interface BrandSearchSelectProps {
     onChange: (brandId: string, brandName: string, requestId?: string) => void;
     categoryId: string;
     onRequestSuccess?: (requestId: string, name: string) => void | Promise<void>;
+    /** Optional custom orchestrator handler (Layer 3 composed action) */
+    onCreateBrand?: (categoryId: string, name: string, listingId?: string) => Promise<{ status: string; id?: string; message?: string }>;
     /** Optional listing ID for traceability (edit-ad flow only). */
     listingId?: string;
     disabled?: boolean;
@@ -32,6 +34,7 @@ export function BrandSearchSelect({
     onChange,
     categoryId,
     onRequestSuccess,
+    onCreateBrand,
     listingId,
     disabled = false,
     placeholder = "Search brand...",
@@ -124,6 +127,18 @@ export function BrandSearchSelect({
             categoryId={categoryId}
             initialName={search}
             listingId={listingId}
+            onSubmitRequest={
+                onCreateBrand
+                    ? async (name) => {
+                          const res = await onCreateBrand(categoryId, name, listingId);
+                          if (res.status === 'SELECTED' || res.status === 'MANUAL_REVIEW') {
+                              setSearch("");
+                              setIsEditing(false);
+                          }
+                          return res;
+                      }
+                    : undefined
+            }
             onSuccess={async (resolvedEntityId, name, decision) => {
                 setSearch("");
                 setIsEditing(false);

--- a/apps/web/src/components/user/CatalogRequestDialog.tsx
+++ b/apps/web/src/components/user/CatalogRequestDialog.tsx
@@ -29,6 +29,8 @@ interface CatalogRequestDialogProps {
     /** Optional: the listing ID that triggered this suggestion (edit-ad flow only). */
     listingId?: string;
     onSuccess?: (resolvedEntityId: string, name: string, decision: 'AUTO_APPROVE' | 'MANUAL_REVIEW' | 'REJECT', created: boolean) => void;
+    /** Optional custom orchestrator mutating and selecting directly (Layer 3 composed action) */
+    onSubmitRequest?: (name: string) => Promise<{ status: string; id?: string; message?: string }>;
 }
 
 export function CatalogRequestDialog({
@@ -40,6 +42,7 @@ export function CatalogRequestDialog({
     initialName = "",
     listingId,
     onSuccess,
+    onSubmitRequest,
 }: CatalogRequestDialogProps) {
 
     const [name, setName] = useState(initialName);
@@ -79,6 +82,26 @@ export function CatalogRequestDialog({
 
         setIsSubmitting(true);
         setErrorMessage(null);
+        if (onSubmitRequest) {
+            try {
+                const res = await onSubmitRequest(name.trim());
+                if (res.status === 'REJECTED' || res.status === 'ERROR') {
+                    setErrorMessage(res.message || "Suggestion rejected or failed.");
+                    notify.error(res.message || "Suggestion rejected or failed.");
+                    return;
+                }
+                if (res.status === 'MANUAL_REVIEW') {
+                    notify.info("Your suggestion has been submitted for review.");
+                }
+                onOpenChange(false);
+            } catch (error: unknown) {
+                setErrorMessage(mapErrorToMessage(error, "Network error. Please try again."));
+            } finally {
+                setIsSubmitting(false);
+            }
+            return;
+        }
+
         try {
             const result = await createCatalogRequest({
                 requestType,

--- a/apps/web/src/components/user/ModelSearchSelect.tsx
+++ b/apps/web/src/components/user/ModelSearchSelect.tsx
@@ -22,6 +22,8 @@ interface ModelSearchSelectProps {
     /** Called with (modelId, modelName, requestId) on selection */
     onChange: (modelId: string, modelName: string, requestId?: string) => void;
     onRequestSuccess?: (requestId: string, name: string) => void | Promise<void>;
+    /** Optional custom orchestrator handler (Layer 3 composed action) */
+    onCreateModel?: (brandId: string, categoryId: string, name: string, listingId?: string) => Promise<{ status: string; id?: string; message?: string }>;
     /** Reserved callback for parent brand sync in async catalog flows. */
     onBrandResolved?: (brandId: string, brandName: string) => void;
     /** Optional listing ID for traceability (edit-ad flow only). */
@@ -38,6 +40,7 @@ export function ModelSearchSelect({
     modelDisplayName = "",
     onChange,
     onRequestSuccess,
+    onCreateModel,
     listingId,
     disabled = false,
     placeholder = "Search model (e.g. iPhone 14 Pro)...",
@@ -52,18 +55,12 @@ export function ModelSearchSelect({
     const [dropdownStyle, setDropdownStyle] = useState<CSSProperties | null>(null);
     const [isRequestDialogOpen, setIsRequestDialogOpen] = useState(false);
 
-    // Local selection bridges the gap during prop/context sync.
-    // Only consulted when selectedModel (from catalog) is not yet available.
-    const [localSelection, setLocalSelection] = useState<{ id: string; name: string } | null>(null);
-
-    // Resolve selected model name.
-    // Priority: matched model in list > local tentative selection > explicit displayName > raw value
+    // Resolve selected model name cleanly from React Query catalog SSOT or RHF prop value without local selection state.
     const selectedModel = useMemo(() => {
         return availableModels.find(m => m.id === value || m._id === value);
     }, [availableModels, value]);
 
-    // If selectedModel is present in the catalog, localSelection is superseded — no effect needed.
-    const selectedName = selectedModel?.name || (!selectedModel ? localSelection?.name : null) || modelDisplayName || value || "";
+    const selectedName = selectedModel?.name || modelDisplayName || value || "";
     useEffect(() => {
         if (!search || search.length < 2) return;
 
@@ -116,7 +113,6 @@ export function ModelSearchSelect({
     const handleSelect = (model: DeviceModel) => {
         const id = String(model.id || model._id);
         const name = model.name;
-        setLocalSelection({ id, name });
         onChange(id, name);
         setSearch("");
         setIsEditing(false);
@@ -163,6 +159,18 @@ export function ModelSearchSelect({
             parentBrandId={brandId}
             initialName={search}
             listingId={listingId}
+            onSubmitRequest={
+                onCreateModel
+                    ? async (name) => {
+                          const res = await onCreateModel(brandId, categoryId, name, listingId);
+                          if (res.status === 'SELECTED' || res.status === 'MANUAL_REVIEW') {
+                              setSearch("");
+                              setIsEditing(false);
+                          }
+                          return res;
+                      }
+                    : undefined
+            }
             onSuccess={async (resolvedEntityId, name, decision) => {
                 setSearch("");
                 setIsEditing(false);
@@ -207,7 +215,6 @@ export function ModelSearchSelect({
                             onClick={(e) => {
                                 e.preventDefault();
                                 e.stopPropagation();
-                                setLocalSelection(null);
                                 onChange("", "");
                                 setSearch("");
                                 setIsEditing(false);

--- a/apps/web/src/components/user/post-ad/context/provider.tsx
+++ b/apps/web/src/components/user/post-ad/context/provider.tsx
@@ -18,6 +18,7 @@ import { usePostAdForm } from "@/hooks/usePostAdForm";
 import { usePostAdValidation } from "@/hooks/usePostAdValidation";
 import { usePostAdAiGeneration } from "../hooks/usePostAdAiGeneration";
 import { useCategoryDependents } from "../hooks/useCategoryDependents";
+import { useCatalogMutations } from "../hooks/useCatalogMutations";
 import { usePostAdStepNavigation } from "../hooks/usePostAdStepNavigation";
 import { usePostAdSparePartSelection } from "../hooks/usePostAdSparePartSelection";
 import { usePostAdSubmissionFlow } from "../hooks/usePostAdSubmissionFlow";
@@ -39,7 +40,7 @@ export function PostAdProvider({
     const sparePartCatalog = useSparePartCatalog({ listingType: LISTING_TYPE.AD, onError: validationHook.setFormError });
     const categorySchemaCatalog = useCategorySchemaCatalog();
     const { dynamicCategories, categoryMap } = categoryCatalog;
-    const { brandMap, availableBrands, availableModels, availableSizes, loadBrandsForCategory, loadModelsForBrand, refreshBrands, brandsError } = brandCatalog;
+    const { brandMap, availableBrands, availableModels, availableSizes, loadBrandsForCategory, loadModelsForBrand, refreshBrands, brandsError, ensureBrandVisible, ensureModelVisible } = brandCatalog;
     const { availableSpareParts, isLoadingSpareParts, sparePartsError, loadSparePartsForCategory } = sparePartCatalog;
     const { categorySchema, loadCategorySchema } = categorySchemaCatalog;
 
@@ -70,9 +71,15 @@ export function PostAdProvider({
     const { listingImages, setListingImages } = imagesHook;
     const { listingLocation, setLocation, coordinates, locationDisplay } = locationHook;
     const { loadError, setLoadError, formError, setFormError } = validationHook;
-    const { requiresScreenSize, handleCategoryChange, handleBrandChange } = useCategoryDependents(
+    const { requiresScreenSize, handleCategoryChange, handleBrandChange, selectBrand, selectModel, clearCategoryDependents } = useCategoryDependents(
         form as any, categoryMap, brandMap as any, setFormError, setBrandIsPending, loadBrandsForCategory, loadSparePartsForCategory, loadCategorySchema, loadModelsForBrand
     );
+    const { createAndSelectBrand, createAndSelectModel } = useCatalogMutations({
+        ensureBrandVisible,
+        ensureModelVisible,
+        selectBrand,
+        selectModel,
+    });
     const { setIsDirty } = useNavigation();
 
     useEffect(() => { const cleanup = suppressGoogleMapsRetryErrors(); return cleanup; }, []);
@@ -91,6 +98,7 @@ export function PostAdProvider({
     const initializeFromListing = useCallback(async (data: Listing) => {
         setMode('edit'); setListingId(String(data.id || (data as any)._id || "")); setCurrentStep(2);
         if (setOriginalAdStatus && data.status) setOriginalAdStatus(data.status);
+        clearCategoryDependents();
         const categoryId = data.categoryId || data.category;
         setValue("categoryId", categoryId); setValue("category", categoryId); setValue("brand", typeof data.brandName === "string" ? data.brandName : ""); setValue("brandId", data.brandId || "");
         setValue("model", typeof data.modelName === "string" ? data.modelName : ""); setValue("modelId", data.modelId || "");
@@ -99,7 +107,7 @@ export function PostAdProvider({
         if (data.location) setValue("location", { city: data.location.city, state: data.location.state, display: data.location.display, coordinates: data.location.coordinates, locationId: (data.location.locationId as string) || (data.location as any).id || undefined });
         if (Array.isArray(data.images)) { const mappedIds = data.images.map((url: string) => ({ id: crypto.randomUUID(), preview: url, isRemote: true })); setListingImages(mappedIds); setValue("images", mappedIds.map((i) => i.preview)); }
         setIsLoading(false);
-    }, [setValue, loadBrandsForCategory, loadSparePartsForCategory, loadModelsForBrand, setListingImages]);
+    }, [clearCategoryDependents, setValue, loadBrandsForCategory, loadSparePartsForCategory, loadModelsForBrand, setListingImages]);
 
     const resetToCreateMode = useCallback(() => { setMode('create'); setListingId(undefined); setCurrentStep(1); form.reset(); (imagesHook as any).setListingImages([]); }, [form, imagesHook]);
     const { generateDescription } = usePostAdAiGeneration(form as any, categoryMap, availableSpareParts, setIsLoading, setFormError);
@@ -113,7 +121,7 @@ export function PostAdProvider({
     const imagesState = useMemo<PostAdImagesState>(() => ({ listingImages, isUploadingImages: imagesHook.isUploadingImages, imageUploadError: imagesHook.imageUploadError }), [listingImages, imagesHook.isUploadingImages, imagesHook.imageUploadError]);
     const flowState = useMemo<PostAdFlowState>(() => ({ currentStep, stepValidationAttempts, isLoading, isSubmitting: isSubmitting || isInternalUploading, isEditMode, userHasInteracted, loadError, formError, submittedAd, form, control, errors, mode, listingId }), [currentStep, stepValidationAttempts, isLoading, isSubmitting, isInternalUploading, isEditMode, userHasInteracted, loadError, formError, submittedAd, form, control, errors, mode, listingId]);
     const stateValue = useMemo<PostAdStateContextType>(() => ({ ...flowState, ...catalogState, ...locationState, ...imagesState }), [flowState, catalogState, locationState, imagesState]);
-    const actionValue = useMemo<PostAdActionContextType>(() => ({ setCurrentStep, nextStep, prevStep, handleCategoryChange, handleBrandChange, toggleSparePart, toggleAllSpareParts, addImages, removeImage, setLocation, loadBrandsForCategory, loadModelsForBrand, loadSparePartsForCategory, loadCategorySchema, refreshBrands, generateDescription, submitAd, setUserHasInteracted, setLoadError, setFormError, setImageUploadError: imagesHook.setImageUploadError, setSubmittedAd, setValue, register, watch, initializeFromListing, resetToCreateMode }), [setCurrentStep, nextStep, prevStep, handleCategoryChange, handleBrandChange, toggleSparePart, toggleAllSpareParts, addImages, removeImage, setLocation, loadBrandsForCategory, loadModelsForBrand, loadSparePartsForCategory, loadCategorySchema, refreshBrands, generateDescription, submitAd, setUserHasInteracted, setLoadError, setFormError, imagesHook.setImageUploadError, setSubmittedAd, setValue, register, watch, initializeFromListing, resetToCreateMode]);
+    const actionValue = useMemo<PostAdActionContextType>(() => ({ setCurrentStep, nextStep, prevStep, handleCategoryChange, handleBrandChange, createAndSelectBrand, createAndSelectModel, toggleSparePart, toggleAllSpareParts, addImages, removeImage, setLocation, loadBrandsForCategory, loadModelsForBrand, loadSparePartsForCategory, loadCategorySchema, refreshBrands, generateDescription, submitAd, setUserHasInteracted, setLoadError, setFormError, setImageUploadError: imagesHook.setImageUploadError, setSubmittedAd, setValue, register, watch, initializeFromListing, resetToCreateMode }), [setCurrentStep, nextStep, prevStep, handleCategoryChange, handleBrandChange, createAndSelectBrand, createAndSelectModel, toggleSparePart, toggleAllSpareParts, addImages, removeImage, setLocation, loadBrandsForCategory, loadModelsForBrand, loadSparePartsForCategory, loadCategorySchema, refreshBrands, generateDescription, submitAd, setUserHasInteracted, setLoadError, setFormError, imagesHook.setImageUploadError, setSubmittedAd, setValue, register, watch, initializeFromListing, resetToCreateMode]);
 
     return (
         <PostAdContextShell catalogState={catalogState} locationState={locationState} imagesState={imagesState} flowState={flowState} actionValue={actionValue} stateValue={stateValue}>

--- a/apps/web/src/components/user/post-ad/context/types.ts
+++ b/apps/web/src/components/user/post-ad/context/types.ts
@@ -7,6 +7,7 @@ import type { CategoryFilter } from "@shared";
 import type { Listing } from "@/lib/api/user/listings/normalizer";
 import type { GeoJSONPoint } from "@/types/location";
 import type { ListingImage, ListingCategory, ListingLocation } from "@/types/listing";
+import type { CatalogMutationResult } from "../hooks/useCatalogMutations";
 
 export interface PostAdContextType {
     currentStep: number;
@@ -22,6 +23,8 @@ export interface PostAdContextType {
     prevStep: () => void;
     handleCategoryChange: (id: string) => Promise<void>;
     handleBrandChange: (name: string, requestId?: string) => Promise<void>;
+    createAndSelectBrand: (categoryId: string, name: string, listingId?: string) => Promise<CatalogMutationResult>;
+    createAndSelectModel: (brandId: string, categoryId: string, name: string, listingId?: string) => Promise<CatalogMutationResult>;
     brandIsPending: boolean;
     toggleSparePart: (partId: string) => void;
     toggleAllSpareParts: (selectAll: boolean) => void;
@@ -72,9 +75,9 @@ export interface PostAdContextType {
     resetToCreateMode: () => void;
 }
 
-export type PostAdStateContextType = Omit<PostAdContextType, "setCurrentStep" | "nextStep" | "prevStep" | "handleCategoryChange" | "handleBrandChange" | "toggleSparePart" | "toggleAllSpareParts" | "addImages" | "removeImage" | "setLocation" | "loadBrandsForCategory" | "loadModelsForBrand" | "loadSparePartsForCategory" | "loadCategorySchema" | "refreshBrands" | "generateDescription" | "submitAd" | "setUserHasInteracted" | "setLoadError" | "setFormError" | "setImageUploadError" | "setSubmittedAd" | "setValue" | "register" | "watch" | "initializeFromListing" | "resetToCreateMode">;
+export type PostAdStateContextType = Omit<PostAdContextType, "setCurrentStep" | "nextStep" | "prevStep" | "handleCategoryChange" | "handleBrandChange" | "createAndSelectBrand" | "createAndSelectModel" | "toggleSparePart" | "toggleAllSpareParts" | "addImages" | "removeImage" | "setLocation" | "loadBrandsForCategory" | "loadModelsForBrand" | "loadSparePartsForCategory" | "loadCategorySchema" | "refreshBrands" | "generateDescription" | "submitAd" | "setUserHasInteracted" | "setLoadError" | "setFormError" | "setImageUploadError" | "setSubmittedAd" | "setValue" | "register" | "watch" | "initializeFromListing" | "resetToCreateMode">;
 
-export type PostAdActionContextType = Pick<PostAdContextType, "setCurrentStep" | "nextStep" | "prevStep" | "handleCategoryChange" | "handleBrandChange" | "toggleSparePart" | "toggleAllSpareParts" | "addImages" | "removeImage" | "setLocation" | "loadBrandsForCategory" | "loadModelsForBrand" | "loadSparePartsForCategory" | "loadCategorySchema" | "refreshBrands" | "generateDescription" | "submitAd" | "setUserHasInteracted" | "setLoadError" | "setFormError" | "setImageUploadError" | "setSubmittedAd" | "setValue" | "register" | "watch" | "initializeFromListing" | "resetToCreateMode">;
+export type PostAdActionContextType = Pick<PostAdContextType, "setCurrentStep" | "nextStep" | "prevStep" | "handleCategoryChange" | "handleBrandChange" | "createAndSelectBrand" | "createAndSelectModel" | "toggleSparePart" | "toggleAllSpareParts" | "addImages" | "removeImage" | "setLocation" | "loadBrandsForCategory" | "loadModelsForBrand" | "loadSparePartsForCategory" | "loadCategorySchema" | "refreshBrands" | "generateDescription" | "submitAd" | "setUserHasInteracted" | "setLoadError" | "setFormError" | "setImageUploadError" | "setSubmittedAd" | "setValue" | "register" | "watch" | "initializeFromListing" | "resetToCreateMode">;
 
 export type PostAdCatalogState = {
     dynamicCategories: ListingCategory[];

--- a/apps/web/src/components/user/post-ad/hooks/useCatalogMutations.ts
+++ b/apps/web/src/components/user/post-ad/hooks/useCatalogMutations.ts
@@ -1,0 +1,135 @@
+import { useCallback, useRef } from "react";
+import { createCatalogRequest } from "@/lib/api/user/catalogRequest";
+import logger from "@/lib/logger";
+
+export interface CatalogMutationResult {
+    status: 'SELECTED' | 'MANUAL_REVIEW' | 'REJECTED' | 'ERROR';
+    id?: string;
+    message?: string;
+}
+
+interface UseCatalogMutationsProps {
+    ensureBrandVisible: (entity: { id: string; name: string }) => Promise<void>;
+    ensureModelVisible: (entity: { id: string; name: string; brandId: string }) => Promise<void>;
+    selectBrand: (id: string, name: string) => Promise<void>;
+    selectModel: (id: string, name: string) => void;
+}
+
+export function useCatalogMutations({
+    ensureBrandVisible,
+    ensureModelVisible,
+    selectBrand,
+    selectModel,
+}: UseCatalogMutationsProps) {
+    const activeMutationRef = useRef<Promise<CatalogMutationResult> | null>(null);
+
+    /**
+     * Composed workflow: HTTP POST -> Ensure Brand Visibility -> Select Brand.
+     * Enforces mutex protection against duplicate or rapid consecutive submissions.
+     */
+    const createAndSelectBrand = useCallback(
+        async (categoryId: string, name: string, listingId?: string): Promise<CatalogMutationResult> => {
+            if (activeMutationRef.current) {
+                return activeMutationRef.current;
+            }
+
+            const promise = (async (): Promise<CatalogMutationResult> => {
+                try {
+                    // Phase 1: HTTP Mutation
+                    const result = await createCatalogRequest({
+                        requestType: 'brand',
+                        categoryId,
+                        requestedName: name,
+                        listingId,
+                    });
+
+                    if (result.decision === 'REJECT') {
+                        return { status: 'REJECTED', message: 'Brand suggestion was rejected by catalog policy.' };
+                    }
+
+                    if (result.decision === 'MANUAL_REVIEW' || !result.approvedEntityId) {
+                        return { status: 'MANUAL_REVIEW', message: 'Brand suggestion submitted for manual review.' };
+                    }
+
+                    // Phase 2: Visibility Guarantee (Layer 1 encapsulated reconciliation)
+                    await ensureBrandVisible({ id: result.approvedEntityId, name: result.name || name });
+
+                    // Phase 3: Selection (invoked strictly AFTER visibility is guaranteed)
+                    await selectBrand(result.approvedEntityId, result.name || name);
+
+                    return { status: 'SELECTED', id: result.approvedEntityId };
+                } catch (error) {
+                    logger.error('[CatalogMutations] createAndSelectBrand failed:', error);
+                    return {
+                        status: 'ERROR',
+                        message: error instanceof Error ? error.message : 'Failed to create and select brand',
+                    };
+                } finally {
+                    activeMutationRef.current = null;
+                }
+            })();
+
+            activeMutationRef.current = promise;
+            return promise;
+        },
+        [ensureBrandVisible, selectBrand]
+    );
+
+    /**
+     * Composed workflow: HTTP POST -> Ensure Model Visibility -> Select Model.
+     * Enforces mutex protection against duplicate or rapid consecutive submissions.
+     */
+    const createAndSelectModel = useCallback(
+        async (brandId: string, categoryId: string, name: string, listingId?: string): Promise<CatalogMutationResult> => {
+            if (activeMutationRef.current) {
+                return activeMutationRef.current;
+            }
+
+            const promise = (async (): Promise<CatalogMutationResult> => {
+                try {
+                    // Phase 1: HTTP Mutation
+                    const result = await createCatalogRequest({
+                        requestType: 'model',
+                        categoryId,
+                        parentBrandId: brandId,
+                        requestedName: name,
+                        listingId,
+                    });
+
+                    if (result.decision === 'REJECT') {
+                        return { status: 'REJECTED', message: 'Model suggestion was rejected by catalog policy.' };
+                    }
+
+                    if (result.decision === 'MANUAL_REVIEW' || !result.approvedEntityId) {
+                        return { status: 'MANUAL_REVIEW', message: 'Model suggestion submitted for manual review.' };
+                    }
+
+                    // Phase 2: Visibility Guarantee (Layer 1 encapsulated reconciliation)
+                    await ensureModelVisible({ id: result.approvedEntityId, name: result.name || name, brandId });
+
+                    // Phase 3: Selection (invoked strictly AFTER visibility is guaranteed)
+                    selectModel(result.approvedEntityId, result.name || name);
+
+                    return { status: 'SELECTED', id: result.approvedEntityId };
+                } catch (error) {
+                    logger.error('[CatalogMutations] createAndSelectModel failed:', error);
+                    return {
+                        status: 'ERROR',
+                        message: error instanceof Error ? error.message : 'Failed to create and select model',
+                    };
+                } finally {
+                    activeMutationRef.current = null;
+                }
+            })();
+
+            activeMutationRef.current = promise;
+            return promise;
+        },
+        [ensureModelVisible, selectModel]
+    );
+
+    return {
+        createAndSelectBrand,
+        createAndSelectModel,
+    };
+}

--- a/apps/web/src/components/user/post-ad/hooks/useCategoryDependents.ts
+++ b/apps/web/src/components/user/post-ad/hooks/useCategoryDependents.ts
@@ -28,18 +28,35 @@ export function useCategoryDependents(
         return Boolean(category.hasScreenSizes);
     }, [selectedCategoryId, categoryMap]);
 
-    const handleCategoryChange = useCallback(async (id: string) => {
-        setFormError(null);
-        form.setValue("category", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
-        form.setValue("categoryId", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
-
-        form.setValue("brand", "", { shouldValidate: true, shouldDirty: true });
-        form.setValue("brandId", "", { shouldValidate: true, shouldDirty: true });
+    /**
+     * Centralized clearing of all dependent fields child to Brand (models, screen sizes, spare parts, device condition).
+     */
+    const clearBrandDependents = useCallback(() => {
         form.setValue("model", "", { shouldValidate: true, shouldDirty: true });
         form.setValue("modelId", "", { shouldValidate: true, shouldDirty: true });
         form.setValue("screenSize", "", { shouldValidate: true, shouldDirty: true });
         form.setValue("spareParts", [], { shouldValidate: true, shouldDirty: true });
         form.setValue("deviceCondition", undefined, { shouldValidate: true, shouldDirty: true });
+    }, [form]);
+
+    /**
+     * Centralized clearing of all dependent fields child to Category (brand + child dependents).
+     */
+    const clearCategoryDependents = useCallback(() => {
+        form.setValue("brand", "", { shouldValidate: true, shouldDirty: true });
+        form.setValue("brandId", "", { shouldValidate: true, shouldDirty: true });
+        clearBrandDependents();
+    }, [form, clearBrandDependents]);
+
+    /**
+     * Explicit selection action for Category. Sets canonical form values, clears dependents, and triggers catalog queries.
+     */
+    const selectCategory = useCallback(async (id: string) => {
+        setFormError(null);
+        form.setValue("category", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+        form.setValue("categoryId", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+
+        clearCategoryDependents();
         setBrandIsPending(false);
         
         await Promise.all([
@@ -47,35 +64,64 @@ export function useCategoryDependents(
             loadSparePartsForCategory(id),
             loadCategorySchema(id)
         ]);
-    }, [form, setFormError, setBrandIsPending, loadBrandsForCategory, loadSparePartsForCategory, loadCategorySchema]);
+    }, [form, setFormError, clearCategoryDependents, setBrandIsPending, loadBrandsForCategory, loadSparePartsForCategory, loadCategorySchema]);
 
-    const handleBrandChange = useCallback(async (name: string, requestId?: string) => {
-        const currentBrand = form.getValues("brand");
-        const brandChanged = currentBrand !== name;
+    /**
+     * Explicit selection action for Brand. Sets canonical form values, clears child dependents when changed, and triggers models query.
+     */
+    const selectBrand = useCallback(async (id: string, name: string) => {
+        const currentBrandId = form.getValues("brandId");
+        const currentBrandName = form.getValues("brand");
+        const brandChanged = currentBrandId !== id && currentBrandName !== name;
 
         setFormError(null);
         form.setValue("brand", name, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
-
-        const brandObj = brandMap[name];
-        const brandId = sanitizeMongoObjectId(brandObj?.id || brandObj?._id) || requestId;
-        form.setValue("brandId", brandId ?? "", { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+        form.setValue("brandId", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
 
         if (brandChanged) {
-            form.setValue("spareParts", [], { shouldValidate: true, shouldDirty: true });
-            form.setValue("model", "", { shouldValidate: true, shouldDirty: true });
-            form.setValue("modelId", "", { shouldValidate: true, shouldDirty: true });
-            form.setValue("screenSize", "", { shouldValidate: true, shouldDirty: true });
-            form.setValue("deviceCondition", undefined, { shouldValidate: true, shouldDirty: true });
+            clearBrandDependents();
         }
 
-        if (brandId) {
-            await loadModelsForBrand(brandId, selectedCategoryId);
+        if (id) {
+            await loadModelsForBrand(id, selectedCategoryId);
         } else {
             await loadModelsForBrand("", selectedCategoryId);
         }
         
         setBrandIsPending(false);
-    }, [form, brandMap, setFormError, setBrandIsPending, selectedCategoryId, loadModelsForBrand]);
+    }, [form, setFormError, clearBrandDependents, loadModelsForBrand, selectedCategoryId, setBrandIsPending]);
 
-    return { requiresScreenSize, handleCategoryChange, handleBrandChange };
+    /**
+     * Explicit selection action for Model. Sets canonical form values cleanly without HTTP queries or cache changes.
+     */
+    const selectModel = useCallback((id: string, name: string) => {
+        setFormError(null);
+        form.setValue("model", name, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+        form.setValue("modelId", id, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+    }, [form, setFormError]);
+
+    /**
+     * Backward-compatible alias for existing callers.
+     */
+    const handleCategoryChange = selectCategory;
+
+    /**
+     * Backward-compatible handler for existing callers passing name + optional requestId.
+     */
+    const handleBrandChange = useCallback(async (name: string, requestId?: string) => {
+        const brandObj = brandMap[name];
+        const brandId = sanitizeMongoObjectId(brandObj?.id || brandObj?._id) || requestId || "";
+        return selectBrand(brandId, name);
+    }, [brandMap, selectBrand]);
+
+    return {
+        requiresScreenSize,
+        handleCategoryChange,
+        handleBrandChange,
+        selectCategory,
+        selectBrand,
+        selectModel,
+        clearBrandDependents,
+        clearCategoryDependents,
+    };
 }

--- a/apps/web/src/components/user/post-ad/steps/listing-information/BrandSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-information/BrandSection.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 export function BrandSection() {
     const { availableBrands, brandMap, brandIsPending, brandsError } = usePostAdCatalog();
     const { isEditMode, form, stepValidationAttempts, listingId } = usePostAdFlow();
-    const { watch, handleBrandChange, loadBrandsForCategory, refreshBrands } = usePostAdAction();
+    const { watch, handleBrandChange, loadBrandsForCategory, refreshBrands, createAndSelectBrand } = usePostAdAction();
     const { withCascadeConfirmation, ConfirmDialog, dialogProps } = useCascadeConfirmation();
 
     const categoryId = String(watch("categoryId") || watch("category") || "");
@@ -52,6 +52,7 @@ export function BrandSection() {
                         value={brandNameValue} 
                         onChange={(_id, name) => onBrandChange(name, _id)} 
                         onRequestSuccess={() => refreshBrands()} 
+                        onCreateBrand={createAndSelectBrand}
                         disabled={brandIsPending || isEditMode} 
                         placeholder={brandIsPending ? "Loading brands…" : "Search or select brand"} 
                         listingId={listingId} 

--- a/apps/web/src/components/user/post-ad/steps/listing-information/ModelSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-information/ModelSection.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/components/ui/utils";
 export function ModelSection() {
     const { requiresScreenSize } = usePostAdCatalog();
     const { isEditMode, form, stepValidationAttempts, listingId } = usePostAdFlow();
-    const { watch, setValue } = usePostAdAction();
+    const { watch, setValue, createAndSelectModel } = usePostAdAction();
     const { withCascadeConfirmation, ConfirmDialog, dialogProps } = useCascadeConfirmation();
 
     const categoryId = String(watch("categoryId") || watch("category") || "");
@@ -60,6 +60,7 @@ export function ModelSection() {
                         value={modelId || modelNameValue} 
                         modelDisplayName={modelNameValue}
                         onChange={(mId, mName) => onModelChange(mId, mName)}
+                        onCreateModel={createAndSelectModel}
                         onBrandResolved={(rbId, rbName) => { 
                             setValue("brandId", rbId, { shouldDirty: true }); 
                             setValue("brand", rbName, { shouldDirty: true }); 

--- a/apps/web/src/hooks/listings/useBrandCatalog.ts
+++ b/apps/web/src/hooks/listings/useBrandCatalog.ts
@@ -8,6 +8,7 @@ import {
     getModels,
     getScreenSizes,
     type Brand,
+    type DeviceModel,
 } from "@/lib/api/user/masterData";
 import logger from "@/lib/logger";
 import { sanitizeMongoObjectId } from "@/lib/listings/locationUtils";
@@ -22,6 +23,40 @@ interface UseBrandCatalogProps {
 const BRANDS_STALE_TIME = 10 * 60 * 1000; // 10 minutes
 const MODELS_STALE_TIME = 5 * 60 * 1000; // 5 minutes
 const SCREEN_SIZES_STALE_TIME = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Normalizes and merges a brand into existing brands array preserving alphabetical sorting by name.
+ */
+function mergeBrandIntoList(list: Brand[], entity: { id: string; name: string }): Brand[] {
+    const existingIndex = list.findIndex(
+        (b) => b.id === entity.id || b._id === entity.id || b.name.toLowerCase() === entity.name.toLowerCase()
+    );
+    let updated: Brand[];
+    if (existingIndex >= 0) {
+        updated = [...list];
+        updated[existingIndex] = { ...updated[existingIndex], id: entity.id, _id: entity.id, name: entity.name };
+    } else {
+        updated = [...list, { id: entity.id, _id: entity.id, name: entity.name }];
+    }
+    return updated.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+}
+
+/**
+ * Normalizes and merges a device model into existing models array preserving alphabetical sorting by name.
+ */
+function mergeModelIntoList(list: DeviceModel[], entity: { id: string; name: string; brandId?: string; categoryId?: string }): DeviceModel[] {
+    const existingIndex = list.findIndex(
+        (m) => m.id === entity.id || m._id === entity.id || m.name.toLowerCase() === entity.name.toLowerCase()
+    );
+    let updated: DeviceModel[];
+    if (existingIndex >= 0) {
+        updated = [...list];
+        updated[existingIndex] = { ...updated[existingIndex], id: entity.id, _id: entity.id, name: entity.name, brandId: entity.brandId, categoryId: entity.categoryId };
+    } else {
+        updated = [...list, { id: entity.id, _id: entity.id, name: entity.name, brandId: entity.brandId, categoryId: entity.categoryId }];
+    }
+    return updated.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+}
 
 export function useBrandCatalog({
     categoryMap,
@@ -234,6 +269,56 @@ export function useBrandCatalog({
         ]);
     }, [activeCategoryId, queryClient]);
 
+    /**
+     * Reconciles brand visibility in the React Query cache.
+     * Attempts to invalidate and await refetching; if synchronization encounters network/transport errors
+     * (timeout, cancellation, offline, transient 5xx), falls back to safely merging into the cache preserving alphabetical ordering.
+     */
+    const ensureBrandVisible = useCallback(
+        async (entity: { id: string; name: string }) => {
+            if (!activeCategoryId) return;
+            const queryKey = ["catalog", "brands", activeCategoryId];
+            try {
+                // First merge optimistically so visibility is immediate and normalized
+                queryClient.setQueryData<Brand[]>(queryKey, (oldData = []) => mergeBrandIntoList(oldData, entity));
+                // Then invalidate to ensure server consistency
+                await queryClient.invalidateQueries({ queryKey });
+            } catch (error) {
+                logger.warn(`[Catalog] ensureBrandVisible refetch failed or timed out, retaining merged cache:`, error);
+                queryClient.setQueryData<Brand[]>(queryKey, (oldData = []) => mergeBrandIntoList(oldData, entity));
+            }
+        },
+        [activeCategoryId, queryClient]
+    );
+
+    /**
+     * Reconciles device model visibility in the React Query cache for the active brand.
+     * Attempts to invalidate and await refetching; if synchronization encounters network/transport errors,
+     * falls back to safely merging into the cache preserving alphabetical ordering.
+     */
+    const ensureModelVisible = useCallback(
+        async (entity: { id: string; name: string; brandId: string }) => {
+            if (!activeCategoryId || !entity.brandId) return;
+            const queryKey = [
+                "catalog",
+                "models",
+                activeCategoryId,
+                entity.brandId,
+                modelSearch,
+            ];
+            try {
+                // First merge optimistically so visibility is immediate and normalized
+                queryClient.setQueryData<DeviceModel[]>(queryKey, (oldData = []) => mergeModelIntoList(oldData, { ...entity, categoryId: activeCategoryId }));
+                // Then invalidate to ensure server consistency
+                await queryClient.invalidateQueries({ queryKey });
+            } catch (error) {
+                logger.warn(`[Catalog] ensureModelVisible refetch failed or timed out, retaining merged cache:`, error);
+                queryClient.setQueryData<DeviceModel[]>(queryKey, (oldData = []) => mergeModelIntoList(oldData, { ...entity, categoryId: activeCategoryId }));
+            }
+        },
+        [activeCategoryId, modelSearch, queryClient]
+    );
+
     return {
         brandMap,
         availableBrands,
@@ -244,5 +329,7 @@ export function useBrandCatalog({
         loadBrandsForCategory,
         loadModelsForBrand,
         refreshBrands,
+        ensureBrandVisible,
+        ensureModelVisible,
     };
 }


### PR DESCRIPTION
## Summary
Refactors the Dynamic Brand and Model Creation flow (`Post-Ad Wizard` & `Catalog Request API`) into a strict 3-Layer Architecture (`useBrandCatalog`, `useCategoryDependents`, `useCatalogMutations`) per the SSOT and Mutex Concurrency guidelines.

Closes #102

## Architecture Separation
- **Layer 1: Query State & Cache Normalization (`useBrandCatalog.ts`)**
  - Encapsulates React Query operations (`getQueryData`, `setQueryData`).
  - Implements `mergeBrand` and `mergeModel` for alphabetical/popularity-preserved cache injections.
  - Exposes resilient `ensureBrandVisible` / `ensureModelVisible` fallback APIs when network requests or server syncs experience timeouts or errors after `201 Created`.
- **Layer 2: Selection & Clearing SSOT (`useCategoryDependents.ts`)**
  - Establishes React Hook Form as the sole source of truth for `brandId` and `modelId` selections.
  - Centralizes dependent clearing (`clearCategoryDependents`, `clearBrandDependents`) without duplicate `setValue` triggers.
- **Layer 3: Mutation Orchestrator (`useCatalogMutations.ts`)**
  - Composes atomic workflow (`POST -> ensureVisible -> select`).
  - Implements mutex concurrency protection (`activeMutationRef.current`) to prevent race conditions during rapid multi-click (`+ + +`) interactions.
- **UI Decoupling (`BrandSearchSelect`, `ModelSearchSelect`, `CatalogRequestDialog`)**
  - Excised all `localSelection` overrides and ad-hoc query cache refetches.

## Verification
- Passed 100% of TypeScript compilation checks across web and core packages.
- Passed all `@esparex/core` (`246 tests`) and `@esparex/backend-api` (`320 tests`) pre-push verification suites.
- Verified knowledge graph synchronization via `graphify update .`.
