### PR TITLE
fix(listings): add price, imageHashes, and locationId mappings to repository adapter

### DIFF
--- a/core/src/__tests__/adapters/outbound/database/listings/MongoListingRepositoryAdapter.spec.ts
+++ b/core/src/__tests__/adapters/outbound/database/listings/MongoListingRepositoryAdapter.spec.ts
@@ -89,5 +89,26 @@ describe('MongoListingRepositoryAdapter', () => {
                 }
             }));
         });
+
+        it('should correctly map price range, imageHashes, sellerId operator, _id operator, and location.locationId string key', async () => {
+            const mockId = new mongoose.Types.ObjectId().toString();
+            const filter: ListingFilter = {
+                _id: { $ne: mockId },
+                sellerId: { $ne: mockId },
+                price: { $gte: 100, $lte: 200 },
+                imageHashes: { $in: ['hash1', 'hash2'] },
+                'location.locationId': mockId,
+            };
+
+            await adapter.count(filter);
+
+            expect(AdModel.countDocuments).toHaveBeenCalledWith(expect.objectContaining({
+                _id: { $ne: mockId },
+                sellerId: { $ne: mockId },
+                price: { $gte: 100, $lte: 200 },
+                imageHashes: { $in: ['hash1', 'hash2'] },
+                'location.locationId': new mongoose.Types.ObjectId(mockId),
+            }));
+        });
     });
 });

--- a/core/src/__tests__/services/AdDuplicateService.spec.ts
+++ b/core/src/__tests__/services/AdDuplicateService.spec.ts
@@ -1,0 +1,113 @@
+import { assessCrossUserDuplicateRisk, findExistingSelfDuplicate } from '../../domains/listings/application/ad/AdDuplicateService';
+import { getListingRepository } from '../../composition/listings';
+import mongoose from 'mongoose';
+
+jest.mock('../../composition/listings', () => ({
+    getListingRepository: jest.fn(),
+}));
+
+describe('AdDuplicateService', () => {
+    const mockRepo = {
+        findOne: jest.fn(),
+        findWithLimit: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getListingRepository as jest.Mock).mockReturnValue(mockRepo);
+    });
+
+    describe('findExistingSelfDuplicate', () => {
+        it('should query listing repository with canonical locationId and price range', async () => {
+            const sellerId = new mongoose.Types.ObjectId().toString();
+            const categoryId = new mongoose.Types.ObjectId().toString();
+            const locationId = new mongoose.Types.ObjectId().toString();
+
+            mockRepo.findOne.mockResolvedValue({ id: 'ad-123', status: 'live' });
+
+            const result = await findExistingSelfDuplicate(
+                sellerId,
+                categoryId,
+                locationId,
+                1000
+            );
+
+            expect(result).toEqual({ id: 'ad-123', status: 'live' });
+            expect(mockRepo.findOne).toHaveBeenCalledWith(expect.objectContaining({
+                sellerId,
+                categoryId,
+                locationId,
+                listingType: 'ad',
+                price: { $gte: 900, $lte: 1100 },
+                status: { $in: ['live', 'pending'] },
+                isDeleted: { $ne: true }
+            }));
+        });
+
+        it('should return null when locationId is missing', async () => {
+            const result = await findExistingSelfDuplicate(
+                'seller-1',
+                'cat-1',
+                undefined
+            );
+            expect(result).toBeNull();
+            expect(mockRepo.findOne).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('assessCrossUserDuplicateRisk', () => {
+        it('should query cross-user duplicates using sellerId exclusion, imageHashes, and price range', async () => {
+            const sellerId = new mongoose.Types.ObjectId().toString();
+            const categoryId = new mongoose.Types.ObjectId().toString();
+            const locationId = new mongoose.Types.ObjectId().toString();
+
+            mockRepo.findWithLimit.mockResolvedValue([
+                { id: 'match-123', status: 'live' }
+            ]);
+
+            const payload = {
+                categoryId,
+                location: { locationId },
+                price: 500,
+            };
+
+            const result = await assessCrossUserDuplicateRisk(
+                payload,
+                sellerId,
+                ['hash-abc', 'hash-def']
+            );
+
+            expect(result.matchedAdId).toBe('match-123');
+            expect(result.score).toBe(80);
+            expect(mockRepo.findWithLimit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    categoryId,
+                    locationId,
+                    price: { $gte: 450, $lte: 550 },
+                    sellerId: { $ne: sellerId },
+                    imageHashes: { $in: ['hash-abc', 'hash-def'] },
+                    status: { $in: ['live', 'pending'] }
+                }),
+                { createdAt: -1 },
+                5
+            );
+        });
+
+        it('should return score 0 when no cross-user listings match', async () => {
+            mockRepo.findWithLimit.mockResolvedValue([]);
+
+            const result = await assessCrossUserDuplicateRisk(
+                {
+                    categoryId: new mongoose.Types.ObjectId().toString(),
+                    location: { locationId: new mongoose.Types.ObjectId().toString() },
+                    price: 500
+                },
+                'seller-123',
+                ['hash-unique']
+            );
+
+            expect(result.score).toBe(0);
+            expect(result.matchedAdId).toBeUndefined();
+        });
+    });
+});

--- a/core/src/adapters/outbound/database/listings/MongoListingRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/listings/MongoListingRepositoryAdapter.ts
@@ -118,6 +118,15 @@ function toMongoId(id: unknown): unknown {
 function buildMongoFilter(filter: ListingFilter): Record<string, unknown> {
     const mongoFilter: Record<string, unknown> = {};
 
+    if (filter._id !== undefined) {
+        mongoFilter._id = typeof filter._id === 'object' && filter._id !== null ? filter._id : toMongoId(filter._id);
+    }
+    if (filter.price !== undefined) {
+        mongoFilter.price = filter.price;
+    }
+    if (filter.imageHashes !== undefined) {
+        mongoFilter.imageHashes = filter.imageHashes;
+    }
     if (filter.status) {
         mongoFilter.status = Array.isArray(filter.status) ? { $in: filter.status } : filter.status;
     }
@@ -146,8 +155,9 @@ function buildMongoFilter(filter: ListingFilter): Record<string, unknown> {
     if (filter.excludeStatus && filter.excludeStatus.length > 0) {
         mongoFilter.status = { ...(mongoFilter.status as Record<string, unknown> || {}), $nin: filter.excludeStatus };
     }
-    if (filter.locationId) {
-        mongoFilter['location.locationId'] = toMongoId(filter.locationId);
+    const locationIdValue = filter.locationId || (filter['location.locationId'] as string);
+    if (locationIdValue) {
+        mongoFilter['location.locationId'] = toMongoId(locationIdValue);
     }
     if (filter.locationCity) {
         mongoFilter['location.city'] = filter.locationCity;

--- a/core/src/domains/listings/application/ad/AdDuplicateService.ts
+++ b/core/src/domains/listings/application/ad/AdDuplicateService.ts
@@ -218,7 +218,7 @@ export const findExistingSelfDuplicate = async (
         status: { $in: [LISTING_STATUS.LIVE, 'pending'] },
         isDeleted: { $ne: true },
         categoryId: categoryId,
-        'location.locationId': locationId,
+        locationId,
         listingType: listingType || 'ad',
     };
 
@@ -274,7 +274,7 @@ export const assessCrossUserDuplicateRisk = async (
 
     const query: Record<string, unknown> = {
         categoryId,
-        'location.locationId': locationId,
+        locationId,
         price: priceRange,
         status: { $in: [LISTING_STATUS.LIVE, 'pending'] },
         sellerId: { $ne: sellerId },

--- a/core/src/domains/listings/ports/ListingRepositoryPort.ts
+++ b/core/src/domains/listings/ports/ListingRepositoryPort.ts
@@ -63,12 +63,15 @@ export interface ActiveListingCountFilter {
 
 export interface ListingFilter {
     session?: unknown;
-    sellerId?: string;
+    _id?: string | { $ne: string } | unknown;
+    sellerId?: string | { $ne: string };
     listingType?: ListingTypeValue;
     status?: AdStatusValue | { $in: AdStatusValue[] };
     categoryId?: string;
     brandId?: string;
     modelId?: string;
+    price?: { $gte: number; $lte: number } | number;
+    imageHashes?: { $in: string[] };
     duplicateFingerprint?: string;
     isDeleted?: boolean | { $ne: boolean };
     isSold?: boolean;


### PR DESCRIPTION
Reimplements missing repository adapter filter mappings and duplicate detection query fixes.

### Changes
- Add `price` (`{ $gte, $lte }`) and `imageHashes` (`{ $in }`) properties to `ListingFilter` interface in `ListingRepositoryPort.ts`
- Widen `sellerId` and `_id` filter types in `ListingFilter` interface to support MongoDB query operators
- Implement explicit mappings for `price`, `imageHashes`, `_id`, and `locationId` in `MongoListingRepositoryAdapter.ts`
- Update `AdDuplicateService.ts` queries to use canonical `locationId` property
- Add `AdDuplicateService.spec.ts` unit tests and expanded `MongoListingRepositoryAdapter.spec.ts` tests