### PR TITLE
fix(ci): introduce event-aware TruffleHog configuration to resolve BASE/HEAD collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,20 @@ jobs:
       - name: Validate environment contract
         run: npm run guard:env-contracts
 
-      - name: Secret Scanning (TruffleHog)
+      - name: Secret Scanning — Commit Diff Mode (TruffleHog)
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000' && github.event.before != github.event.after) }}
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
+          extra_args: --debug --only-verified
+
+      - name: Secret Scanning — Filesystem Mode (TruffleHog)
+        if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == github.event.after)) }}
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
           extra_args: --debug --only-verified
 
       - name: Validate workspace dependency graph


### PR DESCRIPTION
Fixes TruffleHog GitHub Action false failures (`BASE and HEAD commits are the same`).

### Changes
- Add conditional Commit Diff Mode scan for `pull_request` events and multi-commit `push` events (`base` vs `head` or `before` vs `after`)
- Add Filesystem Mode scan for `workflow_dispatch` events, initial pushes, and identical commit range states
- Prevent false workflow failures when BASE and HEAD resolve to identical SHAs