### PR TITLE
perf(adcard): add areAdCardListPropsEqual comparator to AdCardList (PERF-003)

### DIFF
--- a/apps/web/src/__tests__/reactRenderOptimization.spec.ts
+++ b/apps/web/src/__tests__/reactRenderOptimization.spec.ts
@@ -43,4 +43,44 @@ describe('React Component Render Optimization Comparators', () => {
 
         expect(areAdCardGridPropsEqual(prevProps, nextProps)).toBe(false);
     });
+
+    it('prevents unnecessary AdCardList re-renders when relevant props remain equal', () => {
+        const prevProps = {
+            ad: { id: 'ad-456', price: 8000, title: 'Samsung Galaxy S23' },
+            isSaved: false,
+            priority: false,
+            href: '/ads/samsung-galaxy-s23',
+            className: undefined as string | undefined,
+        };
+
+        // New object reference — same values (simulates TanStack Query refetch)
+        const nextProps = {
+            ad: { id: 'ad-456', price: 8000, title: 'Samsung Galaxy S23' },
+            isSaved: false,
+            priority: false,
+            href: '/ads/samsung-galaxy-s23',
+            className: undefined as string | undefined,
+        };
+
+        const areAdCardListPropsEqual = (p: typeof prevProps, n: typeof nextProps) =>
+            p.ad.id === n.ad.id &&
+            p.ad.price === n.ad.price &&
+            p.ad.title === n.ad.title &&
+            p.isSaved === n.isSaved &&
+            p.priority === n.priority &&
+            p.href === n.href &&
+            p.className === n.className;
+
+        expect(areAdCardListPropsEqual(prevProps, nextProps)).toBe(true);
+    });
+
+    it('triggers AdCardList re-render when saved status changes', () => {
+        const prevProps = { ad: { id: 'ad-456', price: 8000, title: 'Samsung Galaxy S23' }, isSaved: false };
+        const nextProps = { ad: { id: 'ad-456', price: 8000, title: 'Samsung Galaxy S23' }, isSaved: true };
+
+        const areAdCardListPropsEqual = (p: typeof prevProps, n: typeof nextProps) =>
+            p.ad.id === n.ad.id && p.isSaved === n.isSaved;
+
+        expect(areAdCardListPropsEqual(prevProps, nextProps)).toBe(false);
+    });
 });

--- a/apps/web/src/components/user/ad-card/AdCardList.tsx
+++ b/apps/web/src/components/user/ad-card/AdCardList.tsx
@@ -29,6 +29,18 @@ export interface AdCardListProps {
   className?: string;
 }
 
+function areAdCardListPropsEqual(prevProps: AdCardListProps, nextProps: AdCardListProps): boolean {
+  return (
+    prevProps.ad.id === nextProps.ad.id &&
+    prevProps.ad.price === nextProps.ad.price &&
+    prevProps.ad.title === nextProps.ad.title &&
+    prevProps.isSaved === nextProps.isSaved &&
+    prevProps.priority === nextProps.priority &&
+    prevProps.href === nextProps.href &&
+    prevProps.className === nextProps.className
+  );
+}
+
 export const AdCardList = memo(function AdCardList({
   ad,
   isSaved = false,
@@ -147,6 +159,6 @@ export const AdCardList = memo(function AdCardList({
       </Card>
     </AdCardLinkWrapper>
   );
-});
+}, areAdCardListPropsEqual);
 
 AdCardList.displayName = "AdCardList";


### PR DESCRIPTION
## Summary

Implements **PERF-003** — Listing Card Render Stability.

Adds `areAdCardListPropsEqual` to `AdCardList`, eliminating unnecessary re-renders caused by TanStack Query returning new `ad` object references with identical values.

---

## Root Cause

`AdCardList` used `React.memo` without a custom prop comparator, falling back to React's default shallow reference equality on the entire `ad` object. When TanStack Query returns refreshed data, each listing object receives a new reference even when content is unchanged. This caused every `AdCardList` instance in the list-view grid to re-render unnecessarily on every refetch and filter change.

`AdCardGrid` already had this optimization (`areAdCardGridPropsEqual`). `AdCardList` was the inconsistency.

---

## Investigation Evidence

| Component | `memo` | Custom Comparator | Verdict |
|---|---|---|---|
| `AdCardGrid` | ✅ | ✅ `areAdCardGridPropsEqual` | Already optimized — no action |
| `AdCardList` | ✅ | ❌ Missing | **Fixed in this PR** |
| `AdCardCover` | ✅ | — | Protected by parent |
| `AdCardMeta` | ✅ | — | Protected by parent |
| `AdCardActions` | ✅ | — | No active consumer passes `onToggleSave` |

Other candidates audited and confirmed **no action required**: `useAdCardNavigation`, `handleCardClick`, `SavedAds`, `HomeFeedClient`, `AdCardCover`, `AdCardMeta`.

---

## Change

```tsx
// apps/web/src/components/user/ad-card/AdCardList.tsx

function areAdCardListPropsEqual(
  prevProps: AdCardListProps,
  nextProps: AdCardListProps
): boolean {
  return (
    prevProps.ad.id     === nextProps.ad.id     &&
    prevProps.ad.price  === nextProps.ad.price  &&
    prevProps.ad.title  === nextProps.ad.title  &&
    prevProps.isSaved   === nextProps.isSaved   &&
    prevProps.priority  === nextProps.priority  &&
    prevProps.href      === nextProps.href      &&
    prevProps.className === nextProps.className
  );
}

export const AdCardList = memo(function AdCardList(...) { ... }, areAdCardListPropsEqual);
