### PR TITLE
feat(mobile): implement push token registration lifecycle (#312)

### DIFF
--- a/apps/mobile/src/bootstrap/services.ts
+++ b/apps/mobile/src/bootstrap/services.ts
@@ -19,6 +19,8 @@ import { ApiNotificationRepository } from '../features/notifications/application
 import { NotificationService } from '../features/notifications/application/NotificationService';
 import { IPushNotificationService } from '../features/notifications/application/IPushNotificationService';
 import { ExpoPushNotificationService } from '../features/notifications/infrastructure/ExpoPushNotificationService';
+import { IPushTokenRegistrationService } from '../features/notifications/application/IPushTokenRegistrationService';
+import { ApiPushTokenRegistrationService } from '../features/notifications/infrastructure/ApiPushTokenRegistrationService';
 
 export interface IServices {
   authService: IAuthService;
@@ -29,40 +31,45 @@ export interface IServices {
   chatService: ChatService;
   notificationService: NotificationService;
   pushNotificationService: IPushNotificationService;
+  pushTokenRegistrationService: IPushTokenRegistrationService;
   imagePicker: IImagePicker;
 }
 
 export const bootstrapServices = (): IServices => {
-  // 1. Auth
-  const authService = new AuthServiceImpl(apiClient, SecureStoreAdapter);
+  // 1. Push Notification & Registration Services
+  const pushNotificationService: IPushNotificationService = new ExpoPushNotificationService();
+  const pushTokenRegistrationService: IPushTokenRegistrationService = new ApiPushTokenRegistrationService(
+    pushNotificationService,
+    apiClient
+  );
+
+  // 2. Auth (injected with pushTokenRegistrationService)
+  const authService = new AuthServiceImpl(apiClient, SecureStoreAdapter, pushTokenRegistrationService);
   setRefreshExecutor(authService.executeTokenRefresh);
 
-  // 2. User
+  // 3. User
   const userRepository = new ApiUserRepository();
   const userService = new UserService(userRepository);
 
-  // 3. Listings
+  // 4. Listings
   const listingRepository = new ApiListingRepository();
   const listingService = new ListingService(listingRepository);
 
-  // 4. Post Ad (shares listingRepository)
+  // 5. Post Ad (shares listingRepository)
   const imageUploadService = new ApiImageUploadService();
   const postAdService = new PostAdService(imageUploadService, listingRepository);
 
-  // 5. Categories
+  // 6. Categories
   const categoryRepository = new ApiCategoryRepository();
   const categoryService = new CategoryService(categoryRepository);
 
-  // 6. Chat
+  // 7. Chat
   const chatRepository = new ApiChatRepository();
   const chatService = new ChatService(chatRepository);
 
-  // 7. Notifications
+  // 8. Notifications
   const notificationRepository = new ApiNotificationRepository();
   const notificationService = new NotificationService(notificationRepository);
-
-  // 8. Push notification service (device token acquisition)
-  const pushNotificationService: IPushNotificationService = new ExpoPushNotificationService();
 
   // 9. Image Picker (native Expo adapter)
   const imagePicker = new ExpoImagePicker();
@@ -76,6 +83,7 @@ export const bootstrapServices = (): IServices => {
     chatService,
     notificationService,
     pushNotificationService,
+    pushTokenRegistrationService,
     imagePicker,
   };
 };

--- a/apps/mobile/src/features/notifications/application/IPushTokenRegistrationService.ts
+++ b/apps/mobile/src/features/notifications/application/IPushTokenRegistrationService.ts
@@ -1,0 +1,25 @@
+/**
+ * IPushTokenRegistrationService — application-layer port for push token backend registration.
+ *
+ * Responsibilities:
+ *   - Orchestrate acquiring push token via IPushNotificationService
+ *   - Register push token with backend POST /api/v1/notifications/register
+ *   - Unregister push token during logout
+ *
+ * Does NOT:
+ *   - Interact directly with React or UI state
+ *   - Handle notification payload reception (PR 3)
+ */
+export interface IPushTokenRegistrationService {
+  /**
+   * Acquire Expo push token and register with backend.
+   * Returns true on success, false on failure (fail-safe).
+   */
+  registerPushToken(): Promise<boolean>;
+
+  /**
+   * Unregister currently registered push token from backend.
+   * Returns true on success, false on failure (fail-safe).
+   */
+  unregisterPushToken(): Promise<boolean>;
+}

--- a/apps/mobile/src/features/notifications/infrastructure/ApiPushTokenRegistrationService.ts
+++ b/apps/mobile/src/features/notifications/infrastructure/ApiPushTokenRegistrationService.ts
@@ -1,0 +1,61 @@
+import { Platform } from 'react-native';
+import { AxiosInstance } from 'axios';
+import { RegisterPushTokenRequestDTO } from '@esparex/contracts';
+import { IPushNotificationService } from '../application/IPushNotificationService';
+import { IPushTokenRegistrationService } from '../application/IPushTokenRegistrationService';
+
+/**
+ * ApiPushTokenRegistrationService
+ *
+ * Concrete infrastructure adapter for registering/unregistering device push tokens
+ * with the Esparex backend API (`/api/v1/notifications/register`).
+ */
+export class ApiPushTokenRegistrationService implements IPushTokenRegistrationService {
+  private currentToken: string | null = null;
+
+  constructor(
+    private readonly pushNotificationService: IPushNotificationService,
+    private readonly apiClient: AxiosInstance
+  ) {}
+
+  async registerPushToken(): Promise<boolean> {
+    try {
+      const result = await this.pushNotificationService.registerForPushNotifications();
+      if (!result.success) {
+        return false;
+      }
+
+      const platform: 'android' | 'ios' | 'web' =
+        Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web';
+
+      const payload: RegisterPushTokenRequestDTO = {
+        token: result.token.value,
+        platform: result.token.platform || platform,
+      };
+
+      await this.apiClient.post('/notifications/register', payload);
+      this.currentToken = result.token.value;
+      return true;
+    } catch {
+      // Fail-safe: push registration errors must not interrupt core app user flows
+      return false;
+    }
+  }
+
+  async unregisterPushToken(): Promise<boolean> {
+    const tokenToUnregister = this.currentToken;
+    this.currentToken = null;
+
+    if (!tokenToUnregister) {
+      return false;
+    }
+
+    try {
+      await this.apiClient.post('/auth/logout', { fcmToken: tokenToUnregister });
+      return true;
+    } catch {
+      // Fail-safe: unregistration failures on logout should not prevent session clearing
+      return false;
+    }
+  }
+}

--- a/apps/mobile/src/features/notifications/infrastructure/__tests__/ApiPushTokenRegistrationService.spec.ts
+++ b/apps/mobile/src/features/notifications/infrastructure/__tests__/ApiPushTokenRegistrationService.spec.ts
@@ -1,0 +1,113 @@
+import { Platform } from 'react-native';
+import { AxiosInstance } from 'axios';
+import { ApiPushTokenRegistrationService } from '../ApiPushTokenRegistrationService';
+import { IPushNotificationService } from '../../application/IPushNotificationService';
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+describe('ApiPushTokenRegistrationService', () => {
+  let pushNotificationService: jest.Mocked<IPushNotificationService>;
+  let apiClient: jest.Mocked<AxiosInstance>;
+  let service: ApiPushTokenRegistrationService;
+
+  beforeEach(() => {
+    pushNotificationService = {
+      requestPermission: jest.fn(),
+      getExpoPushToken: jest.fn(),
+      registerForPushNotifications: jest.fn(),
+    };
+
+    apiClient = {
+      post: jest.fn(),
+    } as unknown as jest.Mocked<AxiosInstance>;
+
+    service = new ApiPushTokenRegistrationService(pushNotificationService, apiClient);
+  });
+
+  describe('registerPushToken', () => {
+    it('successfully acquires token and posts payload to backend', async () => {
+      pushNotificationService.registerForPushNotifications.mockResolvedValue({
+        success: true,
+        token: { value: 'ExponentPushToken[test-123]', platform: 'ios' },
+      });
+
+      apiClient.post.mockResolvedValue({ data: { success: true } });
+
+      const result = await service.registerPushToken();
+
+      expect(result).toBe(true);
+      expect(apiClient.post).toHaveBeenCalledWith('/notifications/register', {
+        token: 'ExponentPushToken[test-123]',
+        platform: 'ios',
+      });
+    });
+
+    it('returns false when push notification permission is denied', async () => {
+      pushNotificationService.registerForPushNotifications.mockResolvedValue({
+        success: false,
+        reason: 'permission-denied',
+      });
+
+      const result = await service.registerPushToken();
+
+      expect(result).toBe(false);
+      expect(apiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('returns false gracefully when backend API call fails', async () => {
+      pushNotificationService.registerForPushNotifications.mockResolvedValue({
+        success: true,
+        token: { value: 'ExponentPushToken[test-123]', platform: 'ios' },
+      });
+
+      apiClient.post.mockRejectedValue(new Error('Network error'));
+
+      const result = await service.registerPushToken();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('unregisterPushToken', () => {
+    it('unregisters active token during logout', async () => {
+      pushNotificationService.registerForPushNotifications.mockResolvedValue({
+        success: true,
+        token: { value: 'ExponentPushToken[test-123]', platform: 'ios' },
+      });
+      apiClient.post.mockResolvedValue({ data: { success: true } });
+
+      await service.registerPushToken();
+
+      const unregisterResult = await service.unregisterPushToken();
+
+      expect(unregisterResult).toBe(true);
+      expect(apiClient.post).toHaveBeenLastCalledWith('/auth/logout', {
+        fcmToken: 'ExponentPushToken[test-123]',
+      });
+    });
+
+    it('returns false when no token has been registered', async () => {
+      const result = await service.unregisterPushToken();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false gracefully if unregister API call fails', async () => {
+      pushNotificationService.registerForPushNotifications.mockResolvedValue({
+        success: true,
+        token: { value: 'ExponentPushToken[test-123]', platform: 'ios' },
+      });
+      apiClient.post.mockResolvedValueOnce({ data: { success: true } });
+
+      await service.registerPushToken();
+
+      apiClient.post.mockRejectedValueOnce(new Error('Server error'));
+
+      const result = await service.unregisterPushToken();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/mobile/src/infrastructure/auth/AuthServiceImpl.ts
+++ b/apps/mobile/src/infrastructure/auth/AuthServiceImpl.ts
@@ -1,11 +1,13 @@
 import { AxiosInstance } from 'axios';
 import { IAuthService, AuthResult } from './AuthService';
 import { ITokenStorage } from './ITokenStorage';
+import { IPushTokenRegistrationService } from '../../features/notifications/application/IPushTokenRegistrationService';
 
 export class AuthServiceImpl implements IAuthService {
   constructor(
     private readonly apiClient: AxiosInstance,
-    private readonly tokenStorage: ITokenStorage
+    private readonly tokenStorage: ITokenStorage,
+    private readonly pushTokenRegistrationService?: IPushTokenRegistrationService
   ) {
     // Bind the executeTokenRefresh context so it can be passed freely
     this.executeTokenRefresh = this.executeTokenRefresh.bind(this);
@@ -24,6 +26,10 @@ export class AuthServiceImpl implements IAuthService {
       await this.tokenStorage.setTokens(accessToken, refreshToken);
     }
 
+    if (this.pushTokenRegistrationService) {
+      await this.pushTokenRegistrationService.registerPushToken();
+    }
+
     // Map backend DTO to Domain AuthResult
     return {
       userId,
@@ -32,7 +38,11 @@ export class AuthServiceImpl implements IAuthService {
 
   async logout(): Promise<void> {
     try {
-      await this.apiClient.post('/auth/logout');
+      if (this.pushTokenRegistrationService) {
+        await this.pushTokenRegistrationService.unregisterPushToken();
+      } else {
+        await this.apiClient.post('/auth/logout');
+      }
     } catch (e) {
       // Ignore network errors on logout, we still want to clear the local session
     } finally {

--- a/apps/mobile/src/providers/AppProvider.tsx
+++ b/apps/mobile/src/providers/AppProvider.tsx
@@ -16,7 +16,10 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, services }) 
   return (
     <SafeAreaProvider>
       <QueryProvider>
-        <AuthProvider authService={services.authService}>
+        <AuthProvider
+          authService={services.authService}
+          pushTokenRegistrationService={services.pushTokenRegistrationService}
+        >
           <ThemeProvider>
             {children}
           </ThemeProvider>

--- a/apps/mobile/src/providers/AuthProvider.tsx
+++ b/apps/mobile/src/providers/AuthProvider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState, useMemo } from '
 import { useQueryClient } from '@tanstack/react-query';
 import { IAuthService } from '../infrastructure/auth/AuthService';
 import { SessionRestoration } from '../infrastructure/auth/SessionRestoration';
+import { IPushTokenRegistrationService } from '../features/notifications/application/IPushTokenRegistrationService';
 
 export type AuthStatus = 'loading' | 'authenticated' | 'anonymous';
 
@@ -15,10 +16,15 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export interface AuthProviderProps {
   authService: IAuthService;
+  pushTokenRegistrationService?: IPushTokenRegistrationService;
   children: React.ReactNode;
 }
 
-export const AuthProvider: React.FC<AuthProviderProps> = ({ authService, children }) => {
+export const AuthProvider: React.FC<AuthProviderProps> = ({
+  authService,
+  pushTokenRegistrationService,
+  children,
+}) => {
   const [status, setStatus] = useState<AuthStatus>('loading');
   const queryClient = useQueryClient();
 
@@ -30,6 +36,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ authService, childre
         const session = await SessionRestoration.restoreSession();
         if (mounted) {
           setStatus(session.status);
+          if (session.status === 'authenticated' && pushTokenRegistrationService) {
+            pushTokenRegistrationService.registerPushToken().catch(() => {});
+          }
         }
       } catch (error) {
         if (mounted) {
@@ -43,7 +52,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ authService, childre
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [pushTokenRegistrationService]);
 
   const login = async (payload: unknown) => {
     await authService.login(payload);

--- a/apps/mobile/src/providers/__tests__/providers.spec.tsx
+++ b/apps/mobile/src/providers/__tests__/providers.spec.tsx
@@ -97,6 +97,10 @@ describe('AppProvider', () => {
       getExpoPushToken: jest.fn(),
       registerForPushNotifications: jest.fn(),
     } as unknown as any,
+    pushTokenRegistrationService: {
+      registerPushToken: jest.fn().mockResolvedValue(true),
+      unregisterPushToken: jest.fn().mockResolvedValue(true),
+    } as unknown as any,
     imagePicker: { pick: jest.fn() },
   };
 


### PR DESCRIPTION
## Summary

Connects the mobile application to the backend push token registration API (`POST /api/v1/notifications/register`) established in PR 2A (#325).

This PR introduces `IPushTokenRegistrationService` and `ApiPushTokenRegistrationService` to acquire Expo push tokens and register them with the backend upon authentication, while ensuring automatic token cleanup on logout (`POST /api/v1/auth/logout`).

---

## Architectural Compliance & Layer Placement

Following Esparex monorepo governance and clean layered architecture:

```text
apps/mobile/src/features/notifications/
├── application/
│   └── IPushTokenRegistrationService.ts      <-- Application Port
└── infrastructure/
    ├── ApiPushTokenRegistrationService.ts     <-- HTTP Infrastructure Adapter
    └── __tests__/
        └── ApiPushTokenRegistrationService.spec.ts
