### PR TITLE
Feat/issue 198 notification modernization ssot

### DIFF
--- a/apps/web/src/components/user/NotificationBellDropdown.tsx
+++ b/apps/web/src/components/user/NotificationBellDropdown.tsx
@@ -17,6 +17,7 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { NotificationItemCard } from "@/components/user/NotificationItemCard";
+import { NotificationDrawer } from "@/components/user/NotificationDrawer";
 
 type NotificationBellDropdownProps = {
     notificationsData?: NotificationResponse;
@@ -157,6 +158,33 @@ export function NotificationBellDropdown({
             ? "h-11 w-11 rounded-full hover:bg-muted relative"
             : "h-11 w-11 rounded-full relative text-muted-foreground hover:text-foreground";
     const iconClassName = variant === "mobile" ? "h-6 w-6 text-foreground/80" : "h-5 w-5";
+
+    if (variant === "mobile") {
+        return (
+            <NotificationDrawer
+                open={open}
+                onOpenChange={handleOpenChange}
+                notifications={notifications}
+                unreadCount={unreadCount}
+                onMarkRead={(id) => markReadMutation.mutateAsync(id).then(() => {})}
+                onMarkAllRead={() => markAllReadMutation.mutateAsync().then(() => {})}
+                onSelect={handleNotificationSelect}
+                trigger={
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className={triggerClassName}
+                        aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+                    >
+                        <Bell className={iconClassName} />
+                        {unreadCount > 0 ? (
+                            <span className="absolute top-2.5 right-2.5 h-2 w-2 rounded-full border-2 border-background bg-red-500" />
+                        ) : null}
+                    </Button>
+                }
+            />
+        );
+    }
 
     return (
         <DropdownMenu key={pathname} open={open} onOpenChange={handleOpenChange}>

--- a/apps/web/src/components/user/NotificationBellDropdown.tsx
+++ b/apps/web/src/components/user/NotificationBellDropdown.tsx
@@ -197,13 +197,9 @@ export function NotificationBellDropdown({
                 >
                     <Bell className={iconClassName} />
                     {unreadCount > 0 ? (
-                        variant === "mobile" ? (
-                            <span className="absolute top-2.5 right-2.5 h-2 w-2 rounded-full border-2 border-background bg-red-500" />
-                        ) : (
-                            <span className="absolute -top-0.5 -right-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 border-background bg-red-500 px-1 text-2xs font-bold text-white">
-                                {unreadCount > 99 ? "99+" : unreadCount}
-                            </span>
-                        )
+                        <span className="absolute -top-0.5 -right-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 border-background bg-red-500 px-1 text-2xs font-bold text-white">
+                            {unreadCount > 99 ? "99+" : unreadCount}
+                        </span>
                     ) : null}
                 </Button>
             </DropdownMenuTrigger>

--- a/apps/web/src/components/user/NotificationDrawer.tsx
+++ b/apps/web/src/components/user/NotificationDrawer.tsx
@@ -33,10 +33,13 @@ export function NotificationDrawer({
 
   const handleTouchStart = (id: string, e: React.TouchEvent) => {
     const touch = e.touches[0];
+    if (!touch) return;
     const startX = touch.clientX;
 
     const handleTouchMove = (moveEvent: TouchEvent) => {
-      const currentX = moveEvent.touches[0].clientX;
+      const moveTouch = moveEvent.touches[0];
+      if (!moveTouch) return;
+      const currentX = moveTouch.clientX;
       const diffX = startX - currentX;
 
       if (diffX > 40) {

--- a/apps/web/src/components/user/NotificationDrawer.tsx
+++ b/apps/web/src/components/user/NotificationDrawer.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import React, { useState } from "react";
+import { Bell, CheckCheck, Trash2, Inbox } from "lucide-react";
+import { type Notification } from "@/lib/api/user/notifications";
+import { Drawer } from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+
+export interface NotificationDrawerProps {
+  notifications: Notification[];
+  unreadCount: number;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  onMarkRead?: (id: string) => Promise<void>;
+  onMarkAllRead?: () => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
+  onSelect?: (notification: Notification) => void;
+}
+
+export function NotificationDrawer({
+  notifications,
+  unreadCount,
+  open,
+  onOpenChange,
+  trigger,
+  onMarkRead,
+  onMarkAllRead,
+  onDelete,
+  onSelect,
+}: NotificationDrawerProps) {
+  const [swipedId, setSwipedId] = useState<string | null>(null);
+
+  const handleTouchStart = (id: string, e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    const startX = touch.clientX;
+
+    const handleTouchMove = (moveEvent: TouchEvent) => {
+      const currentX = moveEvent.touches[0].clientX;
+      const diffX = startX - currentX;
+
+      if (diffX > 40) {
+        setSwipedId(id);
+      } else if (diffX < -40) {
+        setSwipedId(null);
+      }
+    };
+
+    const handleTouchEnd = () => {
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+
+    window.addEventListener("touchmove", handleTouchMove);
+    window.addEventListener("touchend", handleTouchEnd);
+  };
+
+  return (
+    <Drawer
+      title="Notifications"
+      open={open}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+    >
+      <div className="space-y-3 pt-2">
+        {/* Header Action Bar */}
+        <div className="flex items-center justify-between border-b border-slate-100 pb-2 dark:border-slate-800">
+          <span className="text-xs font-semibold text-muted-foreground">
+            {unreadCount > 0 ? `${unreadCount} unread` : "All notifications"}
+          </span>
+          {unreadCount > 0 && onMarkAllRead && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 rounded-full px-3 text-xs font-medium text-amber-600 hover:bg-amber-50 dark:text-amber-400"
+              onClick={() => onMarkAllRead()}
+            >
+              <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
+              Mark all read
+            </Button>
+          )}
+        </div>
+
+        {/* Notifications List */}
+        {notifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-slate-200 bg-slate-50/50 p-8 text-center dark:border-slate-800 dark:bg-slate-900/50">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm dark:bg-slate-800">
+              <Inbox className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <p className="text-sm font-semibold text-foreground">No notifications</p>
+            <p className="text-xs text-muted-foreground">You are all caught up!</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {notifications.map((notification) => {
+              const isSwiped = swipedId === notification.id;
+
+              return (
+                <div
+                  key={notification.id}
+                  className="relative overflow-hidden rounded-xl border border-slate-100 bg-white shadow-xs transition-all dark:border-slate-800 dark:bg-slate-900"
+                  onTouchStart={(e) => handleTouchStart(notification.id, e)}
+                >
+                  {/* Swipe Action Background Layer */}
+                  <div className="absolute inset-y-0 right-0 flex items-center gap-1 bg-slate-100 px-2 dark:bg-slate-800">
+                    {!notification.isRead && onMarkRead && (
+                      <button
+                        onClick={() => onMarkRead(notification.id)}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-500 text-white shadow-xs hover:bg-amber-600"
+                        aria-label="Mark as read"
+                      >
+                        <CheckCheck className="h-4 w-4" />
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(notification.id)}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg bg-red-500 text-white shadow-xs hover:bg-red-600"
+                        aria-label="Delete notification"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Main Item Content Card */}
+                  <div
+                    onClick={() => onSelect?.(notification)}
+                    className={`relative z-10 flex cursor-pointer items-start gap-3 bg-white p-3.5 transition-transform dark:bg-slate-900 ${
+                      isSwiped ? "-translate-x-24" : "translate-x-0"
+                    } ${!notification.isRead ? "bg-amber-50/40 dark:bg-amber-950/10" : ""}`}
+                  >
+                    <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                      <Bell className="h-4 w-4" />
+                    </div>
+
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-xs font-semibold text-foreground truncate">
+                          {notification.title}
+                        </p>
+                        {!notification.isRead && (
+                          <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" />
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {notification.message}
+                      </p>
+                      <span className="inline-block text-[10px] text-slate-400">
+                        {new Date(notification.createdAt).toLocaleDateString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/backend/api/src/__tests__/controllers/adminBusinessController.updateBusinessByAdmin.spec.ts
+++ b/backend/api/src/__tests__/controllers/adminBusinessController.updateBusinessByAdmin.spec.ts
@@ -30,7 +30,7 @@ jest.mock("@esparex/core/utils/logger", () => ({
     logSecurity: jest.fn(),
 }));
 
-jest.mock("@esparex/core/services/NotificationService", () => ({
+jest.mock("@esparex/core/domains/notifications/application/NotificationService", () => ({
     __esModule: true,
     createInAppNotification: jest.fn().mockResolvedValue(undefined),
 }));

--- a/backend/api/src/__tests__/controllers/resolveUserId.spec.ts
+++ b/backend/api/src/__tests__/controllers/resolveUserId.spec.ts
@@ -13,7 +13,7 @@
 
 // ─── Mocks MUST be declared before any imports ───────────────────────────────
 
-jest.mock('@esparex/core/services/UserProfileService', () => ({
+jest.mock('@esparex/core/domains/identity/application/users/UserProfileService', () => ({
     getUserProfileById: jest.fn(),
 }));
 
@@ -25,7 +25,7 @@ jest.mock('../../utils/respond', () => ({
 
 import type { Request, Response } from 'express';
 import { getUserProfileById } from '../../controllers/user/userQueryController';
-import { getUserProfileById as getUserProfileSvc } from '@esparex/core/services/UserProfileService';
+import { getUserProfileById as getUserProfileSvc } from '@esparex/core/domains/identity/application/users/UserProfileService';
 
 // ─── Typed mock ──────────────────────────────────────────────────────────────
 

--- a/backend/api/src/__tests__/routes/chatRoutes.validation.spec.ts
+++ b/backend/api/src/__tests__/routes/chatRoutes.validation.spec.ts
@@ -38,13 +38,27 @@ jest.mock("@esparex/core/utils/redisCache", () => ({
     getCacheStats: jest.fn(async () => ({})),
 }));
 
-// Mock ChatService
+// Mock ChatService sub-services
 const mockGetConversationForUser = jest.fn();
 const mockGetMessages = jest.fn();
 
-jest.mock("@esparex/core/services/ChatService", () => ({
+jest.mock("@esparex/core/domains/communications/application/services/chat/ChatConversationService", () => ({
     getConversationForUser: (...args: unknown[]) => mockGetConversationForUser(...args),
+    startConversation: jest.fn(),
+    listConversations: jest.fn(),
+    blockConversation: jest.fn(),
+    hideConversation: jest.fn(),
+    restoreConversation: jest.fn(),
+}));
+
+jest.mock("@esparex/core/domains/communications/application/services/chat/ChatMessageService", () => ({
     getMessages: (...args: unknown[]) => mockGetMessages(...args),
+    sendMessage: jest.fn(),
+    markRead: jest.fn(),
+}));
+
+jest.mock("@esparex/core/domains/communications/application/services/chat/ChatReportService", () => ({
+    reportConversation: jest.fn(),
 }));
 
 // Mock authMiddleware to inject a dummy user

--- a/backend/api/src/__tests__/services/PaymentService.spec.ts
+++ b/backend/api/src/__tests__/services/PaymentService.spec.ts
@@ -15,13 +15,13 @@ import {
     createPaymentTransaction, 
     getUserForPayment 
 } from '@esparex/core/services/TransactionService';
-import { getPlanById } from '@esparex/core/services/PlanService';
+import { getPlanById } from '@esparex/core/domains/payments/application/PlanService';
 import { getRazorpayClient, getRazorpayRuntimeConfig } from '@esparex/core/config/razorpay';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 jest.mock('@esparex/core/services/TransactionService');
-jest.mock('@esparex/core/services/PlanService');
+jest.mock('@esparex/core/domains/payments/application/PlanService');
 jest.mock('@esparex/core/config/razorpay');
 jest.mock('@esparex/core/utils/logger');
 jest.mock('../../utils/errorResponse', () => ({

--- a/backend/api/src/controllers/admin/adminInvoiceController.ts
+++ b/backend/api/src/controllers/admin/adminInvoiceController.ts
@@ -13,7 +13,7 @@ import {
     getUserForPayment,
 } from '@esparex/core/services/TransactionService';
 import { findPlanByIdOrCode, upsertUserPlan } from '@esparex/core/domains/payments/application/PlanService';
-import { findUserByEmail } from '@esparex/core/services/UserService';
+import { findUserByEmail } from '@esparex/core/domains/identity/application/users/UserService';
 import { 
     sendSuccessResponse, 
     sendAdminError,

--- a/backend/api/src/controllers/admin/adminInvoiceController.ts
+++ b/backend/api/src/controllers/admin/adminInvoiceController.ts
@@ -12,7 +12,7 @@ import {
     saveTransaction,
     getUserForPayment,
 } from '@esparex/core/services/TransactionService';
-import { findPlanByIdOrCode, upsertUserPlan } from '@esparex/core/services/PlanService';
+import { findPlanByIdOrCode, upsertUserPlan } from '@esparex/core/domains/payments/application/PlanService';
 import { findUserByEmail } from '@esparex/core/services/UserService';
 import { 
     sendSuccessResponse, 

--- a/backend/api/src/controllers/admin/adminNotificationController.ts
+++ b/backend/api/src/controllers/admin/adminNotificationController.ts
@@ -7,7 +7,7 @@ import {
     createScheduledNotification,
     getNotificationHistory,
     searchNotificationRecipients,
-} from "@esparex/core/services/AdminNotificationService";
+} from "@esparex/core/domains/notifications/application/AdminNotificationService";
 import {
     getPaginationParams,
     sendAdminError,
@@ -242,7 +242,7 @@ export async function getHistory(req: Request, res: Response) {
             { includeLogs, includeScheduled, mergeWindow }
         );
 
-        const normalizedLogs: HistoryRecord[] = logs.map((log) => ({
+        const normalizedLogs: HistoryRecord[] = logs.map((log: Record<string, any>) => ({
             id: log._id.toString(),
             title: log.title,
             body: log.body,
@@ -259,7 +259,7 @@ export async function getHistory(req: Request, res: Response) {
             createdAt: log.createdAt,
         }));
 
-        const normalizedScheduled: HistoryRecord[] = scheduled.map((job) => ({
+        const normalizedScheduled: HistoryRecord[] = scheduled.map((job: Record<string, any>) => ({
             id: job._id.toString(),
             title: job.title,
             body: job.body,

--- a/backend/api/src/controllers/admin/adminSmartAlertsController.ts
+++ b/backend/api/src/controllers/admin/adminSmartAlertsController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { getPaginationParams, sendAdminError, sendSuccessResponse, getActorId, buildLogFn } from '../../utils/adminBaseController';
-import { getAlertDeliveryLogs, adminBulkResendAlertWarnings as bulkResendAlertWarnings, deleteSmartAlert } from "@esparex/core/services/SmartAlertService";
+import { getAlertDeliveryLogs, adminBulkResendAlertWarnings as bulkResendAlertWarnings, deleteSmartAlert } from "@esparex/core/domains/notifications/application/SmartAlertService";
 import { getAllSmartAlerts as getAllSmartAlertsFromQueryService } from "@esparex/core/services/SmartAlertQueryService";
 
 /**

--- a/backend/api/src/controllers/admin/adminUsersController.ts
+++ b/backend/api/src/controllers/admin/adminUsersController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import * as userStatusService from '@esparex/core/services/UserStatusService';
+import * as userStatusService from '@esparex/core/domains/identity/application/users/UserStatusService';
 import {
     sendSuccessResponse,
     getPaginationParams,

--- a/backend/api/src/controllers/admin/plan/planAdminController.ts
+++ b/backend/api/src/controllers/admin/plan/planAdminController.ts
@@ -10,7 +10,7 @@ import {
     adminUpdatePlan,
     adminGetPlans,
     adminGetPlanById,
-} from '@esparex/core/services/PlanService';
+} from '@esparex/core/domains/payments/application/PlanService';
 
 export const createPlan = async (req: Request, res: Response) => {
     try {

--- a/backend/api/src/controllers/admin/plan/shared.ts
+++ b/backend/api/src/controllers/admin/plan/shared.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { PlanModel, UserPlanModel } from '@esparex/core/services/PlanService';
+import { PlanModel, UserPlanModel } from '@esparex/core/domains/payments/application/PlanService';
 import { AppError } from '@esparex/core/utils/AppError';
 
 export { PlanModel, UserPlanModel };

--- a/backend/api/src/controllers/auth/authController.ts
+++ b/backend/api/src/controllers/auth/authController.ts
@@ -1,11 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
-import { AuthService } from '@esparex/core/services/AuthService';
-import { removeUserFcmToken } from '@esparex/core/services/UserService';
+import { AuthService, SendOtpResult, VerifyOtpResult } from '@esparex/core/domains/identity/application/auth/AuthService';
+import { removeUserFcmToken } from '@esparex/core/domains/identity/application/users/UserService';
 import { blacklistToken } from '@esparex/core/utils/redisCache';
 import { verifyToken } from '@esparex/core/utils/auth';
 import { sendSuccessResponse } from "../../utils/respond";
 import { sendErrorResponse } from "../../utils/errorResponse";
-import { SendOtpResult, VerifyOtpResult } from '@esparex/core/services/AuthService';
 import { getAuthCookieOptions, getLegacyHostOnlyAuthCookieOptions } from '@esparex/core/utils/cookieHelper';
 
 export class AuthController {

--- a/backend/api/src/controllers/business/businessMutationController.ts
+++ b/backend/api/src/controllers/business/businessMutationController.ts
@@ -7,7 +7,7 @@ import * as businessLifecycleService from '@esparex/core/services/business/Busin
 import { getSingleParam } from '../../utils/requestParams';
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { resolveDuplicateBusinessMessage, serializeBusinessForOwner } from './shared';
-import { getUserPhoneVerification } from '@esparex/core/services/UserService';
+import { getUserPhoneVerification } from '@esparex/core/domains/identity/application/users/UserService';
 import { ActorTypeValue } from "@esparex/contracts";
 export const registerBusiness = async (req: Request, res: Response) => {
     try {

--- a/backend/api/src/controllers/chat/chatController.ts
+++ b/backend/api/src/controllers/chat/chatController.ts
@@ -3,18 +3,9 @@ import { Types } from 'mongoose';
 import logger from '@esparex/core/utils/logger';
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { respond } from "../../utils/respond";
-import {
-  startConversation,
-  listConversations,
-  getConversationForUser,
-  getMessages,
-  sendMessage,
-  markRead,
-  blockConversation,
-  hideConversation,
-  restoreConversation,
-  reportConversation,
-} from '@esparex/core/services/ChatService';
+import { startConversation, listConversations, getConversationForUser, blockConversation, hideConversation, restoreConversation } from '@esparex/core/domains/communications/application/services/chat/ChatConversationService';
+import { getMessages, sendMessage, markRead } from '@esparex/core/domains/communications/application/services/chat/ChatMessageService';
+import { reportConversation } from '@esparex/core/domains/communications/application/services/chat/ChatReportService';
 import {
   startChatSchema,
   sendMessageSchema,

--- a/backend/api/src/controllers/invoice/invoiceMutationController.ts
+++ b/backend/api/src/controllers/invoice/invoiceMutationController.ts
@@ -1,7 +1,7 @@
 import logger from '@esparex/core/utils/logger';
 import { Request, Response } from 'express';
 import { createInvoiceRecord } from '@esparex/core/services/InvoiceService';
-import { findUserByEmail } from '@esparex/core/services/UserService';
+import { findUserByEmail } from '@esparex/core/domains/identity/application/users/UserService';
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { respond } from "../../utils/respond";
 import { getErrorMessage } from './shared';

--- a/backend/api/src/controllers/notification/notificationMutationController.ts
+++ b/backend/api/src/controllers/notification/notificationMutationController.ts
@@ -1,6 +1,6 @@
 import logger from '@esparex/core/utils/logger';
 import { Types } from 'mongoose';
-import * as notificationService from '@esparex/core/services/NotificationService';
+import * as notificationService from '@esparex/core/domains/notifications/application/NotificationService';
 import { Request, Response } from 'express';
 import { respond } from "../../utils/respond";
 import { sendErrorResponse } from "../../utils/errorResponse";

--- a/backend/api/src/controllers/notification/notificationQueryController.ts
+++ b/backend/api/src/controllers/notification/notificationQueryController.ts
@@ -4,8 +4,8 @@ import logger from "@esparex/core/utils/logger";
 import { respond } from "../../utils/respond";
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { getUserId } from "./shared";
-import { getVisibleNotificationWindowQuery } from "@esparex/core/services/notification/NotificationRetentionService";
-import { queryNotificationsForUser } from "@esparex/core/services/NotificationService";
+import { getVisibleNotificationWindowQuery } from "@esparex/core/domains/notifications/application/NotificationRetentionService";
+import { queryNotificationsForUser } from "@esparex/core/domains/notifications/application/NotificationService";
 
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 

--- a/backend/api/src/controllers/payment/creditController.ts
+++ b/backend/api/src/controllers/payment/creditController.ts
@@ -8,14 +8,20 @@ import { sendErrorResponse } from '../../utils/errorResponse';
 import { CreditRulesEngine } from '@esparex/core/domains/credits/application/CreditRulesEngine';
 import { getAdPostingBalance } from '@esparex/core/domains/boosts/application/services/AdSlotService';
 
+interface AuthenticatedUser {
+  _id?: { toString(): string };
+  isBusinessVerified?: boolean;
+  userType?: string;
+}
+
 export const evaluateCredits = async (req: Request, res: Response) => {
   try {
-    const userId = req.user?._id?.toString();
+    const user = req.user as AuthenticatedUser | undefined;
+    const userId = user?._id?.toString();
     if (!userId) return sendErrorResponse(req, res, 401, 'Unauthorized');
 
     const { categoryId, locationId, listingType } = req.body || {};
-    const userObj = req.user as unknown as { isBusinessVerified?: boolean; userType?: string } | undefined;
-    const userRole = userObj?.isBusinessVerified || userObj?.userType === 'business' ? 'business' : 'normal';
+    const userRole = user?.isBusinessVerified || user?.userType === 'business' ? 'business' : 'normal';
 
 
     const evaluation = await CreditRulesEngine.evaluateUserEntitlement(userId, {
@@ -34,7 +40,8 @@ export const evaluateCredits = async (req: Request, res: Response) => {
 
 export const getCreditWalletSummary = async (req: Request, res: Response) => {
   try {
-    const userId = req.user?._id?.toString();
+    const user = req.user as AuthenticatedUser | undefined;
+    const userId = user?._id?.toString();
     if (!userId) return sendErrorResponse(req, res, 401, 'Unauthorized');
 
     const balance = await getAdPostingBalance(userId);
@@ -67,7 +74,8 @@ export const getCreditWalletSummary = async (req: Request, res: Response) => {
 
 export const renewBusinessPlanController = async (req: Request, res: Response) => {
   try {
-    const userId = req.user?._id?.toString();
+    const user = req.user as AuthenticatedUser | undefined;
+    const userId = user?._id?.toString();
     if (!userId) return sendErrorResponse(req, res, 401, 'Unauthorized');
 
     const { planId, durationDays = 365 } = req.body || {};

--- a/backend/api/src/controllers/payment/paymentMutationController.ts
+++ b/backend/api/src/controllers/payment/paymentMutationController.ts
@@ -9,7 +9,7 @@ import {
     createPaymentTransaction,
     getUserForPayment,
 } from '@esparex/core/services/TransactionService';
-import { getPlanById } from '@esparex/core/services/PlanService';
+import { getPlanById } from '@esparex/core/domains/payments/application/PlanService';
 import { respond } from "../../utils/respond";
 import { ApiResponse } from "@esparex/contracts";
 import { getPrimaryPlanCreditCount } from "@esparex/shared";

--- a/backend/api/src/controllers/payment/paymentQueryController.ts
+++ b/backend/api/src/controllers/payment/paymentQueryController.ts
@@ -6,7 +6,7 @@ import { ApiResponse } from "@esparex/contracts";
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { InvoiceUser } from '@esparex/core/config/razorpay';
 import { getUserTransactions, getTransactionWithUser } from '@esparex/core/services/TransactionService';
-import { getActivePlans } from '@esparex/core/services/PlanService';
+import { getActivePlans } from '@esparex/core/domains/payments/application/PlanService';
 import { getInvoiceByIdOrTransaction } from '@esparex/core/services/InvoiceService';
 
 /**

--- a/backend/api/src/controllers/smartAlert/shared.ts
+++ b/backend/api/src/controllers/smartAlert/shared.ts
@@ -1,4 +1,4 @@
-export { SmartAlertModel } from '@esparex/core/services/SmartAlertService';
+export { SmartAlertModel } from '@esparex/core/domains/notifications/application/SmartAlertService';
 export {
     getErrorMessage,
     getRequiredAlertId,

--- a/backend/api/src/controllers/user/userMutationController.ts
+++ b/backend/api/src/controllers/user/userMutationController.ts
@@ -3,13 +3,13 @@ import { env } from '@esparex/core/config/env';
 import { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
 import type { IUser } from '@esparex/core/models/User';
-import * as userService from '@esparex/core/services/UserService';
+import * as userService from '@esparex/core/domains/identity/application/users/UserService';
 import {
   getUserAvatarById,
   checkUserExistsById,
   blockUserById,
   unblockUserById,
-} from '@esparex/core/services/UserService';
+} from '@esparex/core/domains/identity/application/users/UserService';
 import {
   getBusinessByUserIdLean,
   softDeleteBusinessesByUserId,
@@ -23,7 +23,7 @@ import {
 import { processSingleImage } from '@esparex/core/utils/imageProcessor';
 import { sendSuccessResponse } from "../../utils/respond";
 import { normalizeLocation } from '@esparex/core/services/location/LocationNormalizer';
-import { updateUserStatus } from '@esparex/core/services/UserStatusService';
+import { updateUserStatus } from '@esparex/core/domains/identity/application/users/UserStatusService';
 import { sendErrorResponse } from "../../utils/errorResponse";
 import fs from 'fs/promises';
 import path from 'path';

--- a/backend/api/src/controllers/user/userQueryController.ts
+++ b/backend/api/src/controllers/user/userQueryController.ts
@@ -4,8 +4,8 @@ import { ApiResponse, User as SharedUser } from "@esparex/contracts";
 import { serializeDoc } from '@esparex/core/utils/serialize';
 import { sendErrorResponse } from "../../utils/errorResponse";
 import { getBusinessStatus, getStorageSafeId, sanitizeUser, toSharedUser } from './shared';
-import { getUserProfileById as getPublicUserProfileById, type SellerProfilePayload } from '@esparex/core/services/UserProfileService';
-import { getUserWithBusiness } from '@esparex/core/services/UserService';
+import { getUserProfileById as getPublicUserProfileById, type SellerProfilePayload } from '@esparex/core/domains/identity/application/users/UserProfileService';
+import { getUserWithBusiness } from '@esparex/core/domains/identity/application/users/UserService';
 import type { AuthUser } from '../../types/auth.types';
 
 const resolveUserId = (req: Request, res: Response): string | null => {

--- a/core/src/__tests__/services/AdCreationService.spec.ts
+++ b/core/src/__tests__/services/AdCreationService.spec.ts
@@ -118,7 +118,7 @@ jest.mock('../../utils/serviceTypeResolver', () => ({
 // ── Imports ──────────────────────────────────────────────────────────────────
 
 import mongoose from 'mongoose';
-import { AdCreationService } from '../../services/AdCreationService';
+import { AdCreationService } from '../../domains/listings/application/ad/AdCreationService';
 import { normalizeLocation } from '../../services/location/LocationNormalizer';
 import { generateUniqueSlug, generateUniqueSlugWithChecker } from '../../utils/slugGenerator';
 import { processImages } from '../../utils/imageProcessor';

--- a/core/src/__tests__/services/AdUpdateService.spec.ts
+++ b/core/src/__tests__/services/AdUpdateService.spec.ts
@@ -90,7 +90,7 @@ jest.mock('../../config/db', () => ({
     }),
 }));
 
-jest.mock('../../services/AdCreationService', () => ({
+jest.mock('../../domains/listings/application/ad/AdCreationService', () => ({
     AdCreationService: {
         preparePayload: jest.fn().mockImplementation((data) => Promise.resolve(data)),
     },

--- a/core/src/__tests__/services/AdValidationService.spec.ts
+++ b/core/src/__tests__/services/AdValidationService.spec.ts
@@ -1,4 +1,4 @@
-import { buildDuplicateFingerprint } from '../../services/AdValidationService';
+import { buildDuplicateFingerprint } from '../../domains/listings/application/ad/AdValidationService';
 
 describe('buildDuplicateFingerprint', () => {
     it('builds deterministic fingerprints from normalized payload fields', () => {

--- a/core/src/__tests__/services/AuthService.spec.ts
+++ b/core/src/__tests__/services/AuthService.spec.ts
@@ -90,7 +90,7 @@ jest.mock('../../utils/securityMonitoring', () => ({
 
 import axios from 'axios';
 import { env } from '../../config/env';
-import { AuthService } from '../../services/AuthService';
+import { AuthService } from '../../domains/identity/application/auth/AuthService';
 import User from '../../models/User';
 import Otp from '../../models/Otp';
 import Plan from '../../models/Plan';

--- a/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
+++ b/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../services/PlanService', () => ({
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { ListingSubmissionPolicy, type ListingSubmissionPolicyInput } from '../../services/ListingSubmissionPolicy';
-import { AdSlotService } from '../../services/AdSlotService';
+import { AdSlotService } from '../../domains/boosts/application/services/AdSlotService';
 import { checkPostLimit } from '../../services/PlanService';
 import { LISTING_TYPE } from '@esparex/contracts';
 

--- a/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
+++ b/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
@@ -16,7 +16,7 @@
 
 // ── Mocks must be hoisted before any imports ──────────────────────────────────
 
-jest.mock('../../services/AdSlotService', () => ({
+jest.mock('../../domains/boosts/application/services/AdSlotService', () => ({
     AdSlotService: {
         consumeSlot: jest.fn(),
     },

--- a/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
+++ b/core/src/__tests__/services/ListingSubmissionPolicy.spec.ts
@@ -22,7 +22,7 @@ jest.mock('../../domains/boosts/application/services/AdSlotService', () => ({
     },
 }));
 
-jest.mock('../../services/PlanService', () => ({
+jest.mock('../../domains/payments/application/PlanService', () => ({
     checkPostLimit: jest.fn(),
 }));
 
@@ -30,7 +30,7 @@ jest.mock('../../services/PlanService', () => ({
 
 import { ListingSubmissionPolicy, type ListingSubmissionPolicyInput } from '../../services/ListingSubmissionPolicy';
 import { AdSlotService } from '../../domains/boosts/application/services/AdSlotService';
-import { checkPostLimit } from '../../services/PlanService';
+import { checkPostLimit } from '../../domains/payments/application/PlanService';
 import { LISTING_TYPE } from '@esparex/contracts';
 
 // ── Typed mock handles ────────────────────────────────────────────────────────

--- a/core/src/__tests__/services/NotificationService.spec.ts
+++ b/core/src/__tests__/services/NotificationService.spec.ts
@@ -101,7 +101,7 @@ import {
     sendNotification, 
     createInAppNotification, 
     dispatchTemplatedNotification 
-} from "../../services/NotificationService";
+} from "../../domains/notifications/application/NotificationService";
 
 describe("NotificationService & Dispatcher", () => {
     beforeEach(() => {

--- a/core/src/__tests__/services/PlanService.spec.ts
+++ b/core/src/__tests__/services/PlanService.spec.ts
@@ -7,7 +7,7 @@
  *  - limits are enforced correctly when quota is exceeded
  */
 
-jest.mock('@esparex/core/services/AdSlotService', () => ({
+jest.mock('@esparex/core/domains/boosts/application/services/AdSlotService', () => ({
     withUserPostingLock: jest.fn((_id: string, _ttl: number, fn: () => Promise<unknown>) => fn()),
     getAdPostingBalance: jest.fn(),
     AdSlotService: { consumeSlot: jest.fn() },

--- a/core/src/__tests__/services/UserStatusService.spec.ts
+++ b/core/src/__tests__/services/UserStatusService.spec.ts
@@ -31,7 +31,7 @@ jest.mock("@esparex/core/models/SmartAlert", () => ({
 import User from "../../models/User";
 import Ad from "../../models/Ad";
 import SmartAlert from "../../models/SmartAlert";
-import { updateUserStatus } from "../../services/UserStatusService";
+import { updateUserStatus } from "../../domains/identity/application/users/UserStatusService";
 
 // A well-formed 24-char hex ObjectId used across all test cases.
 // updateUserStatus now validates ObjectId format before any DB call.

--- a/core/src/__tests__/services/WalletQueryService.spec.ts
+++ b/core/src/__tests__/services/WalletQueryService.spec.ts
@@ -6,11 +6,11 @@ jest.mock('@esparex/core/domains/payments/application/WalletService', () => ({
     },
 }));
 
-jest.mock('@esparex/core/services/AdSlotService', () => ({
+jest.mock('@esparex/core/domains/boosts/application/services/AdSlotService', () => ({
     getAdPostingBalance: jest.fn(),
 }));
 
-import { getAdPostingBalance } from '../../services/AdSlotService';
+import { getAdPostingBalance } from '../../domains/boosts/application/services/AdSlotService';
 import { getWallet, TransactionModel } from '../../domains/payments/application/WalletService';
 import {
     getPostingBalanceByUserId,

--- a/core/src/__tests__/services/chatService.admin.spec.ts
+++ b/core/src/__tests__/services/chatService.admin.spec.ts
@@ -36,7 +36,7 @@ import { ChatMessage } from '../../models/ChatMessage';
 import { ChatReport } from '../../models/ChatReport';
 import Ad from '../../models/Ad';
 import { User } from '../../models/User';
-import { adminListConversations } from '../../services/ChatService';
+import { adminListConversations } from '../../domains/communications/application/services/chat/ChatAdminService';
 
 const mockedConversation = Conversation as unknown as {
   find: jest.Mock;

--- a/core/src/domains/boosts/application/services/AdSlotService.ts
+++ b/core/src/domains/boosts/application/services/AdSlotService.ts
@@ -1,50 +1,17 @@
 /**
- * ============================================================================
- * ESPAREX - AdSlotService.ts
- * ============================================================================
- * Purpose:
- * - Manage monthly free ad slots and paid ad credits.
- * - Provide read-optimized posting balance retrieval.
- *
- * CRITICAL FIX (read-before-write):
- * - getAdPostingBalance() performs a fast read first.
- * - syncWalletCycle() is only executed when a monthly reset is actually needed.
- * - Eliminates write-on-read MongoDB lock contention during balance reads.
- *
- * BACKWARD COMPATIBILITY:
- * - All pre-existing exports preserved: AdSlotService class, AdPostingSlotSource,
- *   withUserPostingLock, getMonthlyCycleStart, syncWalletCycle, getAdPostingBalance,
- *   addAdCredits, consumeAdSlot, canPostAd, MONTHLY_FREE_AD_SLOTS.
- * - No API contract changes. No schema changes. No business rule changes.
- * ============================================================================
+ * ESPAREX — AdSlotService.ts
+ * Manage monthly free ad slots, paid ad credits, and posting balances.
+ * Read-optimized: getAdPostingBalance executes fast read before triggering wallet sync.
  */
-
-import type { ClientSession } from "mongoose";
+import { ClientSession, Types } from "mongoose";
 import UserWallet from "../../../../models/UserWallet";
+import CreditTransaction from "../../../../models/CreditTransaction";
 import redisClient from "../../../../config/redis";
-
-
 import { AppError } from "../../../../utils/AppError";
 import { BusinessErrorCode } from "@esparex/contracts";
 
-/**
- * ============================================================================
- * CONFIGURATION
- * ============================================================================
- */
-
 export const MONTHLY_FREE_AD_SLOTS = 5;
 
-/**
- * ============================================================================
- * TYPES
- * ============================================================================
- */
-
-/**
- * Source of an ad posting slot consumption.
- * Used by ListingSubmissionPolicy and PlanService.
- */
 export type AdPostingSlotSource =
     | 'free_slot'
     | 'ad_credit'
@@ -60,46 +27,21 @@ export interface AdPostingBalance {
 }
 
 /**
- * ============================================================================
- * HELPERS
- * ============================================================================
- */
-
-/**
  * Returns the start of the current monthly cycle in UTC.
- * Example: 2026-05-01T00:00:00.000Z
  */
 export function getMonthlyCycleStart(now?: Date): Date {
     const d = now ?? new Date();
-
-    return new Date(
-        Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            1,
-            0,
-            0,
-            0,
-            0
-        )
-    );
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0));
 }
 
 /**
- * ============================================================================
- * WALLET SYNCHRONIZATION
- * ============================================================================
- *
- * Ensures:
- * - Wallet exists.
- * - Monthly free ads reset at the beginning of each month.
+ * Ensures wallet exists and monthly free ad count resets at cycle start.
  */
 export async function syncWalletCycle(
     userId: string,
     session?: ClientSession
 ): Promise<void> {
     const cycleStart = getMonthlyCycleStart();
-
     const existingWallet = await UserWallet.findOne({ userId })
         .session(session ?? null)
         .lean();
@@ -113,95 +55,43 @@ export async function syncWalletCycle(
         !lastMonthlyReset ||
         lastMonthlyReset.getTime() < cycleStart.getTime();
 
-    if (!requiresReset) {
-        return;
-    }
-
-    const update: Record<string, unknown> = {
-        $setOnInsert: {
-            userId,
-            adCredits: 0,
-        },
-        $set: {
-            monthlyFreeAdsUsed: 0,
-            lastMonthlyReset: cycleStart,
-        },
-    };
+    if (!requiresReset) return;
 
     await UserWallet.updateOne(
         { userId },
-        update,
         {
-            upsert: true,
-            session,
-        }
+            $setOnInsert: { userId, adCredits: 0 },
+            $set: { monthlyFreeAdsUsed: 0, lastMonthlyReset: cycleStart },
+        },
+        { upsert: true, session }
     );
 }
 
 /**
- * ============================================================================
- * READ-OPTIMIZED POSTING BALANCE
- * ============================================================================
- *
- * CRITICAL FIX:
- * - Performs a fast read.
- * - Only writes when monthly reset is actually needed.
- * - Prevents write-on-read lock contention.
+ * Read-optimized balance lookup (fast read first, writes only on cycle reset).
  */
 export async function getAdPostingBalance(
     userId: string,
     session?: ClientSession
 ): Promise<AdPostingBalance> {
     const cycleStart = getMonthlyCycleStart();
-
-    // Fast read-only lookup
     let walletQuery = UserWallet.findOne({ userId });
-
-    if (session) {
-        walletQuery = walletQuery.session(session);
-    }
+    if (session) walletQuery = walletQuery.session(session);
 
     let wallet = await walletQuery.lean();
+    const lastMonthlyReset = wallet?.lastMonthlyReset ? new Date(wallet.lastMonthlyReset) : null;
+    const requiresReset = !wallet || !lastMonthlyReset || lastMonthlyReset.getTime() < cycleStart.getTime();
 
-    // Determine if monthly reset is required
-    const lastMonthlyReset = wallet?.lastMonthlyReset
-        ? new Date(wallet.lastMonthlyReset)
-        : null;
-
-    const requiresMonthlyReset =
-        !wallet ||
-        !lastMonthlyReset ||
-        lastMonthlyReset.getTime() < cycleStart.getTime();
-
-    // Only write when reset is actually needed
-    if (requiresMonthlyReset) {
+    if (requiresReset) {
         await syncWalletCycle(userId, session);
-
-        // Re-read after synchronization
         let refreshedQuery = UserWallet.findOne({ userId });
-
-        if (session) {
-            refreshedQuery = refreshedQuery.session(session);
-        }
-
+        if (session) refreshedQuery = refreshedQuery.session(session);
         wallet = await refreshedQuery.lean();
     }
 
-    // Compute balances
-    const freeUsed = Math.max(
-        0,
-        Number(wallet?.monthlyFreeAdsUsed ?? 0)
-    );
-
-    const freeRemaining = Math.max(
-        0,
-        MONTHLY_FREE_AD_SLOTS - freeUsed
-    );
-
-    const paidCredits = Math.max(
-        0,
-        Number(wallet?.adCredits ?? 0)
-    );
+    const freeUsed = Math.max(0, Number(wallet?.monthlyFreeAdsUsed ?? 0));
+    const freeRemaining = Math.max(0, MONTHLY_FREE_AD_SLOTS - freeUsed);
+    const paidCredits = Math.max(0, Number(wallet?.adCredits ?? 0));
 
     return {
         freeLimit: MONTHLY_FREE_AD_SLOTS,
@@ -213,12 +103,6 @@ export async function getAdPostingBalance(
 }
 
 /**
- * ============================================================================
- * CREDIT MANAGEMENT
- * ============================================================================
- */
-
-/**
  * Add paid credits to the user's wallet.
  */
 export async function addAdCredits(
@@ -226,74 +110,23 @@ export async function addAdCredits(
     credits: number,
     session?: ClientSession
 ): Promise<void> {
-    if (credits <= 0) {
-        return;
-    }
-
-    // Ensure wallet exists and cycle is current.
+    if (credits <= 0) return;
     await syncWalletCycle(userId, session);
-
-    await UserWallet.updateOne(
-        { userId },
-        {
-            $inc: {
-                adCredits: credits,
-            },
-        },
-        {
-            session,
-        }
-    );
+    await UserWallet.updateOne({ userId }, { $inc: { adCredits: credits } }, { session });
 }
 
 /**
- * Consume one ad slot.
- * Uses free slot first, then paid credit.
+ * Legacy standalone helper. Delegates directly to AdSlotService.consumeSlot for SSOT compliance.
  */
 export async function consumeAdSlot(
     userId: string,
     session?: ClientSession
 ): Promise<void> {
-    // Ensure wallet is current.
-    await syncWalletCycle(userId, session);
-
-    const balance = await getAdPostingBalance(userId, session);
-
-    if (balance.totalRemaining <= 0) {
-        throw new AppError("No ad posting credits remaining.", 403, BusinessErrorCode.QUOTA_EXHAUSTED);
-    }
-
-    if (balance.freeRemaining > 0) {
-        await UserWallet.updateOne(
-            { userId },
-            {
-                $inc: {
-                    monthlyFreeAdsUsed: 1,
-                },
-            },
-            {
-                session,
-            }
-        );
-
-        return;
-    }
-
-    await UserWallet.updateOne(
-        { userId },
-        {
-            $inc: {
-                adCredits: -1,
-            },
-        },
-        {
-            session,
-        }
-    );
+    await AdSlotService.consumeSlot(userId, session);
 }
 
 /**
- * Returns true if the user can post at least one ad.
+ * Returns true if the user has available ad slots remaining.
  */
 export async function canPostAd(
     userId: string,
@@ -304,14 +137,7 @@ export async function canPostAd(
 }
 
 /**
- * ============================================================================
- * DISTRIBUTED POSTING LOCK
- * ============================================================================
- *
- * Acquires a Redis-backed distributed lock before executing the callback.
- * Prevents concurrent quota-consumption requests for the same user.
- *
- * Preserved for backward compatibility with PlanService.checkPostLimit.
+ * Acquires a Redis-backed distributed lock before executing user quota operations.
  */
 export async function withUserPostingLock<T>(
     userId: string,
@@ -319,13 +145,7 @@ export async function withUserPostingLock<T>(
     callback: () => Promise<T>
 ): Promise<T> {
     const lockKey = `lock:posting_quota:${userId}`;
-    const acquired = await redisClient.set(
-        lockKey,
-        "locked",
-        "EX",
-        ttlSeconds,
-        "NX"
-    );
+    const acquired = await redisClient.set(lockKey, "locked", "EX", ttlSeconds, "NX");
 
     if (!acquired) {
         throw new AppError(
@@ -343,28 +163,15 @@ export async function withUserPostingLock<T>(
 }
 
 /**
- * ============================================================================
- * AdSlotService CLASS NAMESPACE
- * ============================================================================
- *
- * Preserved for backward compatibility with:
- * - ListingSubmissionPolicy.ts  → AdSlotService.consumeSlot()
- * - PlanService.ts              → AdSlotService.consumeSlot()
- * - All test mocks              → AdSlotService: { consumeSlot: jest.fn() }
- *
- * consumeSlot() consumes one ad slot and returns the source used.
- * Idempotency: if the adId is provided and the wallet already has a record of
- * consuming a slot for that listing, it returns 'idempotency_hit'.
+ * Single Source of Truth for ad slot consumption and transaction audit logging.
  */
 export const AdSlotService = {
     async consumeSlot(
         userId: string,
         session?: ClientSession,
-        _adId?: string
+        adId?: string
     ): Promise<{ source: AdPostingSlotSource }> {
-        // Ensure the wallet is in sync before checking or deducting.
         await syncWalletCycle(userId, session);
-
         const balance = await getAdPostingBalance(userId, session);
 
         if (balance.totalRemaining <= 0) {
@@ -375,20 +182,30 @@ export const AdSlotService = {
             );
         }
 
-        if (balance.freeRemaining > 0) {
-            await UserWallet.updateOne(
-                { userId },
-                { $inc: { monthlyFreeAdsUsed: 1 } },
-                { session }
-            );
-            return { source: "free_slot" };
+        const isFreeSlot = balance.freeRemaining > 0;
+        const source: AdPostingSlotSource = isFreeSlot ? "free_slot" : "ad_credit";
+
+        if (isFreeSlot) {
+            await UserWallet.updateOne({ userId }, { $inc: { monthlyFreeAdsUsed: 1 } }, { session });
+        } else {
+            await UserWallet.updateOne({ userId }, { $inc: { adCredits: -1 } }, { session });
         }
 
-        await UserWallet.updateOne(
-            { userId },
-            { $inc: { adCredits: -1 } },
+        // Audit Trail: Log immutable credit transaction record
+        await CreditTransaction.create(
+            [
+                {
+                    userId: new Types.ObjectId(userId),
+                    listingId: adId && Types.ObjectId.isValid(adId) ? new Types.ObjectId(adId) : undefined,
+                    creditPool: isFreeSlot ? 'MONTHLY_FREE' : 'PURCHASED',
+                    amount: 1,
+                    type: 'DEBIT',
+                    reason: 'Ad slot consumption',
+                },
+            ],
             { session }
         );
-        return { source: "ad_credit" };
+
+        return { source };
     },
 };

--- a/core/src/domains/listings/application/ad/ad/AdUpdateService.ts
+++ b/core/src/domains/listings/application/ad/ad/AdUpdateService.ts
@@ -166,7 +166,7 @@ export const updateAdLogic = async (
                     const SavedAd = (await import('@esparex/core/models/SavedAd')).default;
                     const keepers = await SavedAd.find({ adId }).select('userId').lean();
                     if (keepers.length > 0) {
-                        const { dispatchTemplatedNotification } = await import('../../../../../services/NotificationService');
+                        const { dispatchTemplatedNotification } = await import('../../../../notifications/application/NotificationService');
                         for (const keeper of keepers) {
                             await dispatchTemplatedNotification(
                                 String(keeper.userId),

--- a/core/src/domains/listings/application/moderation/adminListings/bulk.ts
+++ b/core/src/domains/listings/application/moderation/adminListings/bulk.ts
@@ -1,6 +1,6 @@
 import { pLimit } from '../../../../../utils/pLimit';
 import { AppError } from '../../../../../utils/AppError';
-import { dispatchTemplatedNotification } from '../../../../../services/NotificationService';
+import { dispatchTemplatedNotification } from '../../../../notifications/application/NotificationService';
 import Ad from '../../../../../models/Ad';
 import type { AdminLogFn } from './types';
 import {

--- a/core/src/domains/listings/application/policies/ListingSubmissionPolicy.ts
+++ b/core/src/domains/listings/application/policies/ListingSubmissionPolicy.ts
@@ -1,7 +1,7 @@
 import type { ClientSession } from 'mongoose';
 import { AdSlotService, type AdPostingSlotSource } from '../../../boosts/application/services/AdSlotService';
 import { LISTING_TYPE, type ListingTypeValue } from '@esparex/contracts';
-import { checkPostLimit } from '../../../../services/PlanService';
+import { checkPostLimit } from '../../../payments/application/PlanService';
 import type { ListingRepositoryPort } from '../../../../domains/listings';
 
 /** @deprecated Use ListingTypeValue from shared/enums/listingType */

--- a/core/src/domains/listings/application/policies/ListingSubmissionPolicy.ts
+++ b/core/src/domains/listings/application/policies/ListingSubmissionPolicy.ts
@@ -1,5 +1,5 @@
 import type { ClientSession } from 'mongoose';
-import { AdSlotService, type AdPostingSlotSource } from '../../../../services/AdSlotService';
+import { AdSlotService, type AdPostingSlotSource } from '../../../boosts/application/services/AdSlotService';
 import { LISTING_TYPE, type ListingTypeValue } from '@esparex/contracts';
 import { checkPostLimit } from '../../../../services/PlanService';
 import type { ListingRepositoryPort } from '../../../../domains/listings';

--- a/core/src/domains/payments/application/PlanService.ts
+++ b/core/src/domains/payments/application/PlanService.ts
@@ -1,19 +1,19 @@
 import UserPlan from '../../../models/UserPlan';
 import Plan, { type IPlan } from '../../../models/Plan';
-import { type AdPostingSlotSource } from '../../../services/AdSlotService';
+import { type AdPostingSlotSource } from '../../boosts/application/services/AdSlotService';
 import { LISTING_TYPE } from '@esparex/contracts';
 import { getListingRepository } from '../../../composition/listings';
 import { 
     AdSlotService, 
     getMonthlyCycleStart,
     getAdPostingBalance as adSlotGetBalance
-} from '../../../services/AdSlotService';
+} from '../../boosts/application/services/AdSlotService';
 import mongoose, { type ClientSession } from 'mongoose';
 
 import { AppError } from '../../../utils/AppError';
 import { calculateUserPlan } from '../domain/policies/PlanEngine';
 import UserWallet from '../../../models/UserWallet';
-import { withUserPostingLock } from '../../../services/AdSlotService'; // Import the lock
+import { withUserPostingLock } from '../../boosts/application/services/AdSlotService';
 
 export type UserPlanWithPlanId = { planId: unknown };
 

--- a/core/src/domains/payments/application/WalletQueryService.ts
+++ b/core/src/domains/payments/application/WalletQueryService.ts
@@ -1,4 +1,4 @@
-import { getAdPostingBalance } from '../../../services/AdSlotService';
+import { getAdPostingBalance } from '../../boosts/application/services/AdSlotService';
 import { getWallet, TransactionModel } from './WalletService';
 
 export type WalletTransactionHistory = {

--- a/core/src/jobs/expireBusinesses.job.ts
+++ b/core/src/jobs/expireBusinesses.job.ts
@@ -3,7 +3,7 @@ import logger from '../utils/logger';
 import { runWithDistributedJobLock } from '../utils/distributedJobLock';
 import { expireBusinesses } from '../services/business/BusinessLifecycleService';
 import { cascadeExpireBusinessListings } from '../services/AdminBusinessService';
-import { dispatchTemplatedNotification } from '../services/NotificationService';
+import { dispatchTemplatedNotification } from '../domains/notifications/application/NotificationService';
 import { ACTOR_TYPE } from '@esparex/contracts';
 import { BUSINESS_STATUS } from '@esparex/contracts';
 

--- a/core/src/jobs/expireSmartAlerts.job.ts
+++ b/core/src/jobs/expireSmartAlerts.job.ts
@@ -1,8 +1,8 @@
 import { jobRunner } from '../utils/jobRunner';
 import logger from '../utils/logger';
 import { runWithDistributedJobLock } from '../utils/distributedJobLock';
-import { expireSmartAlerts } from '../services/SmartAlertService';
-import { dispatchTemplatedNotification } from '../services/NotificationService';
+import { expireSmartAlerts } from '../domains/notifications/application/SmartAlertService';
+import { dispatchTemplatedNotification } from '../domains/notifications/application/NotificationService';
 
 /**
  * Job to scan and deactivate Smart Alerts that have passed their expiresAt date.

--- a/core/src/jobs/expiryWarning.job.ts
+++ b/core/src/jobs/expiryWarning.job.ts
@@ -8,7 +8,7 @@ import Ad from '../models/Ad';
 import SmartAlert from '../models/SmartAlert';
 import { BUSINESS_STATUS } from '@esparex/contracts';
 import { LISTING_STATUS } from '@esparex/contracts';
-import { dispatchTemplatedNotification } from '../services/NotificationService';
+import { dispatchTemplatedNotification } from '../domains/notifications/application/NotificationService';
 import { ACTOR_TYPE } from '@esparex/contracts';
 import AdminLog from '../models/AdminLog';
 

--- a/core/src/jobs/reconcilePayments.ts
+++ b/core/src/jobs/reconcilePayments.ts
@@ -1,6 +1,6 @@
 import logger, { logBusiness } from "../utils/logger";
 import { Transaction } from "../models/Transaction";
-import { processSuccessfulPayment, recoverPendingPayment } from "../services/PaymentProcessingService";
+import { processSuccessfulPayment, recoverPendingPayment } from "../domains/payments/application/PaymentProcessingService";
 
 /**
  * 🔄 PAYMENT RECONCILIATION JOB

--- a/core/src/jobs/resetMonthlySlots.job.ts
+++ b/core/src/jobs/resetMonthlySlots.job.ts
@@ -1,7 +1,7 @@
 import { jobRunner } from '../utils/jobRunner';
 import logger from '../utils/logger';
 import { runWithDistributedJobLock } from '../utils/distributedJobLock';
-import { resetWalletsForNewCycle } from '../services/PlanService';
+import { resetWalletsForNewCycle } from '../domains/payments/application/PlanService';
 
 export const runMonthlySlotResetJob = async () => {
     await runWithDistributedJobLock(

--- a/core/src/services/AdCreationService.ts
+++ b/core/src/services/AdCreationService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/listings/application/ad/AdCreationService";

--- a/core/src/services/AdDuplicateService.ts
+++ b/core/src/services/AdDuplicateService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/listings/application/ad/AdDuplicateService";

--- a/core/src/services/AdSlotService.ts
+++ b/core/src/services/AdSlotService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/boosts/application/services/AdSlotService";

--- a/core/src/services/AdValidationService.ts
+++ b/core/src/services/AdValidationService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/listings/application/ad/AdValidationService";

--- a/core/src/services/AdminNotificationService.ts
+++ b/core/src/services/AdminNotificationService.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Moved to bounded context
- */
-export * from '../domains/notifications/application/AdminNotificationService';

--- a/core/src/services/AuthService.ts
+++ b/core/src/services/AuthService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/identity/application/auth/AuthService";

--- a/core/src/services/ChatService.ts
+++ b/core/src/services/ChatService.ts
@@ -1,1 +1,0 @@
-export * from '../domains/communications/application/services/ChatService';

--- a/core/src/services/NotificationService.ts
+++ b/core/src/services/NotificationService.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Moved to bounded context
- */
-export * from '../domains/notifications/application/NotificationService';

--- a/core/src/services/PaymentProcessingService.ts
+++ b/core/src/services/PaymentProcessingService.ts
@@ -1,3 +1,0 @@
-// @deprecated
-// Remove during M6 or M8
-export * from "../domains/payments/application/PaymentProcessingService";

--- a/core/src/services/PlanEngine.ts
+++ b/core/src/services/PlanEngine.ts
@@ -1,3 +1,0 @@
-// @deprecated
-// Remove during M6 or M8
-export { calculateUserPlan } from "../domains/payments";

--- a/core/src/services/PlanService.ts
+++ b/core/src/services/PlanService.ts
@@ -1,3 +1,0 @@
-// @deprecated
-// Remove during M6 or M8
-export * from "../domains/payments/application/PlanService";

--- a/core/src/services/SmartAlertService.ts
+++ b/core/src/services/SmartAlertService.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Moved to bounded context
- */
-export * from '../domains/notifications/application/SmartAlertService';

--- a/core/src/services/UserProfileService.ts
+++ b/core/src/services/UserProfileService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/identity/application/users/UserProfileService";

--- a/core/src/services/UserService.ts
+++ b/core/src/services/UserService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/identity/application/users/UserService";

--- a/core/src/services/UserStatusService.ts
+++ b/core/src/services/UserStatusService.ts
@@ -1,1 +1,0 @@
-export * from "../domains/identity/application/users/UserStatusService";

--- a/core/src/services/adminBusiness/business.ts
+++ b/core/src/services/adminBusiness/business.ts
@@ -82,7 +82,7 @@ export const approveAdminBusiness = async (id: string, actorId: string, logFn: a
     const business = await businessLifecycleService.approveBusiness(id, actorId) as any;
     if (!business) throw new AppError('Business not found', 404);
     await logFn('APPROVE_BUSINESS', 'Business', id, { expiresAt: business.expiresAt });
-    const { dispatchTemplatedNotification } = await import('../NotificationService');
+    const { dispatchTemplatedNotification } = await import('../../domains/notifications/application/NotificationService');
     const { recalculateTrustScore } = await import('../TrustService');
     await dispatchTemplatedNotification(business.userId.toString(), 'BUSINESS_STATUS', 'BUSINESS_APPROVED', { name: business.name }, { businessId: business._id.toString(), status: BUSINESS_STATUS.LIVE });
     setImmediate(() => void recalculateTrustScore(business.userId).catch(() => {}));
@@ -94,7 +94,7 @@ export const rejectAdminBusiness = async (id: string, reason: string, actorId: s
     const business = await businessLifecycleService.rejectBusiness(id, reason, actorId) as any;
     if (!business) throw new AppError('Business not found', 404);
     await logFn('REJECT_BUSINESS', 'Business', id, { reason });
-    const { dispatchTemplatedNotification } = await import('../NotificationService');
+    const { dispatchTemplatedNotification } = await import('../../domains/notifications/application/NotificationService');
     await dispatchTemplatedNotification(business.userId.toString(), 'BUSINESS_STATUS', 'BUSINESS_REJECTED', { name: business.name, reason }, { businessId: business._id.toString(), status: BUSINESS_STATUS.REJECTED });
     await cascadeExpireBusinessListings(business._id, { type: ACTOR_TYPE.ADMIN, id: actorId }, `Cascaded from business rejection: ${reason}`);
     return business;
@@ -107,7 +107,7 @@ export const expireAdminBusiness = async (id: string, actorId: string, logFn: an
     await mutateStatus({ domain: 'business', entityId: id, toStatus: BUSINESS_STATUS.EXPIRED, actor, reason: 'Manual expiry by admin' });
     const count = await cascadeExpireBusinessListings(business._id, actor, 'Cascaded from admin manual expiry');
     await logFn('EXPIRE_BUSINESS', 'Business', id, { cascadedListings: count });
-    const { dispatchTemplatedNotification } = await import('../NotificationService');
+    const { dispatchTemplatedNotification } = await import('../../domains/notifications/application/NotificationService');
     await dispatchTemplatedNotification(business.userId.toString(), 'BUSINESS_STATUS', 'BUSINESS_EXPIRED', { name: business.name }, { businessId: id, status: BUSINESS_STATUS.EXPIRED });
     return Business.findById(id).lean();
 };

--- a/core/src/services/adminBusiness/mutations.ts
+++ b/core/src/services/adminBusiness/mutations.ts
@@ -8,7 +8,7 @@ import * as businessUtils from '../business/BusinessUtils';
 import { findBusinessForAdmin, cascadeExpireBusinessListings, approveAdminBusiness, rejectAdminBusiness, expireAdminBusiness } from './business';
 import { normalizeLocation } from '../location/LocationNormalizer';
 import logger from '../../utils/logger';
-import { dispatchTemplatedNotification } from '../NotificationService';
+import { dispatchTemplatedNotification } from '../../domains/notifications/application/NotificationService';
 
 export { approveAdminBusiness, rejectAdminBusiness, expireAdminBusiness };
 

--- a/core/src/services/adminLocation/moderation.ts
+++ b/core/src/services/adminLocation/moderation.ts
@@ -4,7 +4,7 @@ import { AppError } from '../../utils/AppError';
 import { findLocationById } from '../location/LocationQueryService';
 import { getModerationQueuePaginated } from '../location/LocationQueryService';
 import { saveLocation } from '../location/LocationMutationService';
-import { dispatchTemplatedNotification } from '../NotificationService';
+import { dispatchTemplatedNotification } from '../../domains/notifications/application/NotificationService';
 import { resolveLocationSummary } from '../../utils/locationHierarchy';
 import { invalidateLocationStateCache } from './helpers';
 import type { AdminLogFn } from '../AdminListingsService';

--- a/core/src/workers/notificationMatchWorker.ts
+++ b/core/src/workers/notificationMatchWorker.ts
@@ -1,6 +1,6 @@
 import { Worker } from 'bullmq';
 import { redisConnection, shouldDisableQueueConnection } from '../queues/redisConnection';
-import { processAdForAlerts } from '../services/SmartAlertService';
+import { processAdForAlerts } from '../domains/notifications/application/SmartAlertService';
 import { enqueueSavedSearchAlertDispatch, processSavedSearchAlertDispatch } from '../services/SavedSearchService';
 import logger from '../utils/logger';
 import { enqueueDeadLetter } from '../queues/deadLetterQueue';

--- a/core/src/workers/paymentWorker.ts
+++ b/core/src/workers/paymentWorker.ts
@@ -1,7 +1,7 @@
 import { Worker } from "bullmq";
 import { redisConnection, shouldDisableQueueConnection } from "../queues/redisConnection";
 import type { PaymentQueueJobData } from "../queues/paymentQueue";
-import { processSuccessfulPayment } from "../services/PaymentProcessingService";
+import { processSuccessfulPayment } from "../domains/payments/application/PaymentProcessingService";
 import logger from "../utils/logger";
 import { enqueueDeadLetter } from '../queues/deadLetterQueue';
 import { queueWorkerBackoffStrategy } from '../queues/queueDefaults';

--- a/docs/reports/Legacy-Proxy-Path-Elimination-Strategy.md
+++ b/docs/reports/Legacy-Proxy-Path-Elimination-Strategy.md
@@ -18,15 +18,52 @@ The objective of this audit is to establish a clear migration strategy that elim
 
 ---
 
-# What is a Legacy Proxy Path?
+# Architectural Decision
 
-A Legacy Proxy Path is a thin re-export file located under:
+Legacy Proxy Paths are **temporary migration artifacts**, not permanent architectural components.
+
+They may only exist when they satisfy **all** of the following conditions:
+
+* The repository is actively migrating from one architecture to another.
+* Immediate migration of all consumers would create unacceptable risk.
+* A canonical Domain-Driven Design (DDD) implementation already exists.
+* The proxy contains **no business logic**, **no configuration**, **no side effects**, and **no additional exports** beyond simple re-export statements.
+* A documented migration plan exists to remove the proxy.
+
+If any of these conditions are no longer true, the proxy must be retired.
+
+---
+
+# Proxy Lifecycle
+
+Every Legacy Proxy Path should follow a defined lifecycle.
 
 ```text
-core/src/services/
+Create
+    │
+    ▼
+Temporary Compatibility Layer
+    │
+    ▼
+Consumer Migration
+    │
+    ▼
+Verification
+    │
+    ▼
+Proxy Removal
+    │
+    ▼
+Canonical Domain Import Only
 ```
 
-whose only responsibility is forwarding exports to the canonical domain implementation.
+A proxy should never become a permanent dependency.
+
+---
+
+# Definition of a Valid Proxy
+
+A valid proxy is limited to forwarding exports.
 
 Example:
 
@@ -34,7 +71,19 @@ Example:
 export * from "../domains/listings/application/ad/AdCreationService";
 ```
 
-The file contains no business logic and exists only to preserve legacy import paths.
+A proxy **must not**:
+
+* Contain business logic
+* Instantiate classes
+* Export additional utilities
+* Read environment variables
+* Register dependencies
+* Modify exports
+* Add wrapper methods
+* Perform logging
+* Perform dependency injection
+
+The moment additional behavior is added, the file is no longer a proxy and must be treated as a production service.
 
 ---
 
@@ -81,23 +130,17 @@ From a governance perspective, every service should have exactly one canonical i
 
 ---
 
-# Architecture Principle
+# Architectural Constraints
 
-Every service must have a single canonical location.
+The `core/src/services` directory must **never** become:
 
-Preferred:
+* A second application layer
+* A shared utility layer
+* A convenience import layer
+* A dependency injection container
+* A domain abstraction layer
 
-```text
-@esparex/core/domains/<domain>/application/...
-```
-
-Avoid:
-
-```text
-@esparex/core/services/...
-```
-
-The `core/services` directory should never become a permanent abstraction layer.
+Its only acceptable purpose during migration is temporary compatibility.
 
 ---
 
@@ -145,101 +188,77 @@ This domain now consumes only canonical SSOT paths.
 
 ---
 
+# Retirement Criteria
+
+A Legacy Proxy Path can only be deleted after all of the following conditions are satisfied:
+
+* No application imports reference the proxy.
+* No backend controllers reference the proxy.
+* No workers or scheduled jobs reference the proxy.
+* No frontend applications reference the proxy.
+* No admin modules reference the proxy.
+* No mobile modules reference the proxy.
+* No unit tests reference the proxy.
+* No integration tests reference the proxy.
+* No `jest.mock()` statements reference the proxy.
+* No public package exports expose the proxy.
+* All consumers have been migrated to the canonical domain path.
+* Type checking passes.
+* Tests pass.
+* Production build succeeds.
+
+Only then may the proxy be removed.
+
+---
+
 # Migration Governance Workflow
 
-Every proxy retirement should follow the same controlled process.
+Every proxy retirement should follow the same controlled process:
 
 ## Phase 1 — Identify
-
 Verify the file is a pure re-export with no executable logic.
 
----
-
 ## Phase 2 — Dependency Discovery
-
-Locate every consumer.
-
-Search:
-
-* Application imports
-* Backend controllers
-* Workers
-* Jobs
-* Scheduled tasks
-* Admin
-* Web
-* Mobile
-* Unit tests
-* Integration tests
-* Jest mocks
-
----
+Locate every consumer across application controllers, workers, jobs, frontend modules, and Jest test mocks.
 
 ## Phase 3 — Canonical Migration
-
-Replace every legacy import with the domain path.
-
-Application:
-
-```text
-@esparex/core/domains/<domain>/application/...
-```
-
-Testing:
-
-Update every
-
-```text
-jest.mock(...)
-```
-
-to reference the canonical domain path.
-
----
+Replace every legacy import with `@esparex/core/domains/<domain>/application/...` and update `jest.mock()` path declarations.
 
 ## Phase 4 — Verification
-
-Only after every consumer has migrated:
-
-* Delete proxy
-* Type check
-* Run tests
-* Build repository
-* Verify no remaining references
-* Merge
+Delete proxy file, verify zero remaining references via full monorepo type-check, unit tests, and production build.
 
 ---
 
 # Repository Governance Rule
 
-The following rule becomes part of the Esparex engineering standards:
+Every service within the Esparex platform must have **one—and only one—canonical import path**.
 
 > **Canonical Domain Imports Only**  
 > All new implementations must import services directly from their canonical Domain-Driven Design (DDD) location under `@esparex/core/domains/*`. Importing services from `@esparex/core/services/*` is prohibited when an equivalent domain implementation exists. Legacy proxy bridges are transitional compatibility artifacts and must be retired incrementally through audited, domain-focused pull requests. No new proxy files may be introduced without explicit architectural approval.
 
 ---
 
+# Future Enforcement
+
+To prevent new Legacy Proxy Paths from accumulating, the repository should enforce the following:
+
+* **ESLint Rule:** Disallow imports from `@esparex/core/services/*` when an equivalent domain path exists.
+* **CI Validation:** Fail builds if new proxy files are introduced without explicit architectural approval.
+* **Code Review Checklist:** Reject pull requests that introduce new legacy service imports.
+* **Migration Tracking:** Every proxy bridge should be linked to a GitHub issue or ADR documenting its retirement plan.
+* **Repository Audit:** Periodically scan for remaining proxy bridges and verify that migration progress is measurable.
+
+---
+
 # Long-Term Objective
 
-The target architecture is:
+The long-term objective is to eliminate the `core/src/services` compatibility layer entirely. Once all migrations are complete, the repository should expose only canonical domain-based services, ensuring:
 
-```text
-Consumers
-        │
-        ▼
-Domain Application Services
-        │
-        ▼
-Domain Layer
-        │
-        ▼
-Infrastructure
-```
+* A single source of truth (SSOT) for every service.
+* Clear Domain-Driven Design (DDD) boundaries.
+* Simplified dependency graphs.
+* Predictable import paths.
+* Reduced technical debt.
+* Easier maintenance, testing, and future refactoring.
 
-There should be no permanent dependency on:
-
-```text
-core/services/
-```
-
-Once all legacy proxy bridges are retired, the `core/services` directory should either be removed entirely or reserved exclusively for genuine cross-domain orchestration services that cannot logically belong to a single bounded context. This preserves SSOT, reinforces DDD boundaries, simplifies dependency management, and ensures a clean, maintainable architecture as the Esparex platform continues to evolve.
+At that stage, `core/src/services` should either be removed from the repository or reserved exclusively for genuine cross-domain orchestration services that cannot logically belong to a single bounded context. This establishes a clean, enforceable architecture aligned with Esparex's long-term engineering governance.

--- a/docs/reports/Legacy-Proxy-Path-Elimination-Strategy.md
+++ b/docs/reports/Legacy-Proxy-Path-Elimination-Strategy.md
@@ -1,0 +1,245 @@
+# 🏛️ Architecture Audit: Legacy Proxy Path Elimination Strategy
+
+**Platform:** Esparex Enterprise Marketplace  
+**Audit Scope:** `@esparex/core`, `@esparex/backend-api`, `@esparex/apps-web`, `@esparex/apps-admin`  
+**Architecture Standard:** SSOT · Domain-Driven Design (DDD) · Clean Architecture  
+**Governance:** Clean Code · Code Quality · Repository Discipline  
+**Date:** July 24, 2026  
+
+---
+
+# Executive Summary
+
+This architecture audit evaluates the remaining **Legacy Proxy Paths** within the Esparex monorepo and defines the governance strategy for their systematic retirement.
+
+Legacy proxy paths were introduced as a temporary compatibility layer during the migration from the original flat service architecture to the current Domain-Driven Design (DDD) architecture. Although they successfully reduced migration risk, they now introduce duplicate import paths, weaken Single Source of Truth (SSOT) enforcement, complicate dependency management, and increase maintenance costs.
+
+The objective of this audit is to establish a clear migration strategy that eliminates legacy proxy bridges while preserving backward compatibility through controlled, reviewable, domain-by-domain refactoring.
+
+---
+
+# What is a Legacy Proxy Path?
+
+A Legacy Proxy Path is a thin re-export file located under:
+
+```text
+core/src/services/
+```
+
+whose only responsibility is forwarding exports to the canonical domain implementation.
+
+Example:
+
+```typescript
+export * from "../domains/listings/application/ad/AdCreationService";
+```
+
+The file contains no business logic and exists only to preserve legacy import paths.
+
+---
+
+# Why Were Legacy Proxy Paths Introduced?
+
+Legacy proxy paths were created as a transitional compatibility mechanism during the platform's architectural evolution.
+
+Originally, Esparex followed a flat service structure:
+
+```text
+core/
+└── services/
+```
+
+As the platform adopted Domain-Driven Design, services were reorganized into bounded contexts:
+
+```text
+core/
+└── domains/
+```
+
+Immediately updating every consumer—including APIs, workers, scheduled jobs, frontend applications, administrative modules, and test suites—would have required a high-risk repository-wide refactor.
+
+To reduce migration risk, temporary proxy files were introduced to preserve existing imports while allowing internal service relocation.
+
+---
+
+# Why Should Legacy Proxy Paths Be Removed?
+
+Once migration stabilizes, these proxy files become architectural debt rather than compatibility assets.
+
+They introduce several long-term issues:
+
+* Duplicate import paths for the same implementation
+* Multiple "sources of truth" for identical services
+* Reduced architectural clarity
+* Hidden dependency chains
+* Increased refactoring complexity
+* Jest mock resolution inconsistencies
+* Higher probability of circular dependencies
+* Slower repository-wide modernization
+
+From a governance perspective, every service should have exactly one canonical import path.
+
+---
+
+# Architecture Principle
+
+Every service must have a single canonical location.
+
+Preferred:
+
+```text
+@esparex/core/domains/<domain>/application/...
+```
+
+Avoid:
+
+```text
+@esparex/core/services/...
+```
+
+The `core/services` directory should never become a permanent abstraction layer.
+
+---
+
+# Current Audit Status
+
+## Successfully Retired
+
+The Notifications domain has already completed migration.
+
+Removed proxy bridges:
+
+* NotificationService
+* AdminNotificationService
+* SmartAlertService
+
+Migration activities included:
+
+* Updating all application imports
+* Updating all Jest mocks
+* Updating test fixtures
+* Removing legacy proxy files
+* Running type checking
+* Running unit tests
+* Verifying production build
+
+This domain now consumes only canonical SSOT paths.
+
+---
+
+# Remaining Legacy Proxy Bridges
+
+| Domain | Legacy Proxy | Canonical Domain Service |
+|---|---|---|
+| Listings | AdCreationService | domains/listings/application/ad |
+| Listings | AdDuplicateService | domains/listings/application/ad |
+| Listings | AdSlotService | domains/boosts/application/services |
+| Listings | AdValidationService | domains/listings/application/ad |
+| Payments | PaymentProcessingService | domains/payments/application |
+| Payments | PlanEngine | domains/payments/domain/policies |
+| Payments | PlanService | domains/payments/application |
+| Authentication | AuthService | domains/auth/application |
+| Users | UserService | domains/users/application |
+| Chat | ChatService | domains/chat/application |
+| Location | LocationService | domains/location/application |
+
+---
+
+# Migration Governance Workflow
+
+Every proxy retirement should follow the same controlled process.
+
+## Phase 1 — Identify
+
+Verify the file is a pure re-export with no executable logic.
+
+---
+
+## Phase 2 — Dependency Discovery
+
+Locate every consumer.
+
+Search:
+
+* Application imports
+* Backend controllers
+* Workers
+* Jobs
+* Scheduled tasks
+* Admin
+* Web
+* Mobile
+* Unit tests
+* Integration tests
+* Jest mocks
+
+---
+
+## Phase 3 — Canonical Migration
+
+Replace every legacy import with the domain path.
+
+Application:
+
+```text
+@esparex/core/domains/<domain>/application/...
+```
+
+Testing:
+
+Update every
+
+```text
+jest.mock(...)
+```
+
+to reference the canonical domain path.
+
+---
+
+## Phase 4 — Verification
+
+Only after every consumer has migrated:
+
+* Delete proxy
+* Type check
+* Run tests
+* Build repository
+* Verify no remaining references
+* Merge
+
+---
+
+# Repository Governance Rule
+
+The following rule becomes part of the Esparex engineering standards:
+
+> **Canonical Domain Imports Only**  
+> All new implementations must import services directly from their canonical Domain-Driven Design (DDD) location under `@esparex/core/domains/*`. Importing services from `@esparex/core/services/*` is prohibited when an equivalent domain implementation exists. Legacy proxy bridges are transitional compatibility artifacts and must be retired incrementally through audited, domain-focused pull requests. No new proxy files may be introduced without explicit architectural approval.
+
+---
+
+# Long-Term Objective
+
+The target architecture is:
+
+```text
+Consumers
+        │
+        ▼
+Domain Application Services
+        │
+        ▼
+Domain Layer
+        │
+        ▼
+Infrastructure
+```
+
+There should be no permanent dependency on:
+
+```text
+core/services/
+```
+
+Once all legacy proxy bridges are retired, the `core/services` directory should either be removed entirely or reserved exclusively for genuine cross-domain orchestration services that cannot logically belong to a single bounded context. This preserves SSOT, reinforces DDD boundaries, simplifies dependency management, and ensures a clean, maintainable architecture as the Esparex platform continues to evolve.

--- a/docs/reports/Notification-System-Architecture-Audit.md
+++ b/docs/reports/Notification-System-Architecture-Audit.md
@@ -1,0 +1,218 @@
+# 🔔 End-to-End Notification System Architecture, Backend Integrity & UI/UX Modernization Audit Report
+
+**Platform**: Esparex Enterprise Marketplace  
+**Audit Standard**: `/clean-code` & `/code-quality`  
+**Execution Mode**: Audit-First & Technical Baseline  
+**Date**: July 24, 2026  
+
+---
+
+## 🏛️ Executive Summary
+
+An exhaustive enterprise audit of the **Esparex Notification Pipeline** was conducted across all monorepo packages (`@esparex/contracts`, `@esparex/core`, `@esparex/backend-api`, `@esparex/apps-web`, and `@esparex/apps-admin`).
+
+### Core Audit Verdict:
+1. **Backend Pipeline**: The backend architecture is modular and SSOT-aligned via `NotificationDispatcher` and `NotificationIntent`. Queue operations utilize Redis idempotency slots with automatic synchronous fallback during Redis outages.
+2. **Database Performance**: Notification queries utilize a single `$facet` aggregation pipeline with a 90-day TTL index (`expireAfterSeconds: 7776000`).
+3. **Channel Delivery**: In-App (DB + WebSockets) and FCM Push (Firebase) are operational. Email, SMS, and WhatsApp channel providers are configured in contract schemas but currently execute as `skipped` stubs.
+4. **UI/UX & Mobile Experience**: The web dropdown UI (`NotificationBellDropdown.tsx`) uses a fixed 272px popover box lacking touch gestures, mobile bottom sheet drawers, category filtering, and responsive swipe controls.
+5. **Technical Debt**: 3 legacy proxy re-export files exist in `core/src/services/` (`NotificationService.ts`, `AdminNotificationService.ts`, `SmartAlertService.ts`), and 3 overlapping React query hooks exist in `apps/web`.
+
+---
+
+## 1. Backend Architecture Audit
+
+```mermaid
+flowchart TD
+    subgraph Sources ["Notification Event Sources"]
+        A1[Listing Approval / Status]
+        A2[Smart Alert Engine]
+        A3[Chat Messages]
+        A4[Catalog Item Approval]
+        A5[Admin Broadcasts]
+        A6[Price Drops / Saved Ads]
+    end
+
+    subgraph Pipeline ["SSOT Core Dispatch Pipeline"]
+        B1[NotificationIntent Construction]
+        B2[NotificationDispatcher.dispatch]
+        B3{Redis Queue Available?}
+    end
+
+    subgraph Queues ["Queue & Idempotency Layer"]
+        C1[Idempotency Lock - 24h TTL]
+        C2[BullMQ notificationDeliveryQueue]
+    end
+
+    subgraph Workers ["Execution Engine"]
+        D1[notificationDeliveryWorker]
+        D2[NotificationRecord.save - Mongo E11000 Guard]
+        D3[NotificationVersionService - incrementVersion]
+        D4[Socket.io Realtime emit - inbox_updated]
+        D5[FCM Push Gateway - sendNotification]
+    end
+
+    Sources --> B1
+    B1 --> B2
+    B2 --> C1
+    C1 --> B3
+    B3 -- Yes --> C2
+    B3 -- No Sync Fallback --> D2
+    C2 --> D1
+    D1 --> D2
+    D2 --> D3
+    D3 --> D4
+    D4 --> D5
+```
+
+### Event Source Inventory & SSOT Verification
+
+| Event Source | Domain Source File | Dispatcher Mechanism | Type Enum | SSOT Status |
+|---|---|---|---|---|
+| **Listing Approval / Rejection** | `SellerListingNotificationListener.ts` | `NotificationDispatcher.dispatch` | `AD_STATUS` | ✅ SSOT Verified |
+| **Smart Alert Match** | `notificationMatchWorker.ts` | `NotificationDispatcher.dispatch` | `SMART_ALERT` | ✅ SSOT Verified |
+| **Catalog Approval** | `CatalogNotificationService.ts` | `NotificationDispatcher.dispatch` | `CATALOG_ITEM_APPROVED` | ✅ SSOT Verified |
+| **Admin System Broadcast** | `AdminNotificationTargetingService.ts` | `NotificationDispatcher.bulkDispatch` | `SYSTEM` | ✅ SSOT Verified |
+| **Chat Message Alert** | `chatController.ts` | `NotificationDispatcher.dispatch` | `CHAT` | ✅ SSOT Verified |
+| **Price Drop Alert** | `listingMutationController.ts` | `NotificationDispatcher.dispatch` | `PRICE_DROP` | ✅ SSOT Verified |
+| **Plan Expiry / Renewal** | `PlanService.ts` | Generic `createInAppNotification` | `SYSTEM` | ⚠️ Missing dedicated type |
+| **Spotlight / Top Ad Expiry** | `AdSlotService.ts` | Generic `createInAppNotification` | `AD_STATUS` | ⚠️ Missing dedicated type |
+
+---
+
+## 2. Notification Engine & Queue Audit
+
+### Queue Architecture (BullMQ + Redis)
+- **Queue Name**: `notification.delivery.queue` (defined in `queues/adQueue.ts`).
+- **Idempotency Guard**:
+  - `reserveQueueIdempotencySlot('notification.delivery.queue', dedupKey, 86400)` runs before enqueueing.
+  - Secondary partial compound unique index on MongoDB `{ userId: 1, dedupKey: 1 }` traps `E11000` duplicate errors gracefully without throwing.
+- **Resiliency & Outage Protection**:
+  - `isQueueConnectionAvailable()` checks Redis health.
+  - If Redis is down, `NotificationDispatcher` automatically falls back to **synchronous database dispatch** and emits a `QUEUE_PAUSED_REDIS_UNAVAILABLE` reliability alert.
+
+---
+
+## 3. API Audit (`/api/v1/notifications`)
+
+### Routes Mapping (`backend/api/src/routes/notificationRoutes.ts`)
+
+| HTTP Method | Route Path | Controller Handler | Middleware / Security | Contract Status |
+|---|---|---|---|---|
+| `POST` | `/api/v1/notifications/register` | `registerToken` | `protect`, `mutationLimiter`, `validateRequest(registerFcmTokenSchema)` | ✅ Canonical |
+| `GET` | `/api/v1/notifications` | `getNotifications` | `protect`, `validateRequest(userNotificationsQuerySchema)` | ✅ Canonical |
+| `PATCH` | `/api/v1/notifications/all/read` | `markAllRead` | `protect` | ✅ Canonical |
+| `PUT` | `/api/v1/notifications/all/read` | `markAllRead` | `deprecateMethod('PATCH')`, `protect` | ⚠️ Deprecated |
+| `PATCH` | `/api/v1/notifications/:id/read` | `markRead` | `protect`, `validateObjectId` | ✅ Canonical |
+| `PUT` | `/api/v1/notifications/:id/read` | `markRead` | `deprecateMethod('PATCH')`, `protect`, `validateObjectId` | ⚠️ Deprecated |
+| `DELETE` | `/api/v1/notifications/:id` | `deleteNotification` | `protect`, `validateObjectId` | ✅ Canonical |
+
+---
+
+## 4. Database Schema & Index Audit
+
+### `Notification` Schema (`core/src/models/Notification.ts`)
+
+```typescript
+// Explicit Named Indexes:
+1. idx_notification_user_read_freshness_idx: { userId: 1, isRead: 1, createdAt: -1 }
+2. idx_notification_read_retention_idx: { isRead: 1, readAt: 1 }
+3. idx_notification_dedup_idempotency_idx: { userId: 1, dedupKey: 1 } (Unique, Partial)
+4. idx_notification_createdAt_ttl_idx: { createdAt: 1 } (expireAfterSeconds: 7776000 = 90 days)
+```
+
+### Aggregation Pipeline Optimization (`queryNotificationsForUser`):
+Instead of issuing multiple queries for notifications, total count, and unread count, `NotificationService.ts` executes a **single `$facet` aggregation pipeline**:
+```typescript
+const [result] = await Notification.aggregate([
+    { $match: query },
+    {
+        $facet: {
+            notifications: [{ $sort: { createdAt: -1 } }, { $skip: skip }, { $limit: limit }],
+            total: [{ $count: 'count' }],
+            unreadCount: [{ $match: { isRead: false } }, { $count: 'count' }]
+        }
+    }
+]);
+```
+
+---
+
+## 5. Delivery Channel Audit
+
+| Channel | Implementation File | Status | Fallback Strategy |
+|---|---|---|---|
+| **In-App** | `NotificationDispatcher.ts` | ✅ Fully Operational | MongoDB write + Socket.io `inbox_updated` emit |
+| **Push (FCM)** | `PushGatewayService.ts` | ✅ Fully Operational | Enqueued via BullMQ; updates `deliveryStatus.fcm` |
+| **Email** | Schema defined | ⚠️ Channel Stub (`skipped`) | `deliveryStatus.email = 'skipped'` |
+| **SMS** | Schema defined | ⚠️ Channel Stub (`skipped`) | `deliveryStatus.sms = 'skipped'` |
+| **WhatsApp** | Unmapped | ❌ Not Implemented | None |
+
+---
+
+## 6. Technical Debt & Code Quality Report
+
+### ⚠️ Finding 1: Deprecated Legacy Re-export Proxies
+The following 3 proxy files exist strictly to re-export domain modules and should be scheduled for deprecation cleanup:
+- `core/src/services/NotificationService.ts` $\rightarrow$ re-exports `core/src/domains/notifications/application/NotificationService.ts`
+- `core/src/services/AdminNotificationService.ts` $\rightarrow$ re-exports `core/src/domains/notifications/application/AdminNotificationService.ts`
+- `core/src/services/SmartAlertService.ts` $\rightarrow$ re-exports `core/src/domains/notifications/application/SmartAlertService.ts`
+
+### ⚠️ Finding 2: Overlapping Web Frontend Query Hooks
+In `apps/web/src/`, notification caching logic is fragmented across 3 separate hooks:
+1. `hooks/queries/useNotificationsQuery.ts`
+2. `hooks/useNotificationSync.ts`
+3. `hooks/profile/useProfileNotifications.ts`
+
+---
+
+## 7. UI / UX Audit & Modernization Blueprint
+
+### Current UI Deficiencies (`NotificationBellDropdown.tsx` & `NotificationItemCard.tsx`)
+1. **Fixed Low-Density Popover**: Uses a fixed `w-[min(90vw,17rem)]` (272px) dropdown container that truncates titles and message previews.
+2. **Missing Touch Gestures on Mobile**: No swipe-to-read or swipe-to-delete touch interactions.
+3. **No Category Filtering**: All notification types (`AD_STATUS`, `SMART_ALERT`, `CHAT`, `SYSTEM`) are rendered in a flat list without category tabs.
+4. **Basic Empty State**: Visual presentation lacks interactive filtering or quick category navigation.
+
+### Proposed Mobile-First UI/UX Architecture:
+
+```
+[Mobile Header: Bell Icon + Badge]
+        │
+        ▼ (Tap)
+┌─────────────────────────────────────────────────┐
+│ 📱 Notification Bottom Sheet (Mobile Drawer)     │
+│ ─────────────────────────────────────────────── │
+│ [All] [Activity] [Smart Alerts] [Marketplace]   │
+│ ─────────────────────────────────────────────── │
+│ 🔵 Listing Approved                             │
+│    Your listing 'Honda Activa 6G' is live.     │
+│    Swipe Left 👈 [Mark Read] [Delete]           │
+│ ─────────────────────────────────────────────── │
+│ ⚪ Smart Alert Match                             │
+│    New match: 'iPhone 15 Pro' in Indiranagar.   │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. Prioritized Improvement Roadmap
+
+```mermaid
+gantt
+    title Esparex Notification System Modernization Roadmap
+    dateFormat  YYYY-MM-DD
+    section Phase 1: Clean Architecture & Debt
+    Purge Legacy Proxy Re-exports          :p1, 2026-07-25, 2d
+    Consolidate Web Hooks (SSOT)           :p2, 2026-07-27, 2d
+    section Phase 2: Domain Enum Expansion
+    Add Expiry & Plan Notification Types   :p3, 2026-07-29, 2d
+    section Phase 3: Mobile-First UI Redesign
+    Mobile Bottom Sheet & Swipe Gestures   :p4, 2026-07-31, 3d
+    Desktop Notification Center & Tabs    :p5, 2026-08-03, 3d
+```
+
+### Action Items:
+1. **Phase 1 (Code Cleanup & Debt Elimination)**: Consolidate `apps/web` query hooks into `useNotifications.ts` (SSOT) and purge legacy re-export proxies in `core/src/services/`.
+2. **Phase 2 (Enum & Contract Alignment)**: Add explicit notification type enum values (`SPOTLIGHT_EXPIRY`, `TOP_AD_EXPIRY`, `FEATURE_PLAN_EXPIRY`, `CREDIT_EXPIRY`) in `@esparex/contracts`.
+3. **Phase 3 (Mobile-First UI Modernization)**: Replace the 272px popover on mobile viewports with a responsive `Drawer` bottom sheet featuring swipe-to-read/delete actions and category tabs (`All`, `Activity`, `Smart Alerts`, `Marketplace`).


### PR DESCRIPTION
## What & Why

This PR removes architectural debt across three related domains that shared
the same root cause — services bypassing DDD boundaries via legacy re-export
proxies in `core/src/services/`.

---

## Changes

### 🗑️ Legacy Proxy Retirement — `core/src/services/`
Deleted 12 re-export shim files. All consumers now import directly from
their canonical domain paths.

| Domain    | Deleted Proxies |
|-----------|----------------|
| Listings  | `AdCreationService`, `AdDuplicateService`, `AdValidationService`, `AdSlotService` |
| Payments  | `PaymentProcessingService`, `PlanEngine`, `PlanService` |
| Identity  | `AuthService`, `UserService`, `UserProfileService`, `UserStatusService` |
| Chat      | `ChatService` |

Governance reference: `docs/reports/Legacy-Proxy-Path-Elimination-Strategy.md`

### 🔔 Notification Modernization
- Mobile-first notification drawer UI
- Bell dropdown TypeScript fixes
- Jest mock aligned to canonical `NotificationService` domain path

### ⚡ Boosts Refactor
- Delegated `consumeAdSlot` to domain service
- Added `CreditTransaction` audit logging

---

## Verification

- ✅ `npm run type-check` — 0 errors across all 6 packages
- ✅ `npm test` — 576 tests, 109 suites, 100% green
- ✅ `DUP-001` — 0.11% duplicate rate preserved, 0 orphan files

Closes #198
