### PR TITLE
feat(moderation): introduce model registry and adapter interfaces

### DIFF
--- a/core/src/__tests__/services/ai/ModerationModelRegistry.spec.ts
+++ b/core/src/__tests__/services/ai/ModerationModelRegistry.spec.ts
@@ -1,0 +1,192 @@
+import {
+    ModerationModelRegistry,
+    DuplicateModelRegistrationError,
+    ModelNotFoundError,
+} from '../../../services/ai/moderation/registry/ModerationModelRegistry';
+import { ModelAdapter, ModelType } from '../../../services/ai/moderation/registry/ModelAdapter';
+
+class MockModelAdapter<TInput = string, TOutput = Record<string, number>>
+    implements ModelAdapter<TInput, TOutput> {
+    readonly modelId: string;
+    readonly modelType: ModelType;
+    readonly version: string;
+    private loaded = false;
+    private initializedTimestamp?: number;
+
+    constructor(modelId: string, modelType: ModelType = 'nsfw', version = '1.0.0') {
+        this.modelId = modelId;
+        this.modelType = modelType;
+        this.version = version;
+    }
+
+    async initialize(): Promise<void> {
+        this.loaded = true;
+        this.initializedTimestamp = Date.now();
+    }
+
+    async predict(input: TInput): Promise<TOutput> {
+        if (!this.loaded) {
+            throw new Error(`Model ${this.modelId} is not initialized.`);
+        }
+        return { score: 0.95 } as unknown as TOutput;
+    }
+
+    isLoaded(): boolean {
+        return this.loaded;
+    }
+
+    getInitializedAt(): number | undefined {
+        return this.initializedTimestamp;
+    }
+
+    async dispose(): Promise<void> {
+        this.loaded = false;
+        this.initializedTimestamp = undefined;
+    }
+}
+
+describe('ModerationModelRegistry (PR 1)', () => {
+    let registry: ModerationModelRegistry;
+
+    beforeEach(() => {
+        registry = new ModerationModelRegistry();
+    });
+
+    afterEach(async () => {
+        await registry.disposeAll();
+    });
+
+    it('registers and resolves a model adapter by modelId', () => {
+        const adapter = new MockModelAdapter('nsfw-v1', 'nsfw');
+        registry.registerAdapter(adapter);
+
+        expect(registry.hasAdapter('nsfw-v1')).toBe(true);
+        const resolved = registry.getAdapter<string, Record<string, number>>('nsfw-v1');
+        expect(resolved).toBe(adapter);
+        expect(resolved.modelId).toBe('nsfw-v1');
+    });
+
+    it('returns false for non-existent modelId in hasAdapter()', () => {
+        expect(registry.hasAdapter('unknown-model')).toBe(false);
+    });
+
+    it('throws DuplicateModelRegistrationError on duplicate registration', () => {
+        const adapter1 = new MockModelAdapter('nsfw-v1', 'nsfw');
+        const adapter2 = new MockModelAdapter('nsfw-v1', 'nsfw');
+
+        registry.registerAdapter(adapter1);
+        expect(() => registry.registerAdapter(adapter2)).toThrow(DuplicateModelRegistrationError);
+    });
+
+    it('throws ModelNotFoundError when resolving unknown modelId', () => {
+        expect(() => registry.getAdapter('missing-id')).toThrow(ModelNotFoundError);
+    });
+
+    it('enforces explicit loading strategy — does NOT auto-initialize on registration', () => {
+        const adapter = new MockModelAdapter('nsfw-lazy', 'nsfw');
+        registry.registerAdapter(adapter);
+
+        expect(adapter.isLoaded()).toBe(false);
+        expect(adapter.getInitializedAt()).toBeUndefined();
+    });
+
+    it('supports explicit initialize() call and predict() workflow', async () => {
+        const adapter = new MockModelAdapter('nsfw-active', 'nsfw');
+        registry.registerAdapter(adapter);
+
+        const resolved = registry.getAdapter<string, { score: number }>('nsfw-active');
+        await resolved.initialize();
+
+        expect(resolved.isLoaded()).toBe(true);
+        expect(resolved.getInitializedAt()).toBeGreaterThan(0);
+
+        const result = await resolved.predict('test-image-data');
+        expect(result.score).toBe(0.95);
+    });
+
+    it('lists registered models metadata including initializedAt timestamp', async () => {
+        const adapter1 = new MockModelAdapter('nsfw-v1', 'nsfw', '1.0.0');
+        const adapter2 = new MockModelAdapter('ocr-v1', 'ocr', '2.1.0');
+
+        registry.registerAdapter(adapter1);
+        registry.registerAdapter(adapter2);
+
+        await adapter1.initialize();
+
+        const metadataList = registry.listRegisteredModels();
+        expect(metadataList).toHaveLength(2);
+
+        const nsfwMeta = metadataList.find((m) => m.modelId === 'nsfw-v1');
+        const ocrMeta = metadataList.find((m) => m.modelId === 'ocr-v1');
+
+        expect(nsfwMeta).toBeDefined();
+        expect(nsfwMeta?.isLoaded).toBe(true);
+        expect(nsfwMeta?.initializedAt).toBeGreaterThan(0);
+
+        expect(ocrMeta).toBeDefined();
+        expect(ocrMeta?.isLoaded).toBe(false);
+        expect(ocrMeta?.initializedAt).toBeUndefined();
+    });
+
+    it('queries multiple adapters of the same ModelType category', () => {
+        const nsfwPrimary = new MockModelAdapter('nsfw-primary', 'nsfw');
+        const nsfwSecondary = new MockModelAdapter('nsfw-secondary', 'nsfw');
+        const ocrPrimary = new MockModelAdapter('ocr-primary', 'ocr');
+
+        registry.registerAdapter(nsfwPrimary);
+        registry.registerAdapter(nsfwSecondary);
+        registry.registerAdapter(ocrPrimary);
+
+        const nsfwAdapters = registry.getAdaptersByType('nsfw');
+        expect(nsfwAdapters).toHaveLength(2);
+        expect(nsfwAdapters.map((a) => a.modelId)).toEqual(['nsfw-primary', 'nsfw-secondary']);
+
+        const ocrAdapters = registry.getAdaptersByType('ocr');
+        expect(ocrAdapters).toHaveLength(1);
+    });
+
+    it('handles disposal before initialization gracefully', async () => {
+        const adapter = new MockModelAdapter('uninitialized-model', 'safety');
+        registry.registerAdapter(adapter);
+
+        await expect(registry.unregisterAdapter('uninitialized-model')).resolves.not.toThrow();
+        expect(registry.hasAdapter('uninitialized-model')).toBe(false);
+    });
+
+    it('unregisters an adapter and disposes its resources', async () => {
+        const adapter = new MockModelAdapter('to-remove', 'safety');
+        registry.registerAdapter(adapter);
+        await adapter.initialize();
+
+        expect(adapter.isLoaded()).toBe(true);
+        await registry.unregisterAdapter('to-remove');
+
+        expect(registry.hasAdapter('to-remove')).toBe(false);
+        expect(adapter.isLoaded()).toBe(false);
+    });
+
+    it('disposes all registered models and clears the registry on disposeAll()', async () => {
+        const model1 = new MockModelAdapter('m1', 'nsfw');
+        const model2 = new MockModelAdapter('m2', 'ocr');
+
+        registry.registerAdapter(model1);
+        registry.registerAdapter(model2);
+
+        await model1.initialize();
+        await model2.initialize();
+
+        await registry.disposeAll();
+
+        expect(registry.listRegisteredModels()).toHaveLength(0);
+        expect(model1.isLoaded()).toBe(false);
+        expect(model2.isLoaded()).toBe(false);
+    });
+
+    it('handles concurrent model registrations cleanly', async () => {
+        const adapters = Array.from({ length: 10 }, (_, i) => new MockModelAdapter(`concurrent-${i}`, 'custom'));
+
+        await Promise.all(adapters.map((a) => Promise.resolve(registry.registerAdapter(a))));
+
+        expect(registry.listRegisteredModels()).toHaveLength(10);
+    });
+});

--- a/core/src/services/ai/moderation/index.ts
+++ b/core/src/services/ai/moderation/index.ts
@@ -1,0 +1,2 @@
+export * from './registry/ModelAdapter';
+export * from './registry/ModerationModelRegistry';

--- a/core/src/services/ai/moderation/registry/ModelAdapter.ts
+++ b/core/src/services/ai/moderation/registry/ModelAdapter.ts
@@ -1,0 +1,49 @@
+/**
+ * Model Adapter Interface (PR 1)
+ *
+ * Defines the contract for vision, safety, and OCR model adapters.
+ * Implementations handle specific model runtimes (ONNX, TensorFlow.js, local inference, etc.)
+ * while exposing a standard lifecycle and prediction interface to the registry.
+ */
+
+export type ModelType = 'nsfw' | 'object_detection' | 'ocr' | 'safety' | 'custom';
+
+export interface ModelAdapterMetadata {
+    modelId: string;
+    modelType: ModelType;
+    version: string;
+    isLoaded: boolean;
+    initializedAt?: number;
+}
+
+export interface ModelAdapter<TInput = unknown, TOutput = unknown> {
+    readonly modelId: string;
+    readonly modelType: ModelType;
+    readonly version: string;
+
+    /**
+     * Initializes the underlying model weights and runtime resources.
+     */
+    initialize(): Promise<void>;
+
+    /**
+     * Executes prediction/inference using the underlying model.
+     * @throws Error if model is not initialized (isLoaded is false).
+     */
+    predict(input: TInput): Promise<TOutput>;
+
+    /**
+     * Returns true if model weights and resources are loaded and ready.
+     */
+    isLoaded(): boolean;
+
+    /**
+     * Returns timestamp when model was initialized, or undefined if not initialized.
+     */
+    getInitializedAt(): number | undefined;
+
+    /**
+     * Disposes model weights and releases memory/GPU resources.
+     */
+    dispose(): Promise<void>;
+}

--- a/core/src/services/ai/moderation/registry/ModerationModelRegistry.ts
+++ b/core/src/services/ai/moderation/registry/ModerationModelRegistry.ts
@@ -1,0 +1,113 @@
+/**
+ * Moderation Model Registry (PR 1)
+ *
+ * Provides lifecycle management, registration, and resolution for AI moderation model adapters.
+ * Does NOT perform inference directly; delegates prediction to registered ModelAdapters.
+ */
+import { ModelAdapter, ModelAdapterMetadata, ModelType } from './ModelAdapter';
+
+export class DuplicateModelRegistrationError extends Error {
+    constructor(modelId: string) {
+        super(`Model adapter with ID "${modelId}" is already registered in ModerationModelRegistry.`);
+        this.name = 'DuplicateModelRegistrationError';
+    }
+}
+
+export class ModelNotFoundError extends Error {
+    constructor(modelId: string) {
+        super(`Model adapter with ID "${modelId}" was not found in ModerationModelRegistry.`);
+        this.name = 'ModelNotFoundError';
+    }
+}
+
+export class ModerationModelRegistry {
+    private adapters: Map<string, ModelAdapter<any, any>> = new Map();
+
+    /**
+     * Registers a model adapter in the registry.
+     * Does NOT automatically call initialize() on registration (explicit loading strategy).
+     * @throws DuplicateModelRegistrationError if an adapter with the same modelId is already registered.
+     */
+    registerAdapter<TInput, TOutput>(adapter: ModelAdapter<TInput, TOutput>): void {
+        if (this.adapters.has(adapter.modelId)) {
+            throw new DuplicateModelRegistrationError(adapter.modelId);
+        }
+        this.adapters.set(adapter.modelId, adapter);
+    }
+
+    /**
+     * Checks whether an adapter with the specified modelId exists in the registry.
+     */
+    hasAdapter(modelId: string): boolean {
+        return this.adapters.has(modelId);
+    }
+
+    /**
+     * Resolves a registered adapter by its unique modelId.
+     * @throws ModelNotFoundError if no adapter matches the modelId.
+     */
+    getAdapter<TInput = unknown, TOutput = unknown>(modelId: string): ModelAdapter<TInput, TOutput> {
+        const adapter = this.adapters.get(modelId);
+        if (!adapter) {
+            throw new ModelNotFoundError(modelId);
+        }
+        return adapter as ModelAdapter<TInput, TOutput>;
+    }
+
+    /**
+     * Resolves all registered adapters matching the specified ModelType category.
+     */
+    getAdaptersByType<TInput = unknown, TOutput = unknown>(
+        modelType: ModelType
+    ): ModelAdapter<TInput, TOutput>[] {
+        const results: ModelAdapter<TInput, TOutput>[] = [];
+        for (const adapter of this.adapters.values()) {
+            if (adapter.modelType === modelType) {
+                results.push(adapter as ModelAdapter<TInput, TOutput>);
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Lists diagnostic metadata for all registered models in the registry.
+     */
+    listRegisteredModels(): ModelAdapterMetadata[] {
+        return Array.from(this.adapters.values()).map((adapter) => ({
+            modelId: adapter.modelId,
+            modelType: adapter.modelType,
+            version: adapter.version,
+            isLoaded: adapter.isLoaded(),
+            initializedAt: adapter.getInitializedAt(),
+        }));
+    }
+
+    /**
+     * Unregisters an adapter by modelId, disposing it if loaded.
+     */
+    async unregisterAdapter(modelId: string): Promise<void> {
+        const adapter = this.adapters.get(modelId);
+        if (adapter) {
+            if (adapter.isLoaded()) {
+                await adapter.dispose();
+            }
+            this.adapters.delete(modelId);
+        }
+    }
+
+    /**
+     * Disposes all registered model adapters and clears the registry.
+     */
+    async disposeAll(): Promise<void> {
+        for (const adapter of this.adapters.values()) {
+            try {
+                if (adapter.isLoaded()) {
+                    await adapter.dispose();
+                }
+            } catch {
+                // Ignore disposal errors during bulk cleanup
+            }
+        }
+        this.adapters.clear();
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the foundational registry and adapter abstractions for the AI Moderation Platform.

This PR establishes the registry responsible for model lifecycle and resolution without introducing moderation logic or provider implementations.

## Changes

- Add `ModelAdapter` interface.
- Add `ModerationModelRegistry`.
- Export registry components.
- Add unit tests for registration, lookup, lifecycle, and disposal.

## Scope

This PR intentionally does **not** include:

- Image moderation providers
- OCR providers
- Policy engine
- Provider failover
- Orchestrator changes
- API contract changes

These will be delivered in subsequent PRs as part of the AI Moderation Platform epic.

## Verification

- ✅ Type check passes.
- ✅ Registry unit tests pass.
- ✅ No breaking API changes.
- ✅ No changes to existing moderation behavior.

## Risk

Low

This PR introduces isolated infrastructure only and does not affect existing runtime behavior.
