### PR TITLE
refactor(ui): standardize primitive overlay typography with OVERLAY_STYLES constants (#249)

### DIFF
--- a/packages/ui/src/atoms/AlertDialog.tsx
+++ b/packages/ui/src/atoms/AlertDialog.tsx
@@ -5,6 +5,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "../utils";
 import { buttonVariants } from "./Button";
+import { OVERLAY_STYLES } from "../styles/overlay";
 
 function AlertDialog({
   ...props
@@ -99,7 +100,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold", className)}
+      className={cn(OVERLAY_STYLES.modalTitle, className)}
       {...props}
     />
   );
@@ -112,7 +113,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn(OVERLAY_STYLES.description, className)}
       {...props}
     />
   );

--- a/packages/ui/src/atoms/Dialog.tsx
+++ b/packages/ui/src/atoms/Dialog.tsx
@@ -25,6 +25,7 @@ import * as RadixDialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { cn } from "../utils";
 import { Z_INDEX } from "../tokens/zIndex";
+import { OVERLAY_STYLES } from "../styles/overlay";
 
 // ── Root ────────────────────────────────────────────────────────────────────
 const Dialog = RadixDialog.Root;
@@ -203,7 +204,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <RadixDialog.Title
     ref={ref}
-    className={cn("text-h3 font-semibold leading-snug tracking-tight text-slate-900", className)}
+    className={cn(OVERLAY_STYLES.modalTitle, "leading-snug tracking-tight", className)}
     {...props}
   />
 ));
@@ -216,7 +217,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <RadixDialog.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground mt-1", className)}
+    className={cn(OVERLAY_STYLES.description, "mt-1", className)}
     {...props}
   />
 ));

--- a/packages/ui/src/atoms/Drawer.tsx
+++ b/packages/ui/src/atoms/Drawer.tsx
@@ -4,6 +4,7 @@ import { Drawer as VaulDrawer } from "vaul";
 import { X } from "lucide-react";
 
 import { Z_INDEX } from "../tokens/zIndex";
+import { OVERLAY_STYLES } from "../styles/overlay";
 
 export function Drawer({
   title,
@@ -36,7 +37,7 @@ export function Drawer({
           
           {/* Header */}
           <div className="flex shrink-0 items-center justify-between p-4 pb-2">
-            <VaulDrawer.Title className="text-lg font-semibold text-foreground">
+            <VaulDrawer.Title className={OVERLAY_STYLES.panelTitle}>
               {title}
             </VaulDrawer.Title>
             <VaulDrawer.Description className="sr-only">

--- a/packages/ui/src/atoms/Sheet.tsx
+++ b/packages/ui/src/atoms/Sheet.tsx
@@ -6,6 +6,7 @@ import { XIcon } from "lucide-react";
 
 import { cn } from "../utils";
 import { Z_INDEX } from "../tokens/zIndex";
+import { OVERLAY_STYLES } from "../styles/overlay";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -113,7 +114,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-h4 text-foreground font-semibold", className)}
+      className={cn(OVERLAY_STYLES.panelTitle, className)}
       {...props}
     />
   );
@@ -126,7 +127,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn(OVERLAY_STYLES.description, className)}
       {...props}
     />
   );

--- a/packages/ui/src/styles/overlay.ts
+++ b/packages/ui/src/styles/overlay.ts
@@ -1,0 +1,12 @@
+/**
+ * overlay.ts — Style Constants for Overlay Primitives (Dialog, AlertDialog, Sheet, Drawer)
+ *
+ * Consumes canonical SSOT design tokens (typography.ts) and defines centralized
+ * semantic role style compositions for overlay component primitives in @esparex/ui.
+ */
+
+export const OVERLAY_STYLES = {
+  modalTitle: "text-h3 font-semibold text-foreground",
+  panelTitle: "text-h4 font-semibold text-foreground",
+  description: "text-body text-muted-foreground",
+} as const;


### PR DESCRIPTION
### Summary

This PR completes Phase 3 of the Enterprise Typography & Design System Alignment by standardizing overlay primitive typography (`Dialog`, `AlertDialog`, `Sheet`, `Drawer`) in `@esparex/ui` via a scalable style constants module (`packages/ui/src/styles/overlay.ts`).

### Key Changes

1. **Scalable Component Styles Architecture (`packages/ui/src/styles/overlay.ts`)**:
   - Created `packages/ui/src/styles/overlay.ts` exporting `OVERLAY_STYLES` with semantic role keys:
     - `modalTitle`: `"text-h3 font-semibold text-foreground"` (20px / 600)
     - `panelTitle`: `"text-h4 font-semibold text-foreground"` (18px / 600)
     - `description`: `"text-body text-muted-foreground"` (14px / 400)
   - Decouples component presentation utility class compositions from pure design tokens (`typography.ts`).

2. **Primitive Component Standardization**:
   - `packages/ui/src/atoms/Dialog.tsx`: Replaced hardcoded `text-slate-900` and `text-sm` with `OVERLAY_STYLES.modalTitle` and `OVERLAY_STYLES.description`.
   - `packages/ui/src/atoms/AlertDialog.tsx`: Replaced `text-lg` and `text-sm` with `OVERLAY_STYLES.modalTitle` and `OVERLAY_STYLES.description`.
   - `packages/ui/src/atoms/Sheet.tsx`: Updated `SheetTitle` and `SheetDescription` to consume `OVERLAY_STYLES.panelTitle` and `OVERLAY_STYLES.description`.
   - `packages/ui/src/atoms/Drawer.tsx`: Updated `VaulDrawer.Title` to consume `OVERLAY_STYLES.panelTitle`.

### Quality & Governance Gates

- [x] Static Grep Audit: `grep -R "OVERLAY_STYLES" packages/ui/src/atoms` confirms consumption across all 4 primitives.
- [x] Zero Residual Classes: `grep -R "text-h3\|text-h4" packages/ui/src/atoms` confirms zero residual inline typography strings outside `overlay.ts`.
- [x] `npm run type-check` — Passed with 0 errors across 6 workspaces.
- [x] `npm run build` — Passed 100% clean production builds for all library packages and applications.

Closes #249
