### PR TITLE
fix(web): fix popular plan badge tailwind purge and consolidate dialog primitives

### DIFF
--- a/apps/web/src/components/user/BoostPlanDialog.tsx
+++ b/apps/web/src/components/user/BoostPlanDialog.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Button } from "@esparex/ui";
-import { Badge } from "../ui/badge";
 import {
+  Button,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "../ui/dialog";
+} from "@esparex/ui";
+import { Badge } from "../ui/badge";
 import { Card, CardContent } from "../ui/card";
 import {
   Zap,

--- a/apps/web/src/components/user/profile/tabs/PlansTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/PlansTab.tsx
@@ -7,6 +7,12 @@ import type { ProfilePlan, ProfilePlanType } from "../types";
 
 type PlanCard = Omit<ProfilePlan, "type"> & { type: string };
 
+const POPULAR_BADGE_CLASSES: Record<string, string> = {
+    Spotlight: "bg-amber-500 text-white",
+    "More Ads": "bg-blue-600 text-white",
+    "Alert Slots": "bg-emerald-600 text-white",
+};
+
 interface PlansTabProps {
     dynamicPlans: PlanCard[];
     currentPlan: string;
@@ -43,7 +49,7 @@ export function PlansTab({
                     .map((plan) => (
                     <Card key={plan.id} className={plan.popular ? `border-2 ${colorClass} relative gap-0` : "gap-0"}>
                         {plan.popular && (
-                            <Badge className={`absolute -top-2 left-1/2 transform -translate-x-1/2 bg-${colorClass.split('-')[1]}-600 text-xs text-white`}>
+                            <Badge className={`absolute -top-2 left-1/2 transform -translate-x-1/2 text-xs font-semibold ${POPULAR_BADGE_CLASSES[plan.type] || "bg-primary text-white"}`}>
                                 Popular
                             </Badge>
                         )}


### PR DESCRIPTION
## Summary

Workstream 1 of the Payments & Subscriptions Module Audit.

This PR fixes a production Tailwind CSS badge render bug caused by dynamic template string interpolation (`bg-${colorClass.split('-')[1]}-600`) and consolidates dialog imports in `BoostPlanDialog.tsx` to canonical `@esparex/ui` primitives.

---

## Detailed Changes

### 1. Fix Tailwind CSS Dynamic Purge Bug (`PlansTab.tsx`)
- **`PlansTab.tsx`**: Added static `POPULAR_BADGE_CLASSES` dictionary mapping plan types (`Spotlight`, `More Ads`, `Alert Slots`) to concrete Tailwind CSS classes in [PlansTab.tsx](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/profile/tabs/PlansTab.tsx#L45). Replaced string splitting logic to ensure badges render with valid background colors in production builds.

### 2. Consolidate Dialog Primitives (`BoostPlanDialog.tsx`)
- **`BoostPlanDialog.tsx`**: Replaced local `../ui/dialog` imports with canonical `@esparex/ui` `Dialog` primitives in [BoostPlanDialog.tsx](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/BoostPlanDialog.tsx#L7).

---

## Verification Results

- [x] **TypeScript Type Check**: `npm run type-check` passed with 0 errors across all monorepo packages.
- [x] **Next.js Web Build**: `npm run build -w @esparex/apps-web` compiled successfully (39 static/dynamic pages compiled).
- [x] **Zero Logic Mutation**: Checkout orchestration, wallet verification, and payment API integration remain 100% untouched.
