### PR TITLE
refactor(mobile): standardize mapper architecture and governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,26 @@ If similarity is below the threshold, keep components separate even if they appe
 
 ---
 
+## Mapper Ownership Rule
+
+Mappers own boundary transformations between DTOs and Domain entities across all applications and packages.
+
+```text
+Application Mapper
+Domain ──► Request DTO
+
+Infrastructure Mapper
+Response DTO ──► Domain
+```
+
+### Governance Constraints:
+- Repositories never perform mapping logic.
+- Services never perform mapping logic.
+- Mapper-to-Mapper dependencies are strictly prohibited.
+- All API DTO models MUST be defined in `@esparex/contracts`.
+
+---
+
 # 🚨 GLOBAL ACCESSIBILITY & KEYBOARD NAVIGATION GOVERNANCE RULE (MANDATORY)
 
 ## Applies To

--- a/apps/mobile/src/features/listings/infrastructure/mappers/CreatedListingMapper.ts
+++ b/apps/mobile/src/features/listings/infrastructure/mappers/CreatedListingMapper.ts
@@ -1,14 +1,5 @@
+import { CreatedListingResponseDto } from '@esparex/contracts';
 import { CreatedListing } from '../../domain/CreatedListing';
-
-/**
- * CreatedListingResponseDto — strongly typed contract for backend creation responses.
- */
-export interface CreatedListingResponseDto {
-  id: string | number;
-  slug?: string;
-  status?: string;
-  moderationStatus?: string;
-}
 
 /**
  * CreatedListingMapper — pure mapper transforming raw API DTO responses into CreatedListing domain value objects.

--- a/apps/mobile/src/features/listings/infrastructure/mappers/__tests__/CreatedListingMapper.spec.ts
+++ b/apps/mobile/src/features/listings/infrastructure/mappers/__tests__/CreatedListingMapper.spec.ts
@@ -1,0 +1,57 @@
+import { CreatedListingResponseDto } from '@esparex/contracts';
+import { CreatedListingMapper } from '../CreatedListingMapper';
+
+describe('CreatedListingMapper', () => {
+  it('maps a complete CreatedListingResponseDto into a CreatedListing domain entity', () => {
+    const dto: CreatedListingResponseDto = {
+      id: 'ad-101',
+      slug: 'iphone-13-mumbai',
+      status: 'pending',
+      moderationStatus: 'pending_review',
+    };
+
+    const domain = CreatedListingMapper.fromDto(dto);
+
+    expect(domain).toBeDefined();
+    expect(domain.id).toBe('ad-101');
+    expect(domain.slug).toBe('iphone-13-mumbai');
+    expect(domain.moderationStatus).toBe('pending');
+  });
+
+  it('coerces numeric id to string', () => {
+    const dto: CreatedListingResponseDto = {
+      id: 99482,
+      slug: 'item-99482',
+    };
+
+    const domain = CreatedListingMapper.fromDto(dto);
+
+    expect(domain.id).toBe('99482');
+    expect(domain.slug).toBe('item-99482');
+  });
+
+  it('falls back to moderationStatus when status is undefined', () => {
+    const dto: CreatedListingResponseDto = {
+      id: 'ad-202',
+      moderationStatus: 'approved',
+    };
+
+    const domain = CreatedListingMapper.fromDto(dto);
+
+    expect(domain.id).toBe('ad-202');
+    expect(domain.moderationStatus).toBe('approved');
+    expect(domain.slug).toBeUndefined();
+  });
+
+  it('handles empty/undefined optional fields gracefully', () => {
+    const dto: CreatedListingResponseDto = {
+      id: 'ad-303',
+    };
+
+    const domain = CreatedListingMapper.fromDto(dto);
+
+    expect(domain.id).toBe('ad-303');
+    expect(domain.slug).toBeUndefined();
+    expect(domain.moderationStatus).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/features/postAd/application/mappers/__tests__/CreateListingRequestMapper.spec.ts
+++ b/apps/mobile/src/features/postAd/application/mappers/__tests__/CreateListingRequestMapper.spec.ts
@@ -1,6 +1,6 @@
 import { CreateListingRequestMapper } from '../CreateListingRequestMapper';
 import { PostAdDraft } from '../../../domain/PostAdDraft';
-import { UploadedImage } from '../../../../shared/domain/UploadedImage';
+import { UploadedImage } from '../../../domain/UploadedImage';
 
 describe('CreateListingRequestMapper', () => {
   const sampleDraft: PostAdDraft = {
@@ -15,15 +15,8 @@ describe('CreateListingRequestMapper', () => {
 
   const sampleImages: UploadedImage[] = [
     {
-      id: 'img-1',
-      url: 'https://storage.esparex.in/ads/img1.jpg',
       key: 'ads/img1.jpg',
-      mimeType: 'image/jpeg',
-      size: 102450,
-      width: 1200,
-      height: 900,
-      isPrimary: true,
-      uploadedAt: new Date().toISOString(),
+      url: 'https://storage.esparex.in/ads/img1.jpg',
     },
   ];
 

--- a/apps/mobile/src/features/postAd/application/mappers/__tests__/CreateListingRequestMapper.spec.ts
+++ b/apps/mobile/src/features/postAd/application/mappers/__tests__/CreateListingRequestMapper.spec.ts
@@ -1,0 +1,60 @@
+import { CreateListingRequestMapper } from '../CreateListingRequestMapper';
+import { PostAdDraft } from '../../../domain/PostAdDraft';
+import { UploadedImage } from '../../../../shared/domain/UploadedImage';
+
+describe('CreateListingRequestMapper', () => {
+  const sampleDraft: PostAdDraft = {
+    title: 'Test Listing',
+    description: 'This is a test description for a mobile listing.',
+    price: 1500,
+    categoryId: 'cat-electronics',
+    condition: 'used_good',
+    locationId: 'loc-mumbai-1',
+    locationDisplay: 'Mumbai, Maharashtra',
+  };
+
+  const sampleImages: UploadedImage[] = [
+    {
+      id: 'img-1',
+      url: 'https://storage.esparex.in/ads/img1.jpg',
+      key: 'ads/img1.jpg',
+      mimeType: 'image/jpeg',
+      size: 102450,
+      width: 1200,
+      height: 900,
+      isPrimary: true,
+      uploadedAt: new Date().toISOString(),
+    },
+  ];
+
+  it('maps complete draft and uploaded images into a valid CreateListingRequest DTO', () => {
+    const dto = CreateListingRequestMapper.fromDraft(sampleDraft, sampleImages);
+
+    expect(dto).toBeDefined();
+    expect(dto.title).toBe('Test Listing');
+    expect(dto.description).toBe('This is a test description for a mobile listing.');
+    expect(dto.price).toBe(1500);
+    expect(dto.categoryId).toBe('cat-electronics');
+    expect(dto.condition).toBe('used_good');
+    expect(dto.locationId).toBe('loc-mumbai-1');
+    expect(dto.locationDisplay).toBe('Mumbai, Maharashtra');
+    expect(dto.imageKeys).toEqual(['ads/img1.jpg']);
+  });
+
+  it('handles empty images array and optional fields safely', () => {
+    const minimalDraft: PostAdDraft = {
+      title: 'Minimal Item',
+      description: 'Minimal description.',
+      price: 0,
+      categoryId: 'cat-tools',
+    };
+
+    const dto = CreateListingRequestMapper.fromDraft(minimalDraft, []);
+
+    expect(dto.title).toBe('Minimal Item');
+    expect(dto.imageKeys).toEqual([]);
+    expect(dto.condition).toBeUndefined();
+    expect(dto.locationId).toBeUndefined();
+    expect(dto.locationDisplay).toBeUndefined();
+  });
+});

--- a/packages/contracts/src/v1/listings/dto/CreatedListingResponseDto.ts
+++ b/packages/contracts/src/v1/listings/dto/CreatedListingResponseDto.ts
@@ -1,0 +1,9 @@
+/**
+ * CreatedListingResponseDto — strongly typed contract for backend creation responses.
+ */
+export interface CreatedListingResponseDto {
+  id: string | number;
+  slug?: string;
+  status?: string;
+  moderationStatus?: string;
+}

--- a/packages/contracts/src/v1/listings/dto/index.ts
+++ b/packages/contracts/src/v1/listings/dto/index.ts
@@ -3,4 +3,5 @@ export * from './service';
 export * from "./ListingQueryParams";
 export * from './PostAdDraft';
 export * from './CreateListingRequest';
+export * from './CreatedListingResponseDto';
 


### PR DESCRIPTION
### Objective

Standardize mapper architecture across the mobile application and codify mapper governance boundaries without modifying runtime behavior or business logic.

---

### Key Changes

- **DTO SSOT Normalization**: Extracted `CreatedListingResponseDto` from local mobile types into `@esparex/contracts` (`packages/contracts/src/v1/listings/dto/CreatedListingResponseDto.ts`).
- **Mapper Import Standardization**: Updated `CreatedListingMapper` in `apps/mobile` to import response DTO definitions strictly from `@esparex/contracts`.
- **Mapper Unit Test Suite**: Added pure unit test suites for `CreateListingRequestMapper` and `CreatedListingMapper` covering draft transformations, optional/undefined fields, array boundaries, status fallbacks, and ID string coercions.
- **Architecture Governance Rules**: Codified the mandatory **Mapper Ownership Rule** in `AGENTS.md` governing boundaries between Application Mappers (`Domain ──► Request DTO`) and Infrastructure Mappers (`Response DTO ──► Domain`).

---

### Out of Scope (No Behavioral Drift)

- ❌ No UI component changes
- ❌ No API contract changes
- ❌ No business logic or service state changes
- ❌ No navigation changes
- ❌ No database schema changes

---

### Atomic Commit Plan (4 Commits)

```text
7b233c3b chore(mobile): verify architecture guards
f12e2c58 docs(governance): codify mapper ownership rules
54b26679 test(mobile): add mapper unit tests
7964c386 refactor(contracts): extract CreatedListingResponseDto
