### PR TITLE
feat(mobile): wire chat and profile tab navigation

### DIFF
--- a/apps/mobile/src/features/user/presentation/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/features/user/presentation/screens/ProfileScreen.tsx
@@ -1,10 +1,20 @@
 import React, { useCallback } from 'react';
-import { View, ScrollView, RefreshControl, ActivityIndicator } from 'react-native';
+import {
+  View,
+  ScrollView,
+  RefreshControl,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Screen, Container, AppText, Avatar, Card, AppIcon, Badge } from '@esparex/mobile-ui';
 import { useProfile } from '../hooks/useProfile';
 import { ErrorState } from '../../../common/components/ErrorState';
+import { ProfileStackParamList, ROUTES } from '../../../../navigation/routes';
 
-export const ProfileScreen = () => {
+type Props = NativeStackScreenProps<ProfileStackParamList, typeof ROUTES.PROFILE_OVERVIEW>;
+
+export const ProfileScreen = ({ navigation }: Props) => {
   const { data: profile, isLoading, isError, refetch, isRefetching } = useProfile();
 
   const memberSince = profile?.createdAt
@@ -13,6 +23,10 @@ export const ProfileScreen = () => {
         year: 'numeric',
       })
     : undefined;
+
+  const handleSettingsPress = useCallback(() => {
+    navigation.navigate(ROUTES.PROFILE_SETTINGS);
+  }, [navigation]);
 
   if (isError) {
     return (
@@ -35,6 +49,21 @@ export const ProfileScreen = () => {
   return (
     <Screen edges={['top', 'left', 'right']}>
       <Container className="flex-1 bg-slate-50 dark:bg-slate-950">
+        {/* Top-bar with Settings shortcut */}
+        <View className="flex-row items-center justify-between px-4 pt-2 pb-1">
+          <AppText variant="h2" className="font-bold text-slate-900 dark:text-white">
+            My Profile
+          </AppText>
+          <TouchableOpacity
+            onPress={handleSettingsPress}
+            accessibilityLabel="Open settings"
+            accessibilityRole="button"
+            className="p-2"
+          >
+            <AppIcon name="Settings" size={22} color="#64748b" />
+          </TouchableOpacity>
+        </View>
+
         <ScrollView
           showsVerticalScrollIndicator={false}
           refreshControl={
@@ -108,6 +137,25 @@ export const ProfileScreen = () => {
               </AppText>
             </View>
           </Card>
+
+          {/* Settings shortcut card */}
+          <TouchableOpacity
+            onPress={handleSettingsPress}
+            accessibilityLabel="Go to account settings"
+            accessibilityRole="button"
+          >
+            <Card className="p-4 mb-4 bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800">
+              <View className="flex-row items-center justify-between">
+                <View className="flex-row items-center">
+                  <AppIcon name="Settings" size={18} color="#64748b" />
+                  <AppText variant="body" className="font-semibold text-slate-800 dark:text-slate-200 ml-2.5">
+                    Account Settings
+                  </AppText>
+                </View>
+                <AppIcon name="ChevronRight" size={18} color="#94a3b8" />
+              </View>
+            </Card>
+          </TouchableOpacity>
         </ScrollView>
       </Container>
     </Screen>

--- a/apps/mobile/src/features/user/presentation/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/features/user/presentation/screens/SettingsScreen.tsx
@@ -1,13 +1,17 @@
 import React, { useState, useCallback } from 'react';
 import { View, ScrollView, Switch, TouchableOpacity, Alert } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Screen, Container, AppText, Card, AppIcon, AppButton } from '@esparex/mobile-ui';
 import { useProfile } from '../hooks/useProfile';
 import { useUpdateProfile } from '../hooks/useUpdateProfile';
 import { useAuth } from '../../../../providers/AuthProvider';
 import { EditProfileModal } from '../components/EditProfileModal';
 import { ErrorState } from '../../../common/components/ErrorState';
+import { ProfileStackParamList, ROUTES } from '../../../../navigation/routes';
 
-export const SettingsScreen = () => {
+type Props = NativeStackScreenProps<ProfileStackParamList, typeof ROUTES.PROFILE_SETTINGS>;
+
+export const SettingsScreen = ({ navigation }: Props) => {
   const { data: profile, isLoading, isError, refetch } = useProfile();
   const updateProfileMutation = useUpdateProfile();
   const { logout } = useAuth();
@@ -47,6 +51,21 @@ export const SettingsScreen = () => {
   return (
     <Screen edges={['top', 'left', 'right']}>
       <Container className="flex-1 bg-slate-50 dark:bg-slate-950">
+        {/* Back navigation header */}
+        <View className="flex-row items-center px-4 pt-2 pb-1">
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            accessibilityLabel="Back to profile"
+            accessibilityRole="button"
+            className="mr-3 p-1"
+          >
+            <AppIcon name="ArrowLeft" size={22} color="#0ea5e9" />
+          </TouchableOpacity>
+          <AppText variant="h2" className="font-bold text-slate-900 dark:text-white">
+            Settings
+          </AppText>
+        </View>
+
         <ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={{ padding: 16, paddingBottom: 100 }}

--- a/apps/mobile/src/features/user/presentation/screens/__tests__/ProfileScreen.spec.tsx
+++ b/apps/mobile/src/features/user/presentation/screens/__tests__/ProfileScreen.spec.tsx
@@ -27,6 +27,10 @@ jest.mock('../../hooks/useProfile');
 
 const mockUseProfile = useProfile as jest.MockedFunction<typeof useProfile>;
 
+// Minimal mock navigation prop required by the typed NativeStackScreenProps
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any;
+const mockRoute = { key: 'ProfileOverview', name: 'ProfileOverview', params: undefined } as any;
+
 describe('ProfileScreen Component', () => {
   const sampleUser: User = {
     id: 'usr-profile-99',
@@ -58,7 +62,7 @@ describe('ProfileScreen Component', () => {
       isRefetching: false,
     } as any);
 
-    const { queryByText } = render(<ProfileScreen />);
+    const { queryByText } = render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     expect(queryByText('Jane Doe')).toBeNull();
   });
 
@@ -71,7 +75,7 @@ describe('ProfileScreen Component', () => {
       isRefetching: false,
     } as any);
 
-    const { getByText } = render(<ProfileScreen />);
+    const { getByText } = render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     expect(getByText('Jane Doe')).toBeTruthy();
     expect(getByText('+919876543210')).toBeTruthy();
     expect(getByText('Phone Verified')).toBeTruthy();
@@ -87,7 +91,7 @@ describe('ProfileScreen Component', () => {
       isRefetching: false,
     } as any);
 
-    const { getByText } = render(<ProfileScreen />);
+    const { getByText } = render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     expect(getByText('Something went wrong')).toBeTruthy();
   });
 });

--- a/apps/mobile/src/features/user/presentation/screens/__tests__/SettingsScreen.spec.tsx
+++ b/apps/mobile/src/features/user/presentation/screens/__tests__/SettingsScreen.spec.tsx
@@ -39,6 +39,10 @@ jest.mock('../../hooks/useProfile');
 
 const mockUseProfile = useProfile as jest.MockedFunction<typeof useProfile>;
 
+// Minimal mock navigation required by the typed NativeStackScreenProps
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any;
+const mockRoute = { key: 'ProfileSettings', name: 'ProfileSettings', params: undefined } as any;
+
 describe('SettingsScreen Component', () => {
   let queryClient: QueryClient;
 
@@ -64,7 +68,7 @@ describe('SettingsScreen Component', () => {
   const renderScreen = () =>
     render(
       <QueryClientProvider client={queryClient}>
-        <SettingsScreen />
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
       </QueryClientProvider>
     );
 

--- a/apps/mobile/src/navigation/ChatNavigator.tsx
+++ b/apps/mobile/src/navigation/ChatNavigator.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { ChatStackParamList, ROUTES } from './routes';
+import { ConversationListScreen } from '../features/chat/presentation/screens/ConversationListScreen';
+import { ChatThreadScreen } from '../features/chat/presentation/screens/ChatThreadScreen';
+
+const Stack = createNativeStackNavigator<ChatStackParamList>();
+
+// ---------------------------------------------------------------------------
+// ChatNavigator — nested stack inside the Chat tab.
+//
+// CONVERSATION_LIST → select conversation → CHAT_THREAD (with header)
+// ---------------------------------------------------------------------------
+
+const ConversationListEntry = ({
+  navigation,
+}: NativeStackScreenProps<ChatStackParamList, typeof ROUTES.CONVERSATION_LIST>) => {
+  const handleSelectConversation = useCallback(
+    (conversationId: string) => {
+      navigation.navigate(ROUTES.CHAT_THREAD, { conversationId });
+    },
+    [navigation],
+  );
+
+  return <ConversationListScreen onSelectConversation={handleSelectConversation} />;
+};
+
+const ChatThreadEntry = ({
+  route,
+  navigation,
+}: NativeStackScreenProps<ChatStackParamList, typeof ROUTES.CHAT_THREAD>) => {
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  return (
+    <ChatThreadScreen
+      conversationId={route.params.conversationId}
+      onBack={handleBack}
+    />
+  );
+};
+
+export const ChatNavigator = () => (
+  <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Screen name={ROUTES.CONVERSATION_LIST} component={ConversationListEntry} />
+    <Stack.Screen name={ROUTES.CHAT_THREAD} component={ChatThreadEntry} />
+  </Stack.Navigator>
+);

--- a/apps/mobile/src/navigation/MainTabs.tsx
+++ b/apps/mobile/src/navigation/MainTabs.tsx
@@ -1,59 +1,68 @@
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MainTabParamList, ROUTES } from './routes';
-import { AppIcon, Center, AppText } from '@esparex/mobile-ui';
+import { AppIcon } from '@esparex/mobile-ui';
 import { MarketplaceScreen } from '../features/listings/presentation/screens/MarketplaceScreen';
 import { SearchScreen } from '../features/listings/presentation/screens/SearchScreen';
 import { PostAdProvider } from '../features/postAd/PostAdProvider';
 import { PostAdScreen } from '../features/postAd/presentation/PostAdScreen';
+import { ChatNavigator } from './ChatNavigator';
+import { ProfileNavigator } from './ProfileNavigator';
+import { useUnreadNotificationsCount } from '../features/notifications/presentation/hooks/useNotifications';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
-import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
-
-// Temporary placeholder for tab screens
-const PlaceholderScreen = ({ route }: BottomTabScreenProps<MainTabParamList>) => (
-  <Center className="flex-1 bg-slate-950">
-    <AppText variant="h3" className="text-slate-300">{route.name}</AppText>
-  </Center>
-);
-
-// PostAdTab wraps the screen in its feature-local provider.
-// Provider scope is intentionally narrow: mounts/unmounts with the tab,
-// so the draft is discarded when the user navigates away.
+// ---------------------------------------------------------------------------
+// PostAdTab — scoped provider mounts/unmounts with the tab so the draft
+// is discarded when the user navigates away.
+// ---------------------------------------------------------------------------
 const PostAdTab = () => (
   <PostAdProvider>
     <PostAdScreen />
   </PostAdProvider>
 );
 
+// ---------------------------------------------------------------------------
+// MainTabs — bottom tab bar.
+//
+// Tabs:
+//   Home      → MarketplaceScreen
+//   Search    → SearchScreen
+//   Post Ad   → PostAdScreen (scoped PostAdProvider)
+//   Chat      → ChatNavigator (list → thread nested stack)
+//   Profile   → ProfileNavigator (overview → settings nested stack)
+// ---------------------------------------------------------------------------
+
 export const MainTabs = () => {
+  // Drives the unread-count badge on the Chat tab.
+  const unreadCount = useUnreadNotificationsCount();
+
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarStyle: {
           backgroundColor: '#020617', // slate-950
-          borderTopColor: '#1e293b', // slate-800
+          borderTopColor: '#1e293b',  // slate-800
         },
-        tabBarActiveTintColor: '#0ea5e9', // sky-500
+        tabBarActiveTintColor: '#0ea5e9',   // sky-500
         tabBarInactiveTintColor: '#64748b', // slate-500
         tabBarIcon: ({ color, size }) => {
           let iconName: React.ComponentProps<typeof AppIcon>['name'] = 'Home';
-          
-          if (route.name === ROUTES.HOME_TAB) iconName = 'Home';
-          else if (route.name === ROUTES.SEARCH_TAB) iconName = 'Search';
+
+          if (route.name === ROUTES.HOME_TAB)    iconName = 'Home';
+          else if (route.name === ROUTES.SEARCH_TAB)  iconName = 'Search';
           else if (route.name === ROUTES.POST_AD_TAB) iconName = 'PlusCircle';
-          else if (route.name === ROUTES.CHAT_TAB) iconName = 'MessageCircle';
+          else if (route.name === ROUTES.CHAT_TAB)    iconName = 'MessageCircle';
           else if (route.name === ROUTES.PROFILE_TAB) iconName = 'User';
 
           return <AppIcon name={iconName} size={size} color={color} />;
         },
       })}
     >
-      <Tab.Screen 
-        name={ROUTES.HOME_TAB} 
-        component={MarketplaceScreen} 
+      <Tab.Screen
+        name={ROUTES.HOME_TAB}
+        component={MarketplaceScreen}
         options={{ title: 'Home' }}
       />
       <Tab.Screen
@@ -66,14 +75,19 @@ export const MainTabs = () => {
         component={PostAdTab}
         options={{ title: 'Post Ad' }}
       />
-      <Tab.Screen 
-        name={ROUTES.CHAT_TAB} 
-        component={PlaceholderScreen} 
-        options={{ title: 'Chat' }}
+      <Tab.Screen
+        name={ROUTES.CHAT_TAB}
+        component={ChatNavigator}
+        options={{
+          title: 'Chat',
+          // Show a badge when there are unread notifications
+          tabBarBadge: unreadCount > 0 ? unreadCount : undefined,
+          tabBarBadgeStyle: { backgroundColor: '#ef4444', color: '#ffffff', fontSize: 10 },
+        }}
       />
-      <Tab.Screen 
-        name={ROUTES.PROFILE_TAB} 
-        component={PlaceholderScreen} 
+      <Tab.Screen
+        name={ROUTES.PROFILE_TAB}
+        component={ProfileNavigator}
         options={{ title: 'Profile' }}
       />
     </Tab.Navigator>

--- a/apps/mobile/src/navigation/ProfileNavigator.tsx
+++ b/apps/mobile/src/navigation/ProfileNavigator.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ProfileStackParamList, ROUTES } from './routes';
+import { ProfileScreen } from '../features/user/presentation/screens/ProfileScreen';
+import { SettingsScreen } from '../features/user/presentation/screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator<ProfileStackParamList>();
+
+// ---------------------------------------------------------------------------
+// ProfileNavigator — nested stack inside the Profile tab.
+//
+// PROFILE_OVERVIEW → PROFILE_SETTINGS (accessible via the Settings card)
+// ---------------------------------------------------------------------------
+
+export const ProfileNavigator = () => (
+  <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Screen name={ROUTES.PROFILE_OVERVIEW} component={ProfileScreen} />
+    <Stack.Screen name={ROUTES.PROFILE_SETTINGS} component={SettingsScreen} />
+  </Stack.Navigator>
+);

--- a/apps/mobile/src/navigation/linking.ts
+++ b/apps/mobile/src/navigation/linking.ts
@@ -19,9 +19,21 @@ export const linking: LinkingOptions<RootStackParamList> = {
               [ROUTES.HOME_TAB]: 'home',
               [ROUTES.SEARCH_TAB]: 'search',
               [ROUTES.POST_AD_TAB]: 'post',
-              [ROUTES.CHAT_TAB]: 'chat',
-              [ROUTES.PROFILE_TAB]: 'profile',
-            }
+              // Chat nested screens: esparex://chat, esparex://chat/thread/:conversationId
+              [ROUTES.CHAT_TAB]: {
+                screens: {
+                  [ROUTES.CONVERSATION_LIST]: 'chat',
+                  [ROUTES.CHAT_THREAD]: 'chat/thread/:conversationId',
+                },
+              },
+              // Profile nested screens: esparex://profile, esparex://profile/settings
+              [ROUTES.PROFILE_TAB]: {
+                screens: {
+                  [ROUTES.PROFILE_OVERVIEW]: 'profile',
+                  [ROUTES.PROFILE_SETTINGS]: 'profile/settings',
+                },
+              },
+            },
           },
           [ROUTES.LISTING_DETAILS]: 'listing/:id',
         },

--- a/apps/mobile/src/navigation/routes.ts
+++ b/apps/mobile/src/navigation/routes.ts
@@ -19,6 +19,14 @@ export const ROUTES = {
   POST_AD_TAB: 'PostAdTab',
   CHAT_TAB: 'ChatTab',
   PROFILE_TAB: 'ProfileTab',
+
+  // Chat nested screens
+  CONVERSATION_LIST: 'ConversationList',
+  CHAT_THREAD: 'ChatThread',
+
+  // Profile nested screens
+  PROFILE_OVERVIEW: 'ProfileOverview',
+  PROFILE_SETTINGS: 'ProfileSettings',
 } as const;
 
 import { NavigatorScreenParams } from '@react-navigation/native';
@@ -44,8 +52,20 @@ export type MainTabParamList = {
   [ROUTES.HOME_TAB]: undefined;
   [ROUTES.SEARCH_TAB]: undefined;
   [ROUTES.POST_AD_TAB]: undefined;
-  [ROUTES.CHAT_TAB]: undefined;
-  [ROUTES.PROFILE_TAB]: undefined;
+  [ROUTES.CHAT_TAB]: NavigatorScreenParams<ChatStackParamList> | undefined;
+  [ROUTES.PROFILE_TAB]: NavigatorScreenParams<ProfileStackParamList> | undefined;
+};
+
+// Chat stack: list → thread
+export type ChatStackParamList = {
+  [ROUTES.CONVERSATION_LIST]: undefined;
+  [ROUTES.CHAT_THREAD]: { conversationId: string };
+};
+
+// Profile stack: overview → settings
+export type ProfileStackParamList = {
+  [ROUTES.PROFILE_OVERVIEW]: undefined;
+  [ROUTES.PROFILE_SETTINGS]: undefined;
 };
 
 


### PR DESCRIPTION
## Summary

Closes #311 (PR 1 of 3)

Replaces the placeholder screens in the Chat and Profile tabs with fully
functional nested stack navigators. The app now has a complete navigation
tree with deep link support for all screens.

## Changes

### Navigation
- Add `CHAT_THREAD`, `CONVERSATION_LIST`, `PROFILE_OVERVIEW`, `PROFILE_SETTINGS` routes
- Add `ChatStackParamList` and `ProfileStackParamList` typed param lists
- **New** `ChatNavigator.tsx` — nested stack: ConversationList → ChatThread
- **New** `ProfileNavigator.tsx` — nested stack: ProfileOverview → ProfileSettings
- Replace `PlaceholderScreen` in `MainTabs.tsx` with real navigators
- Add live unread notification badge on the Chat tab (`useUnreadNotificationsCount`)
- Extend deep link config: `chat/`, `chat/thread/:conversationId`, `profile/`, `profile/settings`

### Screens
- `ProfileScreen` — adds Settings icon button in header + Settings shortcut card; accepts typed `NativeStackScreenProps`
- `SettingsScreen` — adds back-button header row; accepts typed `NativeStackScreenProps`

### Tests
- Fix `ProfileScreen.spec.tsx` and `SettingsScreen.spec.tsx` to supply mock `navigation` + `route` props

## Verification

- ✅ `npm run type-check -w apps/mobile` — 0 errors
- ✅ `npm test -w apps/mobile` — 30 suites / 90 tests

## Accessibility

- ✅ Back button uses `accessibilityRole="button"` + `accessibilityLabel`
- ✅ Settings button uses `accessibilityRole="button"` + `accessibilityLabel`
- ✅ Logical focus order preserved across all new screens
- ✅ No keyboard traps introduced
- ✅ No accessibility regressions
