### PR TITLE
refactor(location): adopt canonical Spinner primitive and normalize focus rings

### DIFF
--- a/apps/web/src/components/location/components/LocationResultsList.tsx
+++ b/apps/web/src/components/location/components/LocationResultsList.tsx
@@ -63,7 +63,7 @@ export function LocationResultsList({
                                         <button
                                             key={`fallback-${loc.id || index}`}
                                             onMouseDown={(e) => { e.preventDefault(); void onSelect(loc); }}
-                                            className="flex items-start gap-2 w-full px-3 py-2 rounded-xl hover:bg-accent text-left"
+                                            className="flex items-start gap-2 w-full px-3 py-2 rounded-xl hover:bg-accent text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                                         >
                                             <MapPin className="mt-0.5 h-3 w-3 text-muted-foreground shrink-0" />
                                             <span className="min-w-0">
@@ -88,7 +88,7 @@ export function LocationResultsList({
                                 onMouseDown={(e) => { e.preventDefault(); void onSelect(loc); }}
                                 className={cn(
                                     "flex items-start gap-2 w-full px-3 py-2.5 text-left transition-colors rounded-xl",
-                                    "hover:bg-accent cursor-pointer",
+                                    "hover:bg-accent cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                                     selectedIndex === index && "bg-accent"
                                 )}
                             >

--- a/apps/web/src/components/location/components/LocationSelectorPanel.tsx
+++ b/apps/web/src/components/location/components/LocationSelectorPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertCircle, Search, Target, X } from "lucide-react";
-import { Button } from "@esparex/ui";
+import { Button, Spinner } from "@esparex/ui";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/components/ui/utils";
 
@@ -109,7 +109,10 @@ export function LocationSelectorPanel({
                             disabled={disabled}
                         />
                         {isSearching ? (
-                            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+                            <Spinner
+                                size="sm"
+                                className="absolute right-3 top-1/2 -translate-y-1/2"
+                            />
                         ) : query ? (
                             <button onClick={handleClearQuery} className="absolute right-3 top-1/2 -translate-y-1/2" type="button" aria-label="Clear search">
                                 <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Architectural Audit & Remediation for the **Category & Location Subsystem**.

Delivered in **2 atomic commits** on a single PR branch (`feat/issue-category-location-audit`):

1. `94324f33`: `refactor(location): adopt canonical Spinner primitive`
   Replaces the custom raw DIV animated loading spinner (`border-primary border-t-transparent animate-spin`) in `LocationSelectorPanel.tsx` with the canonical `@esparex/ui` `<Spinner size="sm" />` primitive.

2. `fc2a6498`: `fix(location): improve keyboard focus visibility for search results`
   Adds `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to location search result selection buttons in `LocationResultsList.tsx`.

---

## Detailed Changes

### Commit 1 — `refactor(location): adopt canonical Spinner primitive`
- **`LocationSelectorPanel.tsx`**: Replaced custom raw DIV spinner with `<Spinner size="sm" className="absolute right-3 top-1/2 -translate-y-1/2" />` in [LocationSelectorPanel.tsx](file:///Users/admin/Desktop/Esparex/apps/web/src/components/location/components/LocationSelectorPanel.tsx#L112).

### Commit 2 — `fix(location): improve keyboard focus visibility for search results`
- **`LocationResultsList.tsx`**: Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to result selection buttons in [LocationResultsList.tsx](file:///Users/admin/Desktop/Esparex/apps/web/src/components/location/components/LocationResultsList.tsx#L66).

---

## Verification Results

- [x] **TypeScript Type Check**: `npm run type-check` passed with 0 errors across all monorepo packages.
- [x] **Next.js Web Build**: `npm run build -w @esparex/apps-web` compiled successfully (39 static/dynamic pages compiled).
- [x] **Accessibility (WCAG 2.2 AA)**: Clear focus-visible outline rings on location item selection triggers.
- [x] **Zero Business Logic Mutation**: Location context, search hooks, and location resolution algorithms remain 100% untouched.
