### PR TITLE
chore(ci): branch-aware concurrency — preserve CI results on integration branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Integration branches (develop, main, live) must never have runs cancelled —
+  # every merge commit must produce a completed CI result for audit purposes.
+  # Feature branches and PRs cancel stale runs to keep feedback fast.
+  cancel-in-progress: ${{ !contains(fromJSON('["refs/heads/main","refs/heads/develop","refs/heads/live"]'), github.ref) }}
 
 jobs:
   # ── Job 1: Governance, unit tests, and build ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes intermittent missing CI check results on `develop` (and `main`) caused by the global `cancel-in-progress: true` concurrency setting.

---

## Problem

When multiple PRs merged into `develop` within the same CI window (~45 min), the earlier CI run was cancelled by the later one. The earlier merge commit received no completed CI status, creating gaps in the governance audit trail.

---

## Change

**File**: `.github/workflows/ci.yml` — concurrency block only.

```yaml
# Before
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

# After
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  # Integration branches must never have runs cancelled —
  # every merge commit must produce a completed CI result for audit purposes.
  # Feature branches and PRs cancel stale runs to keep feedback fast.
  cancel-in-progress: ${{ !contains(fromJSON('["refs/heads/main","refs/heads/develop","refs/heads/live"]'), github.ref) }}
