### PR TITLE
build(tsconfig): enable noEmitOnError across TypeScript workspaces

### DIFF
--- a/backend/api/jest.config.js
+++ b/backend/api/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     transform: {
         '^.+\\.tsx?$': ['ts-jest', {
             diagnostics: false,
-            tsconfig: '<rootDir>/tsconfig.json'
+            tsconfig: '<rootDir>/tsconfig.test.json'
         }]
     },
     moduleNameMapper: {

--- a/backend/api/tsconfig.json
+++ b/backend/api/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "resolveJsonModule": true,
+    "noEmitOnError": true,
     "lib": ["ES2023", "DOM"],
     "paths": {
       "@/*": ["src/*"],

--- a/backend/api/tsconfig.test.json
+++ b/backend/api/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmitOnError": false
+  }
+}

--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.test.json'
     }]
   }
 };

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -15,6 +15,7 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "noEmitOnError": true,
     "paths": {
       "@core/*": ["./src/*"],
       "@esparex/core/*": ["./src/*"],

--- a/core/tsconfig.test.json
+++ b/core/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmitOnError": false
+  }
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -17,7 +17,8 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmitOnError": true
   },
   "references": [
     { "path": "../packages/contracts" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "composite": true,
-    "declaration": true
+    "declaration": true,
+    "noEmitOnError": true
   },
   "files": [],
   "references": [


### PR DESCRIPTION
## What does this PR do?
Enables `noEmitOnError: true` in all emitting TypeScript workspaces (`root`, `shared`, `core`, and `backend/api`) to prevent compiles from outputting broken JavaScript when type-checking errors are present. Test suites are configured to override this using dedicated `tsconfig.test.json` configuration extensions in `core` and `backend/api` workspaces to maintain compatibility and run tests smoothly.

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `chore` — refactor / cleanup / tooling (build configuration adjustment)
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only

## Packages affected
- [x] `backend`
- [ ] `apps/web`
- [ ] `apps/admin`
- [x] `shared` (also includes `core` and `packages/*` dependencies)

## Test plan
1. **Validation Checks**: Injected a type error into `backend/api/src/index.ts` to trigger a compilation failure. Confirmed that compilation aborted (Exit: 1) and no JavaScript code was emitted to `dist/`, proving `noEmitOnError` works as intended.
2. **Type Checking**: Ran `npm run type-check` to verify that 100% of workspaces remain type-check clean.
3. **Workspace Tests**: Ran both `npm test -w @esparex/backend-api` and `npm test -w @esparex/core` to confirm all 102 Jest test suites continue to compile and pass successfully.
