### PR TITLE
feat(business): add focus management, scroll error and aria step indicators (#246)

### DIFF
--- a/apps/web/src/__tests__/a11y-focus-helpers.spec.ts
+++ b/apps/web/src/__tests__/a11y-focus-helpers.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { scrollToFirstError } from "../lib/formHelpers";
+
+describe("Accessibility & Form Focus Helpers Specifications", () => {
+    it("returns false cleanly when window/document is undefined", () => {
+        expect(scrollToFirstError()).toBe(false);
+    });
+
+    it("queries for target element and invokes scrollIntoView and focus when element exists", () => {
+        const mockTarget = {
+            scrollIntoView: vi.fn(),
+            focus: vi.fn(),
+        };
+
+        const mockQuerySelector = vi.fn().mockReturnValue(mockTarget);
+        const mockDoc = { querySelector: mockQuerySelector };
+
+        const originalDoc = (globalThis as unknown as { document: unknown }).document;
+        const originalWin = (globalThis as unknown as { window: unknown }).window;
+        (globalThis as unknown as { document: unknown }).document = mockDoc;
+        (globalThis as unknown as { window: unknown }).window = {};
+
+        try {
+            const found = scrollToFirstError();
+            expect(found).toBe(true);
+            expect(mockQuerySelector).toHaveBeenCalledWith(
+                '[aria-invalid="true"], input.border-destructive, select.border-destructive, textarea.border-destructive, [data-invalid="true"]'
+            );
+            expect(mockTarget.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+            expect(mockTarget.focus).toHaveBeenCalledWith({ preventScroll: true });
+        } finally {
+            (globalThis as unknown as { document: unknown }).document = originalDoc;
+            (globalThis as unknown as { window: unknown }).window = originalWin;
+        }
+    });
+
+    it("respects containerRef boundaries when provided", () => {
+        const mockTarget = {
+            scrollIntoView: vi.fn(),
+            focus: vi.fn(),
+        };
+        const mockQuerySelector = vi.fn().mockReturnValue(mockTarget);
+        const mockContainer = { querySelector: mockQuerySelector } as unknown as HTMLElement;
+
+        const originalDoc = (globalThis as unknown as { document: unknown }).document;
+        const originalWin = (globalThis as unknown as { window: unknown }).window;
+        (globalThis as unknown as { document: unknown }).document = {};
+        (globalThis as unknown as { window: unknown }).window = {};
+        const containerRef = { current: mockContainer };
+
+        try {
+            const found = scrollToFirstError(containerRef);
+            expect(found).toBe(true);
+            expect(mockQuerySelector).toHaveBeenCalled();
+            expect(mockTarget.scrollIntoView).toHaveBeenCalled();
+        } finally {
+            (globalThis as unknown as { document: unknown }).document = originalDoc;
+            (globalThis as unknown as { window: unknown }).window = originalWin;
+        }
+    });
+});

--- a/apps/web/src/components/user/business-registration/BusinessProfileWizard.tsx
+++ b/apps/web/src/components/user/business-registration/BusinessProfileWizard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useRef, useEffect, type ReactNode } from "react";
 import { ArrowLeft, Loader2 } from "@/icons/IconRegistry";
 import type { User } from "@/types/User";
 import { Button } from "@esparex/ui";
 import { FormError } from "@/components/ui/FormError";
+import { scrollToFirstError } from "@/lib/formHelpers";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { StepBasicDetails } from "./StepBasicDetails";
 import { StepAddress } from "./StepAddress";
@@ -134,11 +135,24 @@ export function BusinessProfileWizard({
         ? submitLabel
         : "Continue to verification";
 
+    const headingRef = useRef<HTMLHeadingElement>(null);
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            headingRef.current?.focus();
+        }
+    }, [safeCurrentStep]);
+
     return (
         <div className="bg-slate-50 py-6 md:py-8">
             <form
                 className="mx-auto flex max-w-4xl flex-col gap-6 px-4 pb-6 md:pb-0"
-                onSubmit={onSubmit}
+                onSubmit={(e) => {
+                    onSubmit(e);
+                    if (formError) {
+                        scrollToFirstError();
+                    }
+                }}
                 noValidate
             >
                 <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm md:px-5">
@@ -160,9 +174,32 @@ export function BusinessProfileWizard({
                     </div>
                 </div>
 
-                <FormError message={formError} className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" />
+                {/* Step indicator accessibility */}
+                <nav aria-label="Wizard Steps" className="flex items-center gap-2">
+                    {steps.map((step, idx) => (
+                        <div
+                            key={step.label}
+                            aria-current={idx === safeCurrentStep ? "step" : undefined}
+                            className={`flex items-center gap-1.5 text-xs font-semibold ${
+                                idx === safeCurrentStep ? "text-blue-600 font-bold" : "text-slate-400"
+                            }`}
+                        >
+                            <span className={`flex h-5 w-5 items-center justify-center rounded-full text-[10px] ${
+                                idx === safeCurrentStep ? "bg-blue-600 text-white" : "bg-slate-200 text-slate-600"
+                            }`}>
+                                {idx + 1}
+                            </span>
+                            <span>{step.label}</span>
+                            {idx < steps.length - 1 ? <span className="mx-1 text-slate-300">/</span> : null}
+                        </div>
+                    ))}
+                </nav>
+
+                <div role="alert" aria-live="polite">
+                    <FormError message={formError} className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" />
+                </div>
                 {submissionStatus ? (
-                    <div className="rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+                    <div className="rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900" role="status" aria-live="polite">
                         <div className="flex items-start gap-3">
                             <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
                             <div className="space-y-1">
@@ -175,7 +212,11 @@ export function BusinessProfileWizard({
 
                 <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
                     <div className="border-b border-slate-100 px-5 py-5 md:px-8 md:py-6">
-                        <h2 className="text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+                        <h2
+                            ref={headingRef}
+                            tabIndex={-1}
+                            className="text-xl font-semibold tracking-tight text-foreground md:text-2xl outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+                        >
                             {activeStep.title}
                         </h2>
                         <p className="mt-2 max-w-2xl text-sm leading-6 text-foreground-tertiary">

--- a/apps/web/src/lib/formHelpers.ts
+++ b/apps/web/src/lib/formHelpers.ts
@@ -1,0 +1,26 @@
+import type { RefObject } from "react";
+
+/**
+ * Focuses and smoothly scrolls the window to the first invalid form element (`aria-invalid="true"` or matching `.border-destructive`).
+ * Respects element ref boundaries when provided.
+ */
+export function scrollToFirstError(containerRef?: RefObject<HTMLElement | null>): boolean {
+  if (typeof window === "undefined" || typeof document === "undefined") return false;
+
+  const root = containerRef?.current || document;
+  const invalidElement = root.querySelector<HTMLElement>(
+    '[aria-invalid="true"], input.border-destructive, select.border-destructive, textarea.border-destructive, [data-invalid="true"]'
+  );
+
+  if (invalidElement) {
+    invalidElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    try {
+      invalidElement.focus({ preventScroll: true });
+    } catch {
+      // Ignore focus failures on un-focusable elements
+    }
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Closes #246

### Summary
Implemented Accessibility, Focus Management, Form Error Auto-Scrolling, and Screen Reader ARIA Compliance for the Business Registration wizard.

### Key Enhancements & Accessibility Compliance
- **Form Auto-Scroll Helper (`formHelpers.ts`)**: Created `scrollToFirstError()` helper in `apps/web/src/lib/formHelpers.ts` to locate the first input with `aria-invalid="true"`, smoothly scroll it into view, and focus it upon validation failure.
- **Step Heading Focus Management (`BusinessProfileWizard.tsx`)**: Programmatically moves keyboard focus to the Step `<h2>` title (`tabIndex={-1}`) on step changes so screen readers announce step transitions.
- **ARIA Stepper Compliance (`BusinessProfileWizard.tsx`)**: Added `aria-current="step"` to active wizard step indicators and `role="alert"` / `aria-live="polite"` to `FormError` banners.
- **Automated Tests (`a11y-focus-helpers.spec.ts`)**: Added unit tests verifying invalid element location, ref boundary scoping, and smooth scrolling/focus calls.

### Verification Results
- [x] **Monorepo Type Check**: `npm run type-check` passed with 0 errors across all packages.
- [x] **A11y Unit Tests**: `npx vitest run src/__tests__/a11y-focus-helpers.spec.ts` passed 3/3 tests (100% green).
- [x] **Pushed Remote**: `origin/feat/issue-246-accessibility-focus-management`.
