### PR TITLE
chore(ui): establish typography SSOT tiny token and SheetTitle text-h4 sizing (#247)

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -58,16 +58,6 @@
 
   --radius: 0.625rem;
 
-  /* Typography scale — legacy tokens (deprecated, scheduled for future removal) */
-  --font-size: 16px;         /* Deprecated — html base is 16px */
-  --text-2xl: 1.5rem;        /* Deprecated — prefer --text-h2 */
-  --text-xl: 1.25rem;        /* Deprecated — prefer --text-h3 */
-  --text-lg: 1.125rem;       /* Deprecated — prefer --text-h4 */
-  --text-base: 1rem;         /* Deprecated — prefer --text-body-lg */
-  --text-sm: 0.875rem;       /* Deprecated — prefer --text-body */
-  --text-xs: 0.75rem;        /* Deprecated — prefer --text-caption */
-  --text-2xs: 0.625rem;      /* Deprecated — prefer --text-tiny */
-
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --font-weight-semibold: 600;

--- a/packages/ui/src/atoms/Sheet.tsx
+++ b/packages/ui/src/atoms/Sheet.tsx
@@ -113,7 +113,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn("text-h4 text-foreground font-semibold", className)}
       {...props}
     />
   );

--- a/packages/ui/src/tokens/typography.ts
+++ b/packages/ui/src/tokens/typography.ts
@@ -19,6 +19,7 @@ export const TYPOGRAPHY_FONT_SIZE: Record<string, [string, { lineHeight: string;
   'body': ['0.875rem', { lineHeight: '1.55', letterSpacing: '0' }],        // 14px (Default Body)
   'small': ['0.8125rem', { lineHeight: '1.5', letterSpacing: '0' }],       // 13px (Secondary / Tables)
   'caption': ['0.75rem', { lineHeight: '1.4', letterSpacing: '0' }],       // 12px (Helper / Badges)
+  'tiny': ['0.6875rem', { lineHeight: '1.4', letterSpacing: '0' }],        // 11px (Dense Labels / Timestamps)
 };
 
 export const TYPOGRAPHY_FONT_WEIGHT: Record<string, string> = {
@@ -34,5 +35,5 @@ export const TYPOGRAPHY_TOKENS = {
   fontWeight: TYPOGRAPHY_FONT_WEIGHT,
 };
 
-export type TypographyFontSize = 'display' | 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'small' | 'caption';
+export type TypographyFontSize = 'display' | 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'small' | 'caption' | 'tiny';
 export type TypographyFontWeight = 'normal' | 'medium' | 'semibold' | 'bold';


### PR DESCRIPTION
### Summary

This PR establishes Phase 1 of the Enterprise Typography SSOT Alignment by adding the missing `tiny` (`0.6875rem` / 11px) token to `@esparex/ui`, updating the `SheetTitle` primitive to use explicit `text-h4` sizing, and cleaning up unconsumed legacy typography variables.

### Key Changes

1. **Typography SSOT Expansion (`packages/ui/src/tokens/typography.ts`)**:
   - Added `'tiny': ['0.6875rem', { lineHeight: '1.4', letterSpacing: '0' }]` (11px) token to `TYPOGRAPHY_FONT_SIZE`.
   - Exported `'tiny'` in `TypographyFontSize` type definition.

2. **Primitive Sizing Fix (`packages/ui/src/atoms/Sheet.tsx`)**:
   - Updated `SheetTitle` className from `text-foreground font-semibold` to `text-h4 text-foreground font-semibold` to enforce canonical SSOT typography token instead of un-sized inheritance.

3. **Tailwind Configuration Synchronization**:
   - Inherited `tiny` token directly from `TYPOGRAPHY_TOKENS.fontSize` in `apps/web/tailwind.config.js` and `apps/admin/tailwind.config.ts`.

4. **Evidence-Based Legacy Variable Cleanup (`apps/web/src/styles/globals.css`)**:
   - Audited `--text-2xl`, `--text-xl`, `--text-lg`, `--text-base`, `--text-sm`, `--text-xs`, `--text-2xs`, and `--font-size` across all codebase files, confirming zero consumers before removing the declarations.

### Quality & Governance Gates

- [x] `npm run type-check` — Passed with 0 errors across 6 workspaces.
- [x] `npm run build` — Passed 100% clean builds for `@esparex/contracts`, `@esparex/shared`, `@esparex/core`, `@esparex/backend-api`, `apps/admin`, and `apps/web`.
- [x] No visual regressions or arbitrary typography utilities introduced.

Closes #247
