### PR TITLE
fix(image): defer sharp loading until image processing is invoked

### DIFF
--- a/core/src/utils/imageProcessor.ts
+++ b/core/src/utils/imageProcessor.ts
@@ -1,9 +1,17 @@
 import { getBucketName, uploadToS3 } from './s3';
 import crypto from 'crypto';
-import sharp from 'sharp';
 import logger from './logger';
 import { env } from '../config/env';
 import { imageDomainRegistry } from "@esparex/shared";
+
+let cached: typeof import('sharp') | undefined;
+
+async function getSharp(): Promise<typeof import('sharp')> {
+    if (!cached) {
+        cached = (await import('sharp')).default as typeof import('sharp');
+    }
+    return cached;
+}
 
 let hasWarnedMissingS3InTest = false;
 const MAX_IMAGE_DIMENSION = 1600;
@@ -25,7 +33,7 @@ const optimizeWithSharp = async (
     mimeType: string
 ): Promise<{ buffer: Buffer; thumbnailBuffer: Buffer; mimeType: string; extension: string }> => {
     try {
-        const image = sharp(fileBuffer);
+        const image = (await getSharp())(fileBuffer);
         const metadata = await image.metadata();
 
         let pipeline = image;
@@ -42,7 +50,7 @@ const optimizeWithSharp = async (
             .webp({ quality: 80, effort: 4 })
             .toBuffer();
 
-        const thumbnailBuffer = await sharp(fileBuffer)
+        const thumbnailBuffer = await (await getSharp())(fileBuffer)
             .resize({
                 width: 300,
                 height: 300,


### PR DESCRIPTION
## Root Cause

`sharp` was imported eagerly at module initialization in `core/src/utils/imageProcessor.ts`:

```ts
import sharp from 'sharp';
```

This forced Node.js to resolve the `sharp` native binary at module parse time. Any test importing `AdOrchestrator` → `AdCreationService` → `imageProcessor` triggered native module resolution, even when no image processing was performed.

On CI runners where `node_modules` was cached from a different platform (e.g., `darwin-arm64` cached onto `linux-x64`), the platform-specific binary was missing, causing Jest to crash before executing any tests:



## Fix

Replaced the eager top-level `import sharp from 'sharp'` with an `async getSharp()` helper that lazy-loads the module only when image processing is actually invoked:

```ts
let cached: typeof import('sharp') | undefined;

async function getSharp(): Promise<typeof import('sharp')> {
    if (!cached) {
        cached = (await import('sharp')).default as typeof import('sharp');
    }
    return cached;
}
```

Both callsites in `optimizeWithSharp` now use `(await getSharp())(fileBuffer)`.

## Verification

- **Lint:** 0 errors
- **Type-check:** Clean
- **Tests:** 246/246 core + 312/312 backend-api passing
- **Build:** Clean production build
- **Behavior unchanged:** Same `sharp` API, same pipeline, same defaults

## Separate from Kernel PR

This fix is intentionally kept out of PR #136 (`chore/kernel-audit-refinement`). It addresses a different concern (runtime behavior around native dependencies and CI portability) and keeps each PR focused and independently rollbackable.