### PR TITLE
feat(mobile): implement chat conversation list

### DIFF
--- a/apps/mobile/src/bootstrap/services.ts
+++ b/apps/mobile/src/bootstrap/services.ts
@@ -13,6 +13,8 @@ import { ExpoImagePicker } from '../features/postAd/infrastructure/ExpoImagePick
 import { IImagePicker } from '../features/postAd/application/IImagePicker';
 import { ApiUserRepository } from '../features/user/application/ApiUserRepository';
 import { UserService } from '../features/user/application/UserService';
+import { ApiChatRepository } from '../features/chat/application/ApiChatRepository';
+import { ChatService } from '../features/chat/application/ChatService';
 
 export interface IServices {
   authService: IAuthService;
@@ -20,6 +22,7 @@ export interface IServices {
   postAdService: PostAdService;
   categoryService: CategoryService;
   userService: UserService;
+  chatService: ChatService;
   imagePicker: IImagePicker;
 }
 
@@ -44,7 +47,11 @@ export const bootstrapServices = (): IServices => {
   const categoryRepository = new ApiCategoryRepository();
   const categoryService = new CategoryService(categoryRepository);
 
-  // 6. Image Picker (native Expo adapter)
+  // 6. Chat
+  const chatRepository = new ApiChatRepository();
+  const chatService = new ChatService(chatRepository);
+
+  // 7. Image Picker (native Expo adapter)
   const imagePicker = new ExpoImagePicker();
 
   return {
@@ -53,6 +60,9 @@ export const bootstrapServices = (): IServices => {
     listingService,
     postAdService,
     categoryService,
+    chatService,
     imagePicker,
   };
 };
+
+export const services = bootstrapServices();

--- a/apps/mobile/src/features/chat/application/ApiChatRepository.ts
+++ b/apps/mobile/src/features/chat/application/ApiChatRepository.ts
@@ -1,0 +1,15 @@
+import { IConversationDTO } from '@esparex/contracts';
+import { apiClient } from '../../../infrastructure/api/apiClient';
+import { IChatRepository } from './IChatRepository';
+
+export class ApiChatRepository implements IChatRepository {
+  async getConversations(): Promise<IConversationDTO[]> {
+    const response = await apiClient.get<IConversationDTO[]>('/api/v1/chat/list');
+    return response.data;
+  }
+
+  async getConversationById(id: string): Promise<IConversationDTO> {
+    const response = await apiClient.get<IConversationDTO>(`/api/v1/chat/${id}`);
+    return response.data;
+  }
+}

--- a/apps/mobile/src/features/chat/application/ChatService.ts
+++ b/apps/mobile/src/features/chat/application/ChatService.ts
@@ -1,0 +1,14 @@
+import { IConversationDTO } from '@esparex/contracts';
+import { IChatRepository } from './IChatRepository';
+
+export class ChatService {
+  constructor(private readonly chatRepository: IChatRepository) {}
+
+  async getConversations(): Promise<IConversationDTO[]> {
+    return this.chatRepository.getConversations();
+  }
+
+  async getConversationById(id: string): Promise<IConversationDTO> {
+    return this.chatRepository.getConversationById(id);
+  }
+}

--- a/apps/mobile/src/features/chat/application/IChatRepository.ts
+++ b/apps/mobile/src/features/chat/application/IChatRepository.ts
@@ -1,0 +1,6 @@
+import { IConversationDTO } from '@esparex/contracts';
+
+export interface IChatRepository {
+  getConversations(): Promise<IConversationDTO[]>;
+  getConversationById(id: string): Promise<IConversationDTO>;
+}

--- a/apps/mobile/src/features/chat/presentation/hooks/__tests__/useConversations.spec.tsx
+++ b/apps/mobile/src/features/chat/presentation/hooks/__tests__/useConversations.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useConversations } from '../useConversations';
+import { services } from '../../../../../bootstrap';
+import { IConversationDTO } from '@esparex/contracts';
+
+jest.mock('../../../../../bootstrap', () => ({
+  services: {
+    chatService: {
+      getConversations: jest.fn(),
+    },
+  },
+}));
+
+const mockGetConversations = services.chatService.getConversations as jest.MockedFunction<
+  typeof services.chatService.getConversations
+>;
+
+describe('useConversations hook', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const sampleConversations: IConversationDTO[] = [
+    {
+      id: 'conv-1',
+      ad: { id: 'ad-100', title: 'Brake Disc Pair Honda City' },
+      buyer: { id: 'usr-buyer', name: 'Rahul Sharma' },
+      seller: { id: 'usr-seller', name: 'Auto Parts India' },
+      lastMessage: 'Is this price negotiable?',
+      lastMessageAt: new Date().toISOString(),
+      unreadBuyer: 0,
+      unreadSeller: 2,
+      isBlocked: false,
+      isAdClosed: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ];
+
+  it('fetches conversations list via chatService', async () => {
+    mockGetConversations.mockResolvedValueOnce(sampleConversations);
+
+    const { result } = renderHook(() => useConversations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(sampleConversations);
+    expect(mockGetConversations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/chat/presentation/hooks/useConversations.ts
+++ b/apps/mobile/src/features/chat/presentation/hooks/useConversations.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { services } from '../../../../bootstrap';
+
+export const useConversations = () => {
+  return useQuery({
+    queryKey: ['chat', 'conversations'],
+    queryFn: async () => {
+      return await services.chatService.getConversations();
+    },
+    staleTime: 1000 * 30, // 30 seconds
+  });
+};

--- a/apps/mobile/src/features/chat/presentation/screens/ConversationListScreen.tsx
+++ b/apps/mobile/src/features/chat/presentation/screens/ConversationListScreen.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback } from 'react';
+import { View, FlatList, TouchableOpacity, RefreshControl, Image } from 'react-native';
+import { Screen, Container, AppText, Card, AppIcon } from '@esparex/mobile-ui';
+import { useConversations } from '../hooks/useConversations';
+import { IConversationDTO } from '@esparex/contracts';
+import { ErrorState } from '../../../common/components/ErrorState';
+
+interface ConversationListScreenProps {
+  onSelectConversation?: (conversationId: string) => void;
+}
+
+export const ConversationListScreen: React.FC<ConversationListScreenProps> = ({
+  onSelectConversation,
+}) => {
+  const { data: conversations, isLoading, isError, refetch, isRefetching } = useConversations();
+
+  const renderConversationItem = useCallback(
+    ({ item }: { item: IConversationDTO }) => {
+      const otherParticipant = item.seller.name || item.buyer.name || 'Chat User';
+      const unreadCount = item.unreadBuyer || item.unreadSeller || 0;
+      const formattedDate = item.lastMessageAt
+        ? new Date(item.lastMessageAt).toLocaleDateString([], {
+            month: 'short',
+            day: 'numeric',
+          })
+        : '';
+
+      return (
+        <Card className="mb-3 p-4 bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800">
+          <TouchableOpacity
+            onPress={() => onSelectConversation?.(item.id)}
+            className="flex-row items-center justify-between"
+          >
+            {/* Thumbnail / Avatar */}
+            <View className="relative mr-3">
+              {item.ad.thumbnail ? (
+                <Image
+                  source={{ uri: item.ad.thumbnail }}
+                  className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800"
+                />
+              ) : (
+                <View className="w-12 h-12 rounded-full bg-sky-100 dark:bg-sky-900/40 items-center justify-center">
+                  <AppIcon name="MessageSquare" size={20} color="#0ea5e9" />
+                </View>
+              )}
+              {unreadCount > 0 && (
+                <View className="absolute -top-1 -right-1 bg-red-500 rounded-full w-5 h-5 items-center justify-center">
+                  <AppText variant="caption" className="text-white text-[10px] font-bold">
+                    {unreadCount > 9 ? '9+' : unreadCount}
+                  </AppText>
+                </View>
+              )}
+            </View>
+
+            {/* Conversation Details */}
+            <View className="flex-1 mr-2">
+              <View className="flex-row items-center justify-between mb-1">
+                <AppText
+                  variant="body"
+                  className="font-bold text-slate-900 dark:text-white"
+                  numberOfLines={1}
+                >
+                  {otherParticipant}
+                </AppText>
+                {formattedDate ? (
+                  <AppText variant="caption" className="text-slate-400 text-xs">
+                    {formattedDate}
+                  </AppText>
+                ) : null}
+              </View>
+
+              <AppText variant="caption" className="text-sky-600 dark:text-sky-400 font-medium mb-1">
+                {item.ad.title}
+              </AppText>
+
+              <AppText
+                variant="caption"
+                className="text-slate-500 dark:text-slate-400"
+                numberOfLines={1}
+              >
+                {item.lastMessage || 'No messages yet'}
+              </AppText>
+            </View>
+
+            <AppIcon name="ChevronRight" size={18} color="#94a3b8" />
+          </TouchableOpacity>
+        </Card>
+      );
+    },
+    [onSelectConversation]
+  );
+
+  if (isError) {
+    return (
+      <Screen>
+        <ErrorState onRetry={refetch} />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right']}>
+      <Container className="flex-1 bg-slate-50 dark:bg-slate-950 p-4">
+        {/* Header */}
+        <View className="mb-4">
+          <AppText variant="h2" className="font-bold text-slate-900 dark:text-white">
+            Messages & Chats
+          </AppText>
+        </View>
+
+        {/* Conversation List */}
+        <FlatList
+          data={conversations || []}
+          keyExtractor={(item) => item.id}
+          renderItem={renderConversationItem}
+          showsVerticalScrollIndicator={false}
+          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+          ListEmptyComponent={
+            !isLoading ? (
+              <View className="items-center justify-center py-16 px-4">
+                <View className="w-16 h-16 rounded-full bg-slate-100 dark:bg-slate-800 items-center justify-center mb-4">
+                  <AppIcon name="MessageSquare" size={28} color="#94a3b8" />
+                </View>
+                <AppText variant="h3" className="font-bold text-slate-800 dark:text-slate-200 mb-1">
+                  No Messages Yet
+                </AppText>
+                <AppText variant="caption" className="text-slate-500 text-center">
+                  Start inquiring about spare parts or listings to see your chats here.
+                </AppText>
+              </View>
+            ) : null
+          }
+        />
+      </Container>
+    </Screen>
+  );
+};

--- a/apps/mobile/src/features/chat/presentation/screens/__tests__/ConversationListScreen.spec.tsx
+++ b/apps/mobile/src/features/chat/presentation/screens/__tests__/ConversationListScreen.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('../../../../../bootstrap', () => ({
+  services: {
+    chatService: {
+      getConversations: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('lucide-react-native', () => {
+  const { View } = require('react-native');
+  return new Proxy(
+    {},
+    {
+      get: () => View,
+    }
+  );
+});
+
+import { ConversationListScreen } from '../ConversationListScreen';
+import { useConversations } from '../../hooks/useConversations';
+import { IConversationDTO } from '@esparex/contracts';
+
+jest.mock('../../hooks/useConversations');
+
+const mockUseConversations = useConversations as jest.MockedFunction<typeof useConversations>;
+
+describe('ConversationListScreen Component', () => {
+  const sampleConversation: IConversationDTO = {
+    id: 'conv-101',
+    ad: { id: 'ad-55', title: 'Hyundai Creta Alloy Wheel 17 inch' },
+    buyer: { id: 'usr-buyer', name: 'Vikas Kumar' },
+    seller: { id: 'usr-me', name: 'My Spare Store' },
+    lastMessage: 'Can you ship to Bangalore?',
+    lastMessageAt: new Date().toISOString(),
+    unreadBuyer: 1,
+    unreadSeller: 0,
+    isBlocked: false,
+    isAdClosed: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders conversations list items', () => {
+    mockUseConversations.mockReturnValue({
+      data: [sampleConversation],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+    } as any);
+
+    const { getByText } = render(<ConversationListScreen />);
+    expect(getByText('Messages & Chats')).toBeTruthy();
+    expect(getByText('My Spare Store')).toBeTruthy();
+    expect(getByText('Hyundai Creta Alloy Wheel 17 inch')).toBeTruthy();
+    expect(getByText('Can you ship to Bangalore?')).toBeTruthy();
+  });
+
+  it('triggers onSelectConversation callback when pressed', () => {
+    mockUseConversations.mockReturnValue({
+      data: [sampleConversation],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+    } as any);
+
+    const onSelectConversation = jest.fn();
+    const { getByText } = render(
+      <ConversationListScreen onSelectConversation={onSelectConversation} />
+    );
+
+    fireEvent.press(getByText('My Spare Store'));
+    expect(onSelectConversation).toHaveBeenCalledWith('conv-101');
+  });
+
+  it('renders empty state when user has no conversations', () => {
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+    } as any);
+
+    const { getByText } = render(<ConversationListScreen />);
+    expect(getByText('No Messages Yet')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/providers/__tests__/providers.spec.tsx
+++ b/apps/mobile/src/providers/__tests__/providers.spec.tsx
@@ -90,6 +90,7 @@ describe('AppProvider', () => {
     listingService: mockListingService,
     postAdService: { submit: jest.fn() } as unknown as PostAdService,
     categoryService: { getCategories: jest.fn() } as unknown as any,
+    chatService: { getConversations: jest.fn() } as unknown as any,
     imagePicker: { pick: jest.fn() },
   };
 

--- a/docs/reports/ChatConversations-Integration-Audit.md
+++ b/docs/reports/ChatConversations-Integration-Audit.md
@@ -1,0 +1,15 @@
+# Chat Conversation List Verification Report — Issue #310 (PR 1)
+
+## 1. Scope & Verification
+- **Target Branch:** `feat/issue-310-pr1-conversations`
+- **Focus Area:** Chat Inbox List (`IChatRepository`, `ApiChatRepository`, `ChatService`, `useConversations.ts`, `ConversationListScreen.tsx`)
+
+## 2. Quality Verification Results
+
+| Quality Gate | Status | Details |
+|---|---|---|
+| **Mobile Architecture Guard** | ✅ PASS | `npm run guard:mobile-architecture` (All mobile layer boundaries clean) |
+| **TypeScript Type Check** | ✅ PASS | `npm run type-check -w apps/mobile` (0 errors) |
+| **Jest Unit Test Suite** | ✅ PASS | `npm test -w apps/mobile` (26/26 test suites passed, 80/80 tests green) |
+| **Chat Query Caching** | ✅ PASS | Structured key `['chat', 'conversations']` |
+| **Backend Route Alignment** | ✅ PASS | Consuming canonical `/v1/chat/list` endpoint |


### PR DESCRIPTION
### Objective

PR 1 of Issue #310: Implement the Chat Conversation List inbox view, `IChatRepository`, `ApiChatRepository`, `ChatService`, `useConversations` React Query hook, `ConversationListScreen`, and unit test coverage.

---

### Key Features & Technical Details

- **Chat Repository & Service**: Created `IChatRepository`, `ApiChatRepository`, and `ChatService` consuming backend `GET /api/v1/chat/list`. Registered `chatService` in `bootstrap/services.ts`.
- **Query Hook**: Created `useConversations.ts` using query key `['chat', 'conversations']`.
- **Inbox UI**: Created `ConversationListScreen.tsx` rendering participant details, ad thumbnails, last message snippets, unread badges, pull-to-refresh, and empty inbox state.
- **Unit Test Suite**: Created test coverage in `useConversations.spec.tsx` and `ConversationListScreen.spec.tsx`.
- **Verification Audit**: Published [`docs/reports/ChatConversations-Integration-Audit.md`](file:///Users/admin/Desktop/Esparex/docs/reports/ChatConversations-Integration-Audit.md) confirming clean quality gate status.

---

### Out of Scope (Remaining PRs in Issue #310)

- ⏳ PR 2: Chat Thread & Real-Time Socket/Polling Integration
- ⏳ PR 3: Real-Time Notifications & Unread Counters
- ⏳ PR 4: Chat & Notification Performance & Quality Gate

---

### Atomic Commit Plan (3 Commits)

```text
0267d4e5 chore(mobile): verify chat conversations quality gates
530f9de8 test(mobile): add chat conversation list tests
3074f472 feat(mobile): implement chat conversation list
