### PR TITLE
fix(auth): enforce canonical business user state destinations and guard checks (#246)

### DIFF
--- a/apps/web/src/components/user/Header.tsx
+++ b/apps/web/src/components/user/Header.tsx
@@ -39,8 +39,8 @@ import { getMobileChromePolicy } from "@/lib/mobile/chromePolicy";
 import { useSharedHeaderLogic } from "@/components/user/hooks/useSharedHeaderLogic";
 import { NotificationBellDropdown } from "@/components/user/NotificationBellDropdown";
 import { usePostAdNavigation } from "@/hooks/usePostAdNavigation";
-import { normalizeBusinessStatus, isBusinessActiveStatus } from "@/lib/status/statusNormalization";
-import { canRegisterBusiness } from "@/guards/businessGuards";
+import { normalizeBusinessStatus } from "@/lib/status/statusNormalization";
+import { canRegisterBusiness, isApprovedBusiness } from "@/guards/businessGuards";
 import { DEFAULT_IMAGE_PLACEHOLDER, toSafeImageSrc } from "@/lib/image/imageUrl";
 import { DEFAULT_APP_LOCATION } from "@/types/location";
 import { parsePublicBrowseParams } from "@/lib/publicBrowseRoutes";
@@ -83,7 +83,7 @@ export function Header({
   const { setIsOpen: setIsMobileDrawerOpen } = useMobileNavDrawer();
 
   const businessStatus = normalizeBusinessStatus(user?.businessStatus, "pending");
-  const isBusinessLive = isBusinessActiveStatus(user?.businessStatus);
+  const isBusinessLive = Boolean(user && isApprovedBusiness(user));
   const shouldShowPendingReview = businessStatus === "pending" && Boolean(user?.businessId);
   const canRegister = Boolean(user && canRegisterBusiness(user));
   const safeProfilePhoto = useMemo(

--- a/apps/web/src/components/user/ProfileSettingsSidebar.tsx
+++ b/apps/web/src/components/user/ProfileSettingsSidebar.tsx
@@ -33,7 +33,7 @@ import { useSmartAlerts } from "@/hooks/useSmartAlerts";
 import { usePurchases } from "@/hooks/usePurchases";
 import { useChatUnreadCount } from "@/hooks/useChatUnreadCount";
 import { formatPrice, formatDate } from "@/lib/formatters";
-import { isBusinessActiveStatus } from "@/lib/status/statusNormalization";
+import { isApprovedBusiness } from "@/guards/businessGuards";
 import { buildPublicBrowseRoute } from "@/lib/publicBrowseRoutes";
 
 
@@ -86,7 +86,7 @@ export function ProfileSettingsSidebar({
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<ProfileTabValue>((initialTab as ProfileTabValue) || "personal");
 
-  const isBusinessLive = isBusinessActiveStatus(user?.businessStatus);
+  const isBusinessLive = Boolean(user && isApprovedBusiness(user));
 
   const { data: adCounts = {} } = useMyListingsStatsQuery({ 
     enabled: activeTab === "mylistings" && !!user,

--- a/apps/web/src/components/user/profile/tabs/MyListingsTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/MyListingsTab.tsx
@@ -31,6 +31,7 @@ import {
 
 import { formatPrice, formatStableNumber } from "@/lib/formatters";
 import { buildPublicListingDetailRoute } from "@/lib/publicListingRoutes";
+import { isApprovedBusiness } from "@/guards/businessGuards";
 
 // ── Types & Constants ────────────────────────────────────────────────────────
 type ListingSubTab = "ads" | "services" | "spare-parts";
@@ -69,9 +70,10 @@ interface MyListingsTabProps {
 export function MyListingsTab({
     adCounts,
     user, navigateTo, getStatusBadge,
-    isBusinessApproved, onRegisterBusiness,
+    isBusinessApproved: isBusinessApprovedProp, onRegisterBusiness,
     initialSubTab = "ads",
 }: MyListingsTabProps) {
+    const isBusinessApproved = isBusinessApprovedProp ?? Boolean(user && isApprovedBusiness(user));
     const router = useRouter();
     const searchParams = useSearchParams();
     const subTab = initialSubTab;

--- a/apps/web/src/guards/withGuard.tsx
+++ b/apps/web/src/guards/withGuard.tsx
@@ -24,7 +24,12 @@ export function withGuard<P extends object>(
                 guard(user);
                 return true;
             } catch (e) {
-                logger.error("Access denied:", e);
+                const message = e instanceof Error ? e.message : String(e);
+                if (message === "BUSINESS_ACCESS_DENIED" || message === "AUTH_REQUIRED") {
+                    logger.debug(`[Guard] Access restricted for user (${user.id || 'guest'}): ${message}`);
+                } else {
+                    logger.error("[Guard] Unexpected error during authorization check:", e);
+                }
                 return false;
             }
         }, [user]);
@@ -41,7 +46,9 @@ export function withGuard<P extends object>(
             }
 
             if (user && !authorized) {
-                void router.replace('/unauthorized');
+                // Canonical User State Destination Matrix:
+                // Normal User / Pending / Rejected -> Redirect to /account/business/apply (renders registration / pending / reapply UI)
+                void router.replace('/account/business/apply');
             }
         }, [user, isLoading, authorized, router, pathname, searchParams]);
 


### PR DESCRIPTION
Closes #246

### Summary
Enforces canonical user state destinations and SSOT permission checks for business navigation and route protection. Resolves UI authorization leaks by ensuring non-approved business users are never shown business-only posting actions or generic "Access Denied" error pages.

### Architectural Governance Alignment
- **Guest (Unauthenticated)**: Redirects to the login flow while preserving the intended destination (`callbackUrl`).
- **Logged-in User Who Is Not an Approved Business** (no application, pending, or rejected): Redirects directly to `/account/business/apply` (the single canonical entry point for the business registration lifecycle).
- **Approved Business User**: Continues directly to the originally requested page (`/post-service` or `/post-spare-part-listing`).

### Key Changes
- **Route Guard Redirects & Error Handling**: Refactored `withGuard.tsx` to handle expected `BUSINESS_ACCESS_DENIED` restrictions via `logger.debug` (eliminating noisy console error dumps) and redirecting unapproved users to `/account/business/apply`.
- **Navigation SSOT Standardization**: Updated `Header.tsx`, `ProfileSettingsSidebar.tsx`, and `MyListingsTab.tsx` to evaluate business status using `isApprovedBusiness(user)` from `businessGuards.ts`.
- **UI-Only Scope**: No backend code or permission matrix rules were modified in this PR.

### Verification Matrix
- [x] **Guest (Unauthenticated)** → Redirects to login flow with return URL.
- [x] **Logged-in user without business application** → Redirects to `/account/business/apply` (Registration view).
- [x] **Pending business user** → Redirects to `/account/business/apply` (Pending view).
- [x] **Rejected business user** → Redirects to `/account/business/apply` (Reapply view).
- [x] **Approved business user** → Directly accesses `/post-service` and `/post-spare-part-listing`.
- [x] **Monorepo Checks**: `npm run type-check` and `npm test` passed 100% green across all packages.
