### PR TITLE
chore(nav): remove legacy My Suggestions tab from profile navigation

### DIFF
--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -2,7 +2,6 @@ import type { LucideIcon } from "@/icons/IconRegistry";
 import {
   Bell,
   Building2,
-  ClipboardList,
   MessageSquare,
   User as UserIcon,
   Heart,
@@ -58,7 +57,6 @@ export type ProfileTabValue =
   | "settings"
   | "smartalerts"
   | "purchases"
-  | "suggestions"
   | "more";
 
 export const PROFILE_TAB_ITEMS: Array<{
@@ -75,7 +73,6 @@ export const PROFILE_TAB_ITEMS: Array<{
     { value: "business", label: "Business", icon: Building2 },
     { value: "smartalerts", label: "Smart Alerts", icon: Bell },
     { value: "purchases", label: "My Purchases", icon: Package },
-    { value: "suggestions", label: "My Suggestions", icon: ClipboardList },
     { value: "plans", label: "Plans", icon: CreditCard },
     { value: "settings", label: "Settings", icon: Settings },
   ];


### PR DESCRIPTION
### Problem

The **My Suggestions** item was visible in the Account sidebar navigation
but was never implemented:

- No page component
- No route in `PROFILE_TAB_PAGE_ROUTES`
- No `case "suggestions"` handler in `ProfileSettingsSidebar`
- No backend API

It was dead config from an incomplete feature, rendering a clickable nav
item that led nowhere.

### Change

Removed all three touch points from `navigation.ts`:

- `| "suggestions"` from the `ProfileTabValue` union type
- `{ value: "suggestions", label: "My Suggestions", icon: ClipboardList }` from `PROFILE_TAB_ITEMS`
- `ClipboardList` icon import (only consumer was the suggestions entry)

### Verification

- `npm run type-check` — ✅ 0 errors across all 6 packages
- Backend API: 68/68 suites, 335 tests ✅
- Core: 50/50 suites, 294 tests ✅
- No other file references `"suggestions"` as a `ProfileTabValue`
