### PR TITLE
fix(core): correct userCache.isReady self-assignment in unified DB path

### DIFF
--- a/core/src/config/db.ts
+++ b/core/src/config/db.ts
@@ -143,7 +143,7 @@ export function getAdminConnection(): Connection {
 
         if (isUnified) {
             userCache.conn = adminCache.conn;
-            userCache.isReady = userCache.isReady;
+            userCache.isReady = adminCache.isReady;
             logger.info('Using unified database connection for Admin and User');
         }
     }


### PR DESCRIPTION
In the unified database connection path (`isUnified = true`), `userCache.isReady` was incorrectly assigned to itself (`no-self-assign`). It should mirror `adminCache.isReady`, consistent with `userCache.conn = adminCache.conn` on the preceding line.

Discovered during post-merge linting verification. Resolves 1 ESLint error.