### PR TITLE
fix: eliminate oversized bottom padding and viewport-height scaling issues

### DIFF
--- a/apps/web/src/app/(private)/account/_shell/AccountPageShell.tsx
+++ b/apps/web/src/app/(private)/account/_shell/AccountPageShell.tsx
@@ -38,7 +38,7 @@ export function AccountPageShell({ tab, listingSubTab, messagesView, conversatio
         void router.push(getPageRoute(page, { adId, category, businessId, serviceId }));
     };
 
-    if (loading) return <div className="flex items-center justify-center min-h-screen"><Spinner size="xl" label="Loading your account" /></div>;
+    if (loading) return <div className="flex items-center justify-center min-h-[60vh]"><Spinner size="xl" label="Loading your account" /></div>;
 
     return (
         <ProfileSettingsSidebar

--- a/apps/web/src/components/user/BrowseListingsView.tsx
+++ b/apps/web/src/components/user/BrowseListingsView.tsx
@@ -125,7 +125,7 @@ export function BrowseListingsView<TItem, TFilters>({
   };
 
   return (
-    <div className="min-h-screen bg-slate-50/40">
+    <div className="bg-slate-50/40">
       <BrowseFiltersBar
         {...sharedFilterProps}
         respectMobileChromePolicy={respectMobileChromePolicy}

--- a/apps/web/src/components/user/BrowseResultsPanel.tsx
+++ b/apps/web/src/components/user/BrowseResultsPanel.tsx
@@ -119,8 +119,8 @@ export function BrowseResultsPanel<TItem>({
             <div
               className={
                 view === "list"
-                  ? "flex flex-col gap-3 pb-8"
-                  : "grid grid-cols-1 min-[375px]:grid-cols-2 gap-3 pb-8 md:gap-5 md:grid-cols-3 lg:grid-cols-4"
+                  ? "flex flex-col gap-3"
+                  : "grid grid-cols-1 min-[375px]:grid-cols-2 gap-3 md:gap-5 md:grid-cols-3 lg:grid-cols-4"
               }
             >
               {items.map((item, index) => (

--- a/apps/web/src/components/user/ProfileSettingsSidebar.tsx
+++ b/apps/web/src/components/user/ProfileSettingsSidebar.tsx
@@ -322,7 +322,7 @@ export function ProfileSettingsSidebar({
   };
 
   return (
-    <div className="bg-gray-50 min-h-screen">
+    <div className="bg-gray-50">
       {/* UNIFIED RESPONSIVE ACCOUNT HEADER (Single Instance) */}
       <AccountHeader
         activeTab={activeTab}

--- a/apps/web/src/components/user/SellerProfilePage.tsx
+++ b/apps/web/src/components/user/SellerProfilePage.tsx
@@ -40,7 +40,7 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
     };
 
     return (
-        <main className="min-h-screen bg-slate-50 pb-20">
+        <div className="bg-slate-50 pb-4">
             <div className="mx-auto w-full max-w-5xl px-4 py-6 md:py-8 space-y-5">
                 <BackButton
                     label="Back"
@@ -138,6 +138,6 @@ export function SellerProfilePage({ profile }: SellerProfilePageProps) {
                     )}
                 </section>
             </div>
-        </main>
+        </div>
     );
 }

--- a/apps/web/src/components/user/listing-detail/AdDetailSkeleton.tsx
+++ b/apps/web/src/components/user/listing-detail/AdDetailSkeleton.tsx
@@ -20,7 +20,7 @@ function TitleAndMetricsSkeleton({ isDesktop = false }: { isDesktop?: boolean })
 
 export function AdDetailSkeleton() {
     return (
-        <div className="bg-gray-50 pb-20 md:pb-6">
+        <div className="bg-gray-50 pb-6">
             <div className="max-w-7xl mx-auto md:px-6 lg:px-8 md:py-6">
                 {/* Breadcrumb Skeleton */}
                 <div className="flex gap-2 mb-4 px-4 md:px-0">

--- a/apps/web/src/components/user/profile/tabs/MoreMenuTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/MoreMenuTab.tsx
@@ -20,7 +20,7 @@ export function MoreMenuTab({
   renderTabBadge,
 }: MoreMenuTabProps) {
   return (
-    <div className="space-y-4 block md:hidden max-w-full pb-20">
+    <div className="space-y-4 block md:hidden max-w-full">
       {/* Navigation List */}
       <Card className="p-2 border-0 shadow-sm bg-white">
         <div className="space-y-1" role="list">

--- a/apps/web/src/components/user/profile/tabs/PlansTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/PlansTab.tsx
@@ -247,7 +247,7 @@ export function PlansTab({
     };
 
     return (
-        <div className="space-y-4 pb-6 sm:pb-8">
+        <div className="space-y-4">
             {/* Top Row: Single-Line Sub-Tabs Switcher + Desktop Current Plan Badge */}
             <div className="flex flex-col md:flex-row items-stretch md:items-center justify-between gap-3">
                 <div


### PR DESCRIPTION
## Summary

Comprehensive UI/UX layout audit to remove unnecessary bottom padding, duplicate spacing stacks, and incorrect `min-h-screen` usage across account, browse, and public pages. Layout-only — no business logic, API contracts, or UI redesign.

## Root Cause Discovery

`chromePolicy.ts` returns `showMobileBottomNav: false` for all `/account/*` routes. This means `CommonLayout`'s `<main>` does **not** apply bottom padding on account pages. `ProfileSettingsSidebar`'s `PageContainer pb-20` is the **single correct clearance layer** for `MobileAccountBottomNav` (`h-16` = 64px). Any child tab adding its own `pb-20` was duplicating this clearance.

## Changes

| # | File | Change | Spacing Eliminated |
|---|---|---|---|
| 1 | `ProfileSettingsSidebar.tsx` | Remove `min-h-screen` from wrapper | Empty gray area scales with viewport height |
| 2 | `MoreMenuTab.tsx` | Remove duplicate `pb-20` | **80px** below Logout button on mobile |
| 3 | `PlansTab.tsx` | Remove redundant `pb-6 sm:pb-8` | **24–32px** below last plan card |
| 4 | `SellerProfilePage.tsx` | `<main>`→`<div>` (semantic fix), remove `min-h-screen`, `pb-20`→`pb-4` | **~80px** + invalid nested `<main>` corrected |
| 5 | `AdDetailSkeleton.tsx` | `pb-20 md:pb-6`→`pb-6` | **56px** mismatch vs actual `ListingDetail` render |
| 6 | `BrowseListingsView.tsx` | Remove `min-h-screen` | Empty bg area on large/ultrawide monitors |
| 7 | `BrowseResultsPanel.tsx` | Remove `pb-8` from grid/list divs | **32px** below last card (section already has `pb-6`) |
| 8 | `AccountPageShell.tsx` | `min-h-screen`→`min-h-[60vh]` in loading state | Secondary 100vh constraint inside `flex-1` container |

## Duplicate Spacing Eliminated

| Location | Before | After |
|---|---|---|
| Account / More tab (mobile) | 160px empty bottom | 80px (correct nav clearance) |
| Account / Plans tab (mobile) | 104–112px extra | 80px (correct nav clearance) |
| Seller profile page (mobile) | ~176px empty bottom | ~96px (CommonLayout handles it) |
| Browse page (large desktop) | Full viewport empty area | Content-driven height |
| Account module (large desktop) | Viewport-scaling empty area | Content-driven height |

## Preserved

- ✅ `ProfileSettingsSidebar` `PageContainer pb-20` — correct, single-owner clearance for `MobileAccountBottomNav`
- ✅ All safe-area insets — untouched
- ✅ All sticky/fixed element positioning — untouched
- ✅ `PersonalTab` sticky Save CTA — unchanged

## Verification

- ✅ `npm run build` — zero TypeScript errors
- ✅ **319 web tests** — all passed
- ✅ **281 core tests** — all passed

## PR Checklist

- [x] Keyboard navigation tested — unchanged
- [x] Focus order verified — unchanged
- [x] Screen reader compatibility — no ARIA changes
- [x] ARIA attributes reviewed — no changes
- [x] WCAG 2.2 AA compliance — no regressions
- [x] No accessibility regressions
- [x] No API contract changes
- [x] No business logic changes
- [x] No UI redesign
- [x] `npm run build` passed
