### PR TITLE
feat(notifications): implement push notification handlers, deep linking, and badge sync (#312)

### DIFF
--- a/apps/mobile/src/bootstrap/services.ts
+++ b/apps/mobile/src/bootstrap/services.ts
@@ -19,6 +19,8 @@ import { ApiNotificationRepository } from '../features/notifications/application
 import { NotificationService } from '../features/notifications/application/NotificationService';
 import { IPushNotificationService } from '../features/notifications/application/IPushNotificationService';
 import { ExpoPushNotificationService } from '../features/notifications/infrastructure/ExpoPushNotificationService';
+import { IPushNotificationEventService } from '../features/notifications/application/IPushNotificationEventService';
+import { ExpoPushNotificationEventService } from '../features/notifications/infrastructure/ExpoPushNotificationEventService';
 import { IPushTokenRegistrationService } from '../features/notifications/application/IPushTokenRegistrationService';
 import { ApiPushTokenRegistrationService } from '../features/notifications/infrastructure/ApiPushTokenRegistrationService';
 
@@ -31,6 +33,7 @@ export interface IServices {
   chatService: ChatService;
   notificationService: NotificationService;
   pushNotificationService: IPushNotificationService;
+  pushNotificationEventService: IPushNotificationEventService;
   pushTokenRegistrationService: IPushTokenRegistrationService;
   imagePicker: IImagePicker;
 }
@@ -38,6 +41,7 @@ export interface IServices {
 export const bootstrapServices = (): IServices => {
   // 1. Push Notification & Registration Services
   const pushNotificationService: IPushNotificationService = new ExpoPushNotificationService();
+  const pushNotificationEventService: IPushNotificationEventService = new ExpoPushNotificationEventService();
   const pushTokenRegistrationService: IPushTokenRegistrationService = new ApiPushTokenRegistrationService(
     pushNotificationService,
     apiClient
@@ -83,6 +87,7 @@ export const bootstrapServices = (): IServices => {
     chatService,
     notificationService,
     pushNotificationService,
+    pushNotificationEventService,
     pushTokenRegistrationService,
     imagePicker,
   };

--- a/apps/mobile/src/features/notifications/application/IPushNotificationEventService.ts
+++ b/apps/mobile/src/features/notifications/application/IPushNotificationEventService.ts
@@ -1,0 +1,38 @@
+import { PushNotificationPayload, NotificationResponse } from '../domain/NotificationPayload';
+
+/**
+ * IPushNotificationEventService — application-layer port for runtime notification events,
+ * foreground alert presentation, background response listeners, and OS badge management.
+ */
+export interface IPushNotificationEventService {
+  /**
+   * Configures foreground notification handler rules (banner, sound, badge).
+   */
+  configureNotificationHandler(): void;
+
+  /**
+   * Subscribes a callback to receive notifications when app is in foreground.
+   * Returns an unsubscribe cleanup function.
+   */
+  addNotificationReceivedListener(
+    listener: (notification: PushNotificationPayload) => void
+  ): () => void;
+
+  /**
+   * Subscribes a callback when user taps/interacts with a notification.
+   * Returns an unsubscribe cleanup function.
+   */
+  addNotificationResponseReceivedListener(
+    listener: (response: NotificationResponse) => void
+  ): () => void;
+
+  /**
+   * Sets OS application icon badge count.
+   */
+  setBadgeCount(count: number): Promise<boolean>;
+
+  /**
+   * Gets current OS application icon badge count.
+   */
+  getBadgeCount(): Promise<number>;
+}

--- a/apps/mobile/src/features/notifications/domain/NotificationPayload.ts
+++ b/apps/mobile/src/features/notifications/domain/NotificationPayload.ts
@@ -1,0 +1,18 @@
+/**
+ * PushNotificationPayload — domain representation of a received push notification payload.
+ * No Expo SDK types leak beyond the infrastructure adapter boundary.
+ */
+export interface PushNotificationPayload {
+  readonly id: string;
+  readonly title?: string;
+  readonly body?: string;
+  readonly data?: Record<string, unknown>;
+}
+
+/**
+ * NotificationResponse — domain representation of a user interaction/tap on a notification.
+ */
+export interface NotificationResponse {
+  readonly actionIdentifier: string;
+  readonly notification: PushNotificationPayload;
+}

--- a/apps/mobile/src/features/notifications/infrastructure/ExpoPushNotificationEventService.ts
+++ b/apps/mobile/src/features/notifications/infrastructure/ExpoPushNotificationEventService.ts
@@ -1,0 +1,74 @@
+import * as Notifications from 'expo-notifications';
+import { IPushNotificationEventService } from '../application/IPushNotificationEventService';
+import { PushNotificationPayload, NotificationResponse } from '../domain/NotificationPayload';
+
+/**
+ * ExpoPushNotificationEventService — infrastructure adapter for runtime notification events using Expo SDK.
+ */
+export class ExpoPushNotificationEventService implements IPushNotificationEventService {
+  configureNotificationHandler(): void {
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: true,
+        shouldPlaySound: true,
+        shouldSetBadge: true,
+      }),
+    });
+  }
+
+  addNotificationReceivedListener(
+    listener: (notification: PushNotificationPayload) => void
+  ): () => void {
+    const subscription = Notifications.addNotificationReceivedListener((expoNotification) => {
+      const payload: PushNotificationPayload = {
+        id: expoNotification.request.identifier,
+        title: expoNotification.request.content.title ?? undefined,
+        body: expoNotification.request.content.body ?? undefined,
+        data: (expoNotification.request.content.data as Record<string, unknown> | undefined) ?? {},
+      };
+      listener(payload);
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }
+
+  addNotificationResponseReceivedListener(
+    listener: (response: NotificationResponse) => void
+  ): () => void {
+    const subscription = Notifications.addNotificationResponseReceivedListener((expoResponse) => {
+      const response: NotificationResponse = {
+        actionIdentifier: expoResponse.actionIdentifier,
+        notification: {
+          id: expoResponse.notification.request.identifier,
+          title: expoResponse.notification.request.content.title ?? undefined,
+          body: expoResponse.notification.request.content.body ?? undefined,
+          data: (expoResponse.notification.request.content.data as Record<string, unknown> | undefined) ?? {},
+        },
+      };
+      listener(response);
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }
+
+  async setBadgeCount(count: number): Promise<boolean> {
+    try {
+      const sanitizedCount = Math.max(0, Math.floor(count));
+      return await Notifications.setBadgeCountAsync(sanitizedCount);
+    } catch {
+      return false;
+    }
+  }
+
+  async getBadgeCount(): Promise<number> {
+    try {
+      return await Notifications.getBadgeCountAsync();
+    } catch {
+      return 0;
+    }
+  }
+}

--- a/apps/mobile/src/features/notifications/infrastructure/__tests__/ExpoPushNotificationEventService.spec.ts
+++ b/apps/mobile/src/features/notifications/infrastructure/__tests__/ExpoPushNotificationEventService.spec.ts
@@ -1,0 +1,140 @@
+import * as Notifications from 'expo-notifications';
+import { ExpoPushNotificationEventService } from '../ExpoPushNotificationEventService';
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  addNotificationReceivedListener: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
+  setBadgeCountAsync: jest.fn(),
+  getBadgeCountAsync: jest.fn(),
+}));
+
+const mockSetHandler = Notifications.setNotificationHandler as jest.Mock;
+const mockAddReceived = Notifications.addNotificationReceivedListener as jest.Mock;
+const mockAddResponse = Notifications.addNotificationResponseReceivedListener as jest.Mock;
+const mockSetBadge = Notifications.setBadgeCountAsync as jest.Mock;
+const mockGetBadge = Notifications.getBadgeCountAsync as jest.Mock;
+
+describe('ExpoPushNotificationEventService', () => {
+  let service: ExpoPushNotificationEventService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ExpoPushNotificationEventService();
+  });
+
+  describe('configureNotificationHandler', () => {
+    it('configures Expo notification handler rules', () => {
+      service.configureNotificationHandler();
+
+      expect(mockSetHandler).toHaveBeenCalledWith({
+        handleNotification: expect.any(Function),
+      });
+    });
+  });
+
+  describe('addNotificationReceivedListener', () => {
+    it('subscribes to Expo notification received and maps payload to domain model', () => {
+      const mockRemove = jest.fn();
+      let capturedCallback: (event: any) => void = () => {};
+
+      mockAddReceived.mockImplementation((cb) => {
+        capturedCallback = cb;
+        return { remove: mockRemove };
+      });
+
+      const listenerSpy = jest.fn();
+      const unsubscribe = service.addNotificationReceivedListener(listenerSpy);
+
+      capturedCallback({
+        request: {
+          identifier: 'notif-123',
+          content: {
+            title: 'New Message',
+            body: 'Hello world',
+            data: { conversationId: 'conv-1' },
+          },
+        },
+      });
+
+      expect(listenerSpy).toHaveBeenCalledWith({
+        id: 'notif-123',
+        title: 'New Message',
+        body: 'Hello world',
+        data: { conversationId: 'conv-1' },
+      });
+
+      unsubscribe();
+      expect(mockRemove).toHaveBeenCalled();
+    });
+  });
+
+  describe('addNotificationResponseReceivedListener', () => {
+    it('subscribes to Expo response received and maps response to domain model', () => {
+      const mockRemove = jest.fn();
+      let capturedCallback: (event: any) => void = () => {};
+
+      mockAddResponse.mockImplementation((cb) => {
+        capturedCallback = cb;
+        return { remove: mockRemove };
+      });
+
+      const listenerSpy = jest.fn();
+      const unsubscribe = service.addNotificationResponseReceivedListener(listenerSpy);
+
+      capturedCallback({
+        actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+        notification: {
+          request: {
+            identifier: 'notif-456',
+            content: {
+              title: 'Ad Approved',
+              body: 'Your ad is live',
+              data: { listingId: 'ad-99' },
+            },
+          },
+        },
+      });
+
+      expect(listenerSpy).toHaveBeenCalledWith({
+        actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+        notification: {
+          id: 'notif-456',
+          title: 'Ad Approved',
+          body: 'Your ad is live',
+          data: { listingId: 'ad-99' },
+        },
+      });
+
+      unsubscribe();
+      expect(mockRemove).toHaveBeenCalled();
+    });
+  });
+
+  describe('badge management', () => {
+    it('sets badge count successfully', async () => {
+      mockSetBadge.mockResolvedValue(true);
+
+      const result = await service.setBadgeCount(5);
+
+      expect(result).toBe(true);
+      expect(mockSetBadge).toHaveBeenCalledWith(5);
+    });
+
+    it('returns false gracefully when setBadgeCount fails', async () => {
+      mockSetBadge.mockRejectedValue(new Error('SDK error'));
+
+      const result = await service.setBadgeCount(-1);
+
+      expect(result).toBe(false);
+    });
+
+    it('gets badge count successfully', async () => {
+      mockGetBadge.mockResolvedValue(3);
+
+      const count = await service.getBadgeCount();
+
+      expect(count).toBe(3);
+    });
+  });
+});

--- a/apps/mobile/src/navigation/NotificationNavigationResolver.ts
+++ b/apps/mobile/src/navigation/NotificationNavigationResolver.ts
@@ -1,0 +1,39 @@
+import { Linking } from 'react-native';
+import { NotificationResponse } from '../features/notifications/domain/NotificationPayload';
+
+export const NotificationNavigationResolver = {
+  /**
+   * Resolves notification response payload into a deep link target URL and opens it.
+   * Fail-safe: Returns boolean success indicator without throwing on invalid URLs.
+   */
+  async handleNotificationResponse(response: NotificationResponse): Promise<boolean> {
+    try {
+      const data = response.notification.data ?? {};
+      const url = data.url as string | undefined;
+      const target = data.target as string | undefined;
+      const conversationId = data.conversationId as string | undefined;
+      const listingId = data.listingId as string | undefined;
+
+      let targetUrl: string | null = null;
+
+      if (url && typeof url === 'string') {
+        targetUrl = url;
+      } else if (target === 'chat' && conversationId) {
+        targetUrl = `esparex://chat/thread/${conversationId}`;
+      } else if (target === 'listing' && listingId) {
+        targetUrl = `esparex://listing/${listingId}`;
+      } else if (target === 'notifications') {
+        targetUrl = 'esparex://profile';
+      }
+
+      if (targetUrl) {
+        await Linking.openURL(targetUrl);
+        return true;
+      }
+
+      return false;
+    } catch {
+      return false;
+    }
+  },
+};

--- a/apps/mobile/src/navigation/__tests__/NotificationNavigationResolver.spec.ts
+++ b/apps/mobile/src/navigation/__tests__/NotificationNavigationResolver.spec.ts
@@ -1,0 +1,83 @@
+import { Linking } from 'react-native';
+import { NotificationNavigationResolver } from '../NotificationNavigationResolver';
+import { NotificationResponse } from '../../features/notifications/domain/NotificationPayload';
+
+jest.mock('react-native', () => ({
+  Linking: {
+    openURL: jest.fn(),
+  },
+}));
+
+const mockOpenURL = Linking.openURL as jest.Mock;
+
+describe('NotificationNavigationResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates via explicit url parameter when present', async () => {
+    mockOpenURL.mockResolvedValue(true);
+
+    const response: NotificationResponse = {
+      actionIdentifier: 'default',
+      notification: {
+        id: '1',
+        data: { url: 'esparex://chat/thread/c123' },
+      },
+    };
+
+    const result = await NotificationNavigationResolver.handleNotificationResponse(response);
+
+    expect(result).toBe(true);
+    expect(mockOpenURL).toHaveBeenCalledWith('esparex://chat/thread/c123');
+  });
+
+  it('navigates to chat thread deep link when target is chat', async () => {
+    mockOpenURL.mockResolvedValue(true);
+
+    const response: NotificationResponse = {
+      actionIdentifier: 'default',
+      notification: {
+        id: '2',
+        data: { target: 'chat', conversationId: 'conv-456' },
+      },
+    };
+
+    const result = await NotificationNavigationResolver.handleNotificationResponse(response);
+
+    expect(result).toBe(true);
+    expect(mockOpenURL).toHaveBeenCalledWith('esparex://chat/thread/conv-456');
+  });
+
+  it('navigates to listing deep link when target is listing', async () => {
+    mockOpenURL.mockResolvedValue(true);
+
+    const response: NotificationResponse = {
+      actionIdentifier: 'default',
+      notification: {
+        id: '3',
+        data: { target: 'listing', listingId: 'ad-789' },
+      },
+    };
+
+    const result = await NotificationNavigationResolver.handleNotificationResponse(response);
+
+    expect(result).toBe(true);
+    expect(mockOpenURL).toHaveBeenCalledWith('esparex://listing/ad-789');
+  });
+
+  it('returns false safely when unknown target is provided', async () => {
+    const response: NotificationResponse = {
+      actionIdentifier: 'default',
+      notification: {
+        id: '4',
+        data: { target: 'unknown' },
+      },
+    };
+
+    const result = await NotificationNavigationResolver.handleNotificationResponse(response);
+
+    expect(result).toBe(false);
+    expect(mockOpenURL).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/providers/AppProvider.tsx
+++ b/apps/mobile/src/providers/AppProvider.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { IAuthService } from '../infrastructure/auth/AuthService';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthProvider } from './AuthProvider';
 import { QueryProvider } from './QueryProvider';
 import { ThemeProvider } from './ThemeProvider';
+import { PushNotificationListener } from './PushNotificationListener';
 
 import { IServices } from '../bootstrap/services';
 
@@ -20,9 +20,13 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, services }) 
           authService={services.authService}
           pushTokenRegistrationService={services.pushTokenRegistrationService}
         >
-          <ThemeProvider>
-            {children}
-          </ThemeProvider>
+          <PushNotificationListener
+            pushNotificationEventService={services.pushNotificationEventService}
+          >
+            <ThemeProvider>
+              {children}
+            </ThemeProvider>
+          </PushNotificationListener>
         </AuthProvider>
       </QueryProvider>
     </SafeAreaProvider>

--- a/apps/mobile/src/providers/PushNotificationListener.tsx
+++ b/apps/mobile/src/providers/PushNotificationListener.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { IPushNotificationEventService } from '../features/notifications/application/IPushNotificationEventService';
+import { NotificationNavigationResolver } from '../navigation/NotificationNavigationResolver';
+import { useUnreadNotificationsCount } from '../features/notifications/presentation/hooks/useNotifications';
+
+interface PushNotificationListenerProps {
+  pushNotificationEventService: IPushNotificationEventService;
+  children?: React.ReactNode;
+}
+
+export const PushNotificationListener: React.FC<PushNotificationListenerProps> = ({
+  pushNotificationEventService,
+  children,
+}) => {
+  const queryClient = useQueryClient();
+  const unreadCount = useUnreadNotificationsCount();
+
+  // Synchronize OS application icon badge with unread notifications count
+  useEffect(() => {
+    if (typeof unreadCount === 'number') {
+      pushNotificationEventService.setBadgeCount(unreadCount).catch(() => {});
+    }
+  }, [unreadCount, pushNotificationEventService]);
+
+  // Set up listeners on mount and clean up on unmount
+  useEffect(() => {
+    // 1. Configure foreground alert presentation rules
+    pushNotificationEventService.configureNotificationHandler();
+
+    // 2. Subscribe to foreground notification received event
+    const removeReceivedListener = pushNotificationEventService.addNotificationReceivedListener(
+      () => {
+        // Invalidate notifications query to refresh real-time unread counts
+        queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        queryClient.invalidateQueries({ queryKey: ['notifications', 'unreadCount'] });
+      }
+    );
+
+    // 3. Subscribe to user tap response event
+    const removeResponseListener = pushNotificationEventService.addNotificationResponseReceivedListener(
+      (response) => {
+        NotificationNavigationResolver.handleNotificationResponse(response).catch(() => {});
+      }
+    );
+
+    return () => {
+      removeReceivedListener();
+      removeResponseListener();
+    };
+  }, [pushNotificationEventService, queryClient]);
+
+  return <>{children}</>;
+};

--- a/apps/mobile/src/providers/__tests__/PushNotificationListener.spec.tsx
+++ b/apps/mobile/src/providers/__tests__/PushNotificationListener.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PushNotificationListener } from '../PushNotificationListener';
+import { IPushNotificationEventService } from '../../features/notifications/application/IPushNotificationEventService';
+
+jest.mock('../../features/notifications/presentation/hooks/useNotifications', () => ({
+  useUnreadNotificationsCount: () => 3,
+}));
+
+describe('PushNotificationListener', () => {
+  let mockEventService: jest.Mocked<IPushNotificationEventService>;
+  let queryClient: QueryClient;
+  let removeReceived: jest.Mock;
+  let removeResponse: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient();
+
+    removeReceived = jest.fn();
+    removeResponse = jest.fn();
+
+    mockEventService = {
+      configureNotificationHandler: jest.fn(),
+      addNotificationReceivedListener: jest.fn().mockReturnValue(removeReceived),
+      addNotificationResponseReceivedListener: jest.fn().mockReturnValue(removeResponse),
+      setBadgeCount: jest.fn().mockResolvedValue(true),
+      getBadgeCount: jest.fn().mockResolvedValue(3),
+    };
+  });
+
+  it('configures notification handler and subscribes to listeners on mount', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PushNotificationListener pushNotificationEventService={mockEventService} />
+      </QueryClientProvider>
+    );
+
+    expect(mockEventService.configureNotificationHandler).toHaveBeenCalled();
+    expect(mockEventService.addNotificationReceivedListener).toHaveBeenCalled();
+    expect(mockEventService.addNotificationResponseReceivedListener).toHaveBeenCalled();
+    expect(mockEventService.setBadgeCount).toHaveBeenCalledWith(3);
+  });
+
+  it('unsubscribes listeners cleanly on unmount', () => {
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <PushNotificationListener pushNotificationEventService={mockEventService} />
+      </QueryClientProvider>
+    );
+
+    unmount();
+
+    expect(removeReceived).toHaveBeenCalled();
+    expect(removeResponse).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/providers/__tests__/providers.spec.tsx
+++ b/apps/mobile/src/providers/__tests__/providers.spec.tsx
@@ -12,6 +12,32 @@ import { ApiListingRepository } from '../../features/listings/application/ApiLis
 import { PostAdService } from '../../features/postAd/application/PostAdService';
 import { UserService } from '../../features/user/application/UserService';
 
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(),
+  MediaTypeOptions: { Images: 'Images' },
+}));
+
+jest.mock('expo-device', () => ({
+  isDevice: true,
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  setNotificationHandler: jest.fn(),
+  addNotificationReceivedListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  addNotificationResponseReceivedListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  setBadgeCountAsync: jest.fn().mockResolvedValue(true),
+  getBadgeCountAsync: jest.fn().mockResolvedValue(0),
+  AndroidImportance: { MAX: 5 },
+}));
+
+jest.mock('expo-constants', () => ({
+  expoConfig: { extra: { eas: { projectId: 'test-project-id' } } },
+}));
+
 jest.mock('react-native-safe-area-context', () => {
   const inset = { top: 0, right: 0, bottom: 0, left: 0 };
   return {
@@ -96,6 +122,13 @@ describe('AppProvider', () => {
       requestPermission: jest.fn(),
       getExpoPushToken: jest.fn(),
       registerForPushNotifications: jest.fn(),
+    } as unknown as any,
+    pushNotificationEventService: {
+      configureNotificationHandler: jest.fn(),
+      addNotificationReceivedListener: jest.fn().mockReturnValue(() => {}),
+      addNotificationResponseReceivedListener: jest.fn().mockReturnValue(() => {}),
+      setBadgeCount: jest.fn().mockResolvedValue(true),
+      getBadgeCount: jest.fn().mockResolvedValue(0),
     } as unknown as any,
     pushTokenRegistrationService: {
       registerPushToken: jest.fn().mockResolvedValue(true),


### PR DESCRIPTION
## Summary

Completes **Issue #312** by implementing runtime push notification event handling, foreground alert presentation, notification tap response deep linking, OS icon badge synchronization, and component lifecycle listener cleanup.

---

## Architectural Highlights

### 1. Domain Separation & Zero Expo SDK Leakage
- `[NEW]` [NotificationPayload.ts](file:///Users/admin/Desktop/Esparex/apps/mobile/src/features/notifications/domain/NotificationPayload.ts) — Defines `PushNotificationPayload` and `NotificationResponse` domain models, keeping Expo SDK types 100% isolated inside the infrastructure layer.

### 2. Service Layer Split
- `[NEW]` [IPushNotificationEventService.ts](file:///Users/admin/Desktop/Esparex/apps/mobile/src/features/notifications/application/IPushNotificationEventService.ts) — Separates runtime event handling and badge management into a dedicated application port:
  - `configureNotificationHandler()`
  - `addNotificationReceivedListener()`
  - `addNotificationResponseReceivedListener()`
  - `setBadgeCount()` / `getBadgeCount()`
- `[NEW]` [ExpoPushNotificationEventService.ts](file:///Users/admin/Desktop/Esparex/apps/mobile/src/features/notifications/infrastructure/ExpoPushNotificationEventService.ts) — Concrete Expo adapter managing foreground banner rules (`shouldShowAlert: true, shouldPlaySound: true, shouldSetBadge: true`), payload mapping, and native OS badge counts.

### 3. Navigation & Deep Link Resolution
- `[NEW]` [NotificationNavigationResolver.ts](file:///Users/admin/Desktop/Esparex/apps/mobile/src/navigation/NotificationNavigationResolver.ts) — Resolves notification tap payloads into deep link URLs (`esparex://chat/thread/:conversationId`, `esparex://listing/:id`) and triggers navigation via `Linking.openURL()`.

### 4. Provider & Lifecycle Integration
- `[NEW]` [PushNotificationListener.tsx](file:///Users/admin/Desktop/Esparex/apps/mobile/src/providers/PushNotificationListener.tsx) — Rendered inside `AppProvider`:
  - Automatically configures foreground presentation rules on mount.
  - Invalidates React Query notification caches upon receiving foreground alerts.
  - Synchronizes OS application icon badge count with `useUnreadNotificationsCount()`.
  - Cleans up subscriptions on component unmount.

---

## Changes

- `[NEW]` `apps/mobile/src/features/notifications/domain/NotificationPayload.ts`
- `[NEW]` `apps/mobile/src/features/notifications/application/IPushNotificationEventService.ts`
- `[NEW]` `apps/mobile/src/features/notifications/infrastructure/ExpoPushNotificationEventService.ts`
- `[NEW]` `apps/mobile/src/navigation/NotificationNavigationResolver.ts`
- `[NEW]` `apps/mobile/src/providers/PushNotificationListener.tsx`
- `[MODIFY]` `apps/mobile/src/bootstrap/services.ts`
- `[MODIFY]` `apps/mobile/src/providers/AppProvider.tsx`
- `[NEW]` `apps/mobile/src/features/notifications/infrastructure/__tests__/ExpoPushNotificationEventService.spec.ts`
- `[NEW]` `apps/mobile/src/navigation/__tests__/NotificationNavigationResolver.spec.ts`
- `[NEW]` `apps/mobile/src/providers/__tests__/PushNotificationListener.spec.tsx`
- `[MODIFY]` `apps/mobile/src/providers/__tests__/providers.spec.tsx`

---

## Verification & Quality Gates

- ✅ **TypeScript Type Check**: `npm run type-check -w @esparex/apps-mobile` passed with **0 errors**.
- ✅ **Mobile Test Suite**: `npm test -w @esparex/apps-mobile` passed all **39 test suites / 139 tests** (100% green).
- ✅ **Unit Tests**:
  - `ExpoPushNotificationEventService.spec.ts` (Foreground configuration, event mapping, badge management)
  - `NotificationNavigationResolver.spec.ts` (Chat thread, listing, and custom deep-link navigation)
  - `PushNotificationListener.spec.tsx` (Component mounting, badge sync, unmount cleanup)
- ✅ **Remote Branch**: Pushed to `origin/feat/issue-312-pr3-push-handling`.

---

## Issue #312 Roadmap Status

```text
Issue #312 — Push Notifications & In-App Alerts
├── ✅ PR 1 — Push Foundation (Merged)
├── ✅ PR 2A — Contracts & Backend (Merged #325)
├── ✅ PR 2B — Mobile Registration (Merged #326)
└── ✅ PR 3 — Push Notification Handling (This PR - Final Step)
