### PR TITLE
test(mobile): expand notification and unread count test coverage

### DIFF
--- a/apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx
+++ b/apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useNotifications,
+  useUnreadNotificationsCount,
+} from '../useNotifications';
+import { services } from '../../../../../bootstrap';
+import { AppNotification } from '../../../domain/Notification';
+
+jest.mock('../../../../../bootstrap', () => ({
+  services: {
+    notificationService: {
+      getNotifications: jest.fn(),
+    },
+  },
+}));
+
+const mockGetNotifications = services.notificationService
+  .getNotifications as jest.MockedFunction<
+  typeof services.notificationService.getNotifications
+>;
+
+const makeWrapper = () => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+const sampleNotifications: AppNotification[] = [
+  {
+    id: 'n-1',
+    type: 'CHAT',
+    title: 'New offer on your listing',
+    body: 'Someone made an offer.',
+    isRead: false,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 'n-2',
+    type: 'AD_STATUS',
+    title: 'Listing approved',
+    body: 'Your listing is live.',
+    isRead: true,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 'n-3',
+    type: 'CHAT',
+    title: 'Chat message received',
+    body: 'You have a new message.',
+    isRead: false,
+    createdAt: new Date().toISOString(),
+  },
+];
+
+describe('useNotifications', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns notifications from the service', async () => {
+    mockGetNotifications.mockResolvedValueOnce(sampleNotifications);
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(sampleNotifications);
+    expect(mockGetNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when service resolves with empty list', async () => {
+    mockGetNotifications.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('useUnreadNotificationsCount', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns count of unread notifications', async () => {
+    mockGetNotifications.mockResolvedValueOnce(sampleNotifications);
+
+    const { result } = renderHook(() => useUnreadNotificationsCount(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current).toBe(2));
+  });
+
+  it('returns 0 when all notifications are read', async () => {
+    const allRead = sampleNotifications.map((n) => ({ ...n, isRead: true }));
+    mockGetNotifications.mockResolvedValueOnce(allRead);
+
+    const { result } = renderHook(() => useUnreadNotificationsCount(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current).toBe(0));
+  });
+
+  it('returns 0 when notifications list is empty', async () => {
+    mockGetNotifications.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useUnreadNotificationsCount(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current).toBe(0));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #311 (PR 3 of 3 — final quality pass)

Adds test coverage for the `useNotifications` and
`useUnreadNotificationsCount` hooks introduced in Issue #310 and used
by the Chat tab badge wired in PR1 of this issue.

## Changes

- **New** `useUnreadCount.spec.tsx` — 5 test cases:
  - `useNotifications` returns notifications from the service
  - `useNotifications` handles empty list
  - `useUnreadNotificationsCount` returns correct count of unread items
  - `useUnreadNotificationsCount` returns 0 when all are read
  - `useUnreadNotificationsCount` returns 0 for empty list

## Verification

- ✅ `npm run type-check -w apps/mobile` — 0 errors
- ✅ `npm test -w apps/mobile` — **32 suites / 100 tests**
- ✅ `npm run type-check` (monorepo-wide) — **0 errors** across contracts, shared, core, backend-api, apps-admin, apps-web
- ✅ Pre-push hooks: backend-api 336/336, core 297/297

## Four-Rule Governance Check

- ✅ No DTO imported into presentation
- ✅ No repository imported into UI
- ✅ No service instantiated outside bootstrap
- ✅ No new `any` / `as any` introduced
