### PR TITLE
fix(web): add aria-pressed and focus rings to service type toggle buttons

### DIFF
--- a/apps/web/src/components/user/post-service/PostServiceForm.tsx
+++ b/apps/web/src/components/user/post-service/PostServiceForm.tsx
@@ -209,8 +209,9 @@ export function PostServiceForm({ editServiceId }: { editServiceId?: string }) {
                                             key={typeId}
                                             type="button"
                                             onClick={() => toggleServiceType(typeId)}
+                                            aria-pressed={selected}
                                             className={cn(
-                                                "rounded-xl border px-3 py-3 text-left text-sm font-semibold transition-all",
+                                                "rounded-xl border px-3 py-3 text-left text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                                                 selected
                                                     ? "bg-primary border-primary text-white shadow-sm"
                                                     : "bg-white border-slate-100 text-foreground-secondary hover:border-slate-200"


### PR DESCRIPTION
## Summary

Architectural Audit & Remediation for the **Post Service & Spare Parts Forms Subsystem**.

This PR adds WAI-ARIA `aria-pressed={selected}` state attributes and standardized `:focus-visible` interaction outline ring styling (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`) to the multi-select service type toggle buttons in `PostServiceForm.tsx`. This enables screen readers to accurately announce button toggle state (`pressed` / `not pressed`) while providing keyboard users with clear visual focus indicators.

---

## Detailed Changes

- **`PostServiceForm.tsx`**: Added `aria-pressed={selected}` and `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to service type toggle buttons in [PostServiceForm.tsx](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/post-service/PostServiceForm.tsx#L209).

---

## Verification Results

- [x] **TypeScript Type Check**: `npm run type-check` passed with 0 errors across all monorepo packages.
- [x] **Next.js Web Build**: `npm run build -w @esparex/apps-web` compiled successfully (39 static/dynamic pages compiled).
- [x] **WAI-ARIA Accessibility**: Screen readers announce pressed state (`aria-pressed="true" / "false"`).
- [x] **Zero Business Logic Mutation**: RHF form state, array toggling logic (`toggleServiceType`), Zod validation, and service creation submission workflows remain 100% untouched.
