### PR TITLE
fix(post-ad): prevent false navigation guard after successful submission

### DIFF
--- a/apps/web/src/components/user/post-ad/context/provider.tsx
+++ b/apps/web/src/components/user/post-ad/context/provider.tsx
@@ -83,7 +83,15 @@ export function PostAdProvider({
     const { setIsDirty } = useNavigation();
 
     useEffect(() => { const cleanup = suppressGoogleMapsRetryErrors(); return cleanup; }, []);
-    useEffect(() => { setIsDirty(form.formState.isDirty || listingImages.length > 0); }, [form.formState.isDirty, listingImages.length, setIsDirty]);
+    useEffect(() => {
+        // After a successful submission, the success modal becomes the terminal UI.
+        // The navigation guard must remain disabled until resetToCreateMode() starts a fresh session.
+        if (submittedAd) {
+            setIsDirty(false);
+            return;
+        }
+        setIsDirty(form.formState.isDirty || listingImages.length > 0);
+    }, [form.formState.isDirty, listingImages.length, setIsDirty, submittedAd]);
     useEffect(() => { return () => setIsDirty(false); }, [setIsDirty]);
 
     useEffect(() => {
@@ -109,7 +117,7 @@ export function PostAdProvider({
         setIsLoading(false);
     }, [clearCategoryDependents, setValue, loadBrandsForCategory, loadSparePartsForCategory, loadModelsForBrand, setListingImages]);
 
-    const resetToCreateMode = useCallback(() => { setMode('create'); setListingId(undefined); setCurrentStep(1); form.reset(); (imagesHook as any).setListingImages([]); }, [form, imagesHook]);
+    const resetToCreateMode = useCallback(() => { setMode('create'); setListingId(undefined); setCurrentStep(1); form.reset(); (imagesHook as any).setListingImages([]); setSubmittedAd(null); }, [form, imagesHook]);
     const { generateDescription } = usePostAdAiGeneration(form as any, categoryMap, availableSpareParts, setIsLoading, setFormError);
     const { toggleAllSpareParts, toggleSparePart } = usePostAdSparePartSelection(form as any, availableSpareParts);
     const { nextStep, prevStep } = usePostAdStepNavigation({ form: form as any, currentStep, setCurrentStep, setStepValidationAttempts, requiresScreenSize, categoryFilters: categorySchema?.filters ?? [], trigger });

--- a/apps/web/tests/edit-listing.spec.ts
+++ b/apps/web/tests/edit-listing.spec.ts
@@ -428,4 +428,25 @@ test.describe("📝 EDIT AD - End-to-End Regression Suite", () => {
                 .first()
         ).toBeVisible({ timeout: 10_000 });
     });
+
+    // =========================================================================
+    // TEST 11: Navigation Guard Regression Test
+    // =========================================================================
+    test("11. Navigation Guard Regression Test", async ({ page }) => {
+        await gotoEditPage(page);
+
+        const saveBtn = page.locator('button:has-text("Save Changes")');
+        await expect(saveBtn).toBeVisible();
+        await saveBtn.click();
+
+        await expect(
+            page.locator("text=Updated Successfully").or(page.locator("text=Submitted Successfully"))
+        ).toBeVisible({ timeout: 10_000 });
+
+        const doneBtn = page.locator('button:has-text("Done")');
+        await expect(doneBtn).toBeVisible();
+        await doneBtn.click();
+
+        await expect(page.locator("text=Unsaved Changes")).not.toBeVisible();
+    });
 });


### PR DESCRIPTION
## Summary

Fixes a verified Post Ad navigation guard bug where the "Unsaved Changes" dialog could appear immediately after a successful submission.

## Root Cause

After a successful submission, `setIsDirty(false)` was correctly executed. However, the provider's reactive effect immediately reasserted `isDirty` because `listingImages.length > 0` remained true. This caused the navigation guard to intercept success modal dismissal.

## Changes

- Disable navigation guard while `submittedAd` is active
- Reset `submittedAd` in `resetToCreateMode()`
- Document the lifecycle behavior
- Add Playwright regression coverage

## Verification

- ✅ Type check passed
- ✅ Existing E2E listing edit suite passed
- ✅ New Playwright regression test passed

## Out of Scope

This PR does **not** address the production spinner/blank overlay issue. That investigation remains a separate work item because the forensic audit showed the primary submission state machine completes successfully.
