### PR TITLE
feat(core): implement LocalVisionModerationProvider with ModelRegistry integration

### DIFF
--- a/core/src/__tests__/services/ai/LocalVisionModerationProvider.spec.ts
+++ b/core/src/__tests__/services/ai/LocalVisionModerationProvider.spec.ts
@@ -1,0 +1,120 @@
+import { LocalVisionModerationProvider } from '../../../services/ai/moderation/providers/LocalVisionModerationProvider';
+import { ModerationModelRegistry } from '../../../services/ai/moderation/registry/ModerationModelRegistry';
+import { ModelAdapter, ModelType } from '../../../services/ai/moderation/registry/ModelAdapter';
+import { ImageModerationRequest } from '../../../services/ai/moderation/types';
+
+class MockSafetyAdapter implements ModelAdapter<ImageModerationRequest, { adultScore: number; violenceScore: number; racyScore: number; goreScore: number }> {
+    readonly modelId = 'mock-safety-adapter';
+    readonly modelType: ModelType = 'safety';
+    readonly version = '1.0.0';
+    private loaded = false;
+    private initTime?: number;
+
+    async initialize(): Promise<void> {
+        this.loaded = true;
+        this.initTime = Date.now();
+    }
+
+    async predict(_input: ImageModerationRequest): Promise<{ adultScore: number; violenceScore: number; racyScore: number; goreScore: number }> {
+        if (!this.loaded) throw new Error('Model not initialized');
+        return { adultScore: 0.1, violenceScore: 0.05, racyScore: 0.2, goreScore: 0.01 };
+    }
+
+    isLoaded(): boolean {
+        return this.loaded;
+    }
+
+    getInitializedAt(): number | undefined {
+        return this.initTime;
+    }
+
+    async dispose(): Promise<void> {
+        this.loaded = false;
+    }
+}
+
+class MockObjectDetectionAdapter implements ModelAdapter<ImageModerationRequest, { labels: string[] }> {
+    readonly modelId = 'mock-object-adapter';
+    readonly modelType: ModelType = 'object_detection';
+    readonly version = '1.0.0';
+    private loaded = false;
+    private initTime?: number;
+
+    async initialize(): Promise<void> {
+        this.loaded = true;
+        this.initTime = Date.now();
+    }
+
+    async predict(_input: ImageModerationRequest): Promise<{ labels: string[] }> {
+        if (!this.loaded) throw new Error('Model not initialized');
+        return { labels: ['Mobile Phone', 'Electronics', 'Mobile Phone'] };
+    }
+
+    isLoaded(): boolean {
+        return this.loaded;
+    }
+
+    getInitializedAt(): number | undefined {
+        return this.initTime;
+    }
+
+    async dispose(): Promise<void> {
+        this.loaded = false;
+    }
+}
+
+describe('LocalVisionModerationProvider (PR 2)', () => {
+    let registry: ModerationModelRegistry;
+
+    beforeEach(() => {
+        registry = new ModerationModelRegistry();
+    });
+
+    afterEach(async () => {
+        await registry.disposeAll();
+    });
+
+    it('returns default baseline response when registry is empty', async () => {
+        const provider = new LocalVisionModerationProvider(registry);
+        const response = await provider.moderateImage({ imageUrl: 'https://example.com/item.jpg' });
+
+        expect(provider.providerName).toBe('LocalVisionModerationProvider');
+        expect(response.provider).toBe('LocalVisionModerationProvider');
+        expect(response.adultScore).toBe(0);
+        expect(response.violenceScore).toBe(0);
+        expect(response.labels).toEqual([]);
+        expect(response.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('aggregates scores and deduplicates labels from registered loaded model adapters', async () => {
+        const safetyAdapter = new MockSafetyAdapter();
+        const objectAdapter = new MockObjectDetectionAdapter();
+
+        registry.registerAdapter(safetyAdapter);
+        registry.registerAdapter(objectAdapter);
+
+        await safetyAdapter.initialize();
+        await objectAdapter.initialize();
+
+        const provider = new LocalVisionModerationProvider(registry);
+        const response = await provider.moderateImage({ imageUrl: 'https://example.com/phone.jpg' });
+
+        expect(response.adultScore).toBe(0.1);
+        expect(response.racyScore).toBe(0.2);
+        expect(response.labels).toEqual(['Mobile Phone', 'Electronics']);
+        expect(response.signals[0].classifier).toBe('LocalVisionModerationProvider');
+        expect(response.signals[0].details?.registeredModelsCount).toBe(2);
+    });
+
+    it('ignores uninitialized model adapters gracefully during moderation execution', async () => {
+        const safetyAdapter = new MockSafetyAdapter();
+        registry.registerAdapter(safetyAdapter);
+        // Do NOT call initialize()
+
+        const provider = new LocalVisionModerationProvider(registry);
+        const response = await provider.moderateImage({ imageUrl: 'https://example.com/unloaded.jpg' });
+
+        expect(response.adultScore).toBe(0);
+        expect(response.signals[0].details?.registeredModelsCount).toBe(1);
+    });
+});

--- a/core/src/services/ai/moderation/index.ts
+++ b/core/src/services/ai/moderation/index.ts
@@ -1,2 +1,4 @@
+export * from './types';
 export * from './registry/ModelAdapter';
 export * from './registry/ModerationModelRegistry';
+export * from './providers/LocalVisionModerationProvider';

--- a/core/src/services/ai/moderation/providers/LocalVisionModerationProvider.ts
+++ b/core/src/services/ai/moderation/providers/LocalVisionModerationProvider.ts
@@ -1,0 +1,89 @@
+/**
+ * Local Vision Moderation Provider (PR 2)
+ *
+ * Implements ImageModerationProvider by delegating safety & object detection inference
+ * to local model adapters registered inside ModerationModelRegistry.
+ */
+import { ImageModerationProvider, ImageModerationRequest, ImageModerationResponse, ModerationProviderOptions } from '../types';
+import { ModerationModelRegistry } from '../registry/ModerationModelRegistry';
+import logger from '../../../../utils/logger';
+
+interface SafetyPredictionResult {
+    adultScore?: number;
+    violenceScore?: number;
+    racyScore?: number;
+    goreScore?: number;
+}
+
+interface ObjectDetectionPredictionResult {
+    labels?: string[];
+}
+
+export class LocalVisionModerationProvider implements ImageModerationProvider {
+    readonly providerName = 'LocalVisionModerationProvider';
+    private registry: ModerationModelRegistry;
+
+    constructor(registry: ModerationModelRegistry = new ModerationModelRegistry()) {
+        this.registry = registry;
+    }
+
+    async moderateImage(
+        request: ImageModerationRequest,
+        _options?: ModerationProviderOptions
+    ): Promise<ImageModerationResponse> {
+        const startTime = Date.now();
+        let adultScore = 0;
+        let violenceScore = 0;
+        let racyScore = 0;
+        let goreScore = 0;
+        const labels: string[] = [];
+
+        try {
+            // Resolve registered safety model adapters
+            const safetyAdapters = this.registry.getAdaptersByType<ImageModerationRequest, SafetyPredictionResult>('safety');
+            for (const adapter of safetyAdapters) {
+                if (adapter.isLoaded()) {
+                    const result = await adapter.predict(request);
+                    if (typeof result?.adultScore === 'number') adultScore = Math.max(adultScore, result.adultScore);
+                    if (typeof result?.violenceScore === 'number') violenceScore = Math.max(violenceScore, result.violenceScore);
+                    if (typeof result?.racyScore === 'number') racyScore = Math.max(racyScore, result.racyScore);
+                    if (typeof result?.goreScore === 'number') goreScore = Math.max(goreScore, result.goreScore);
+                }
+            }
+
+            // Resolve registered object detection model adapters
+            const objectAdapters = this.registry.getAdaptersByType<ImageModerationRequest, ObjectDetectionPredictionResult>('object_detection');
+            for (const adapter of objectAdapters) {
+                if (adapter.isLoaded()) {
+                    const result = await adapter.predict(request);
+                    if (Array.isArray(result?.labels)) {
+                        labels.push(...result.labels);
+                    }
+                }
+            }
+        } catch (error) {
+            logger.warn(`[LocalVisionModerationProvider] Inference warning during moderation execution`, { error });
+        }
+
+        const latencyMs = Date.now() - startTime;
+
+        return {
+            provider: this.providerName,
+            latencyMs,
+            adultScore,
+            violenceScore,
+            racyScore,
+            goreScore,
+            labels: Array.from(new Set(labels)),
+            signals: [
+                {
+                    classifier: this.providerName,
+                    score: Math.max(adultScore, violenceScore, racyScore, goreScore),
+                    details: {
+                        registeredModelsCount: this.registry.listRegisteredModels().length,
+                    },
+                },
+            ],
+        };
+    }
+}

--- a/core/src/services/ai/moderation/types.ts
+++ b/core/src/services/ai/moderation/types.ts
@@ -1,0 +1,38 @@
+/**
+ * AI Moderation Provider Abstraction Types (PR 2)
+ */
+
+export interface ModerationSignalDTO {
+    classifier: string;
+    score: number;
+    details?: Record<string, unknown>;
+}
+
+export interface ImageModerationRequest {
+    imageUrl?: string;
+    imageBuffer?: Buffer;
+    mimeType?: string;
+}
+
+export interface ImageModerationResponse {
+    provider: string;
+    latencyMs: number;
+    adultScore: number;
+    violenceScore: number;
+    racyScore: number;
+    goreScore: number;
+    labels: string[];
+    signals: ModerationSignalDTO[];
+}
+
+export interface ModerationProviderOptions {
+    timeoutMs?: number;
+}
+
+export interface ImageModerationProvider {
+    readonly providerName: string;
+    moderateImage(
+        request: ImageModerationRequest,
+        options?: ModerationProviderOptions
+    ): Promise<ImageModerationResponse>;
+}


### PR DESCRIPTION
## Summary

This is **PR 2 of 7** in the Pluggable AI Content Moderation Architecture epic.

This PR introduces **`LocalVisionModerationProvider`**, implementing the `ImageModerationProvider` interface by integrating with the `ModerationModelRegistry` introduced in PR 1 (#330).

## Architectural Highlights

- **Provider Abstraction Integration:** Implements `ImageModerationProvider` and queries registered `safety` and `object_detection` model adapters from `ModerationModelRegistry`.
- **Score Aggregation & Label Deduplication:** Evaluates loaded model adapters, aggregates adult/violence/racy/gore risk scores, deduplicates detected object labels, and reports execution metrics.
- **Graceful Uninitialized Adapter Handling:** Safely ignores uninitialized adapters during moderation execution without throwing runtime errors.
- **Strict Scope Boundaries:** Includes **zero** failover, OCR, policy engine, queue, orchestrator, or API contract changes.

## Changes

- `core/src/services/ai/moderation/types.ts`: Created `ImageModerationProvider`, `ImageModerationRequest`, `ImageModerationResponse`, and `ModerationSignalDTO` contract interfaces.
- `core/src/services/ai/moderation/providers/LocalVisionModerationProvider.ts`: Created `LocalVisionModerationProvider` implementation.
- `core/src/services/ai/moderation/index.ts`: Exported provider and types from `@esparex/core`.
- `core/src/__tests__/services/ai/LocalVisionModerationProvider.spec.ts`: Added provider unit test suite covering baseline responses, registry integration, score aggregation, and uninitialized adapter handling.

## Verification

- ✅ `npm run type-check`: Passed with 0 errors across all monorepo packages.
- ✅ `LocalVisionModerationProvider.spec.ts`: 3/3 tests passed.
- ✅ `ModerationModelRegistry.spec.ts`: 12/12 tests passed.
- ✅ Pre-push test suites: Passed 69 backend API test suites (345 tests) & 53 core test suites (314 tests).

## Risk

Low (Pure addition of `LocalVisionModerationProvider` and provider contract types; zero modifications to existing production endpoints or orchestrators).

## Epic Roadmap Context

- [x] **PR 1 (Merged #330):** `ModerationModelRegistry` + `ModelAdapter` interface + Unit Tests
- [x] **PR 2 (This PR):** `LocalVisionModerationProvider` + Model Registry Integration
- [ ] **PR 3:** `EarlyExitCostControlPipeline` (Stage 1 processing & perceptual hashing)
- [ ] **PR 4:** `ProviderFailoverManager` & Multi-Cloud Provider Adapters
- [ ] **PR 5:** `ImageModerationOrchestrator` 3-Stage Pipeline integration
- [ ] **PR 6:** `OCRService` / `LocalOcrProvider` (Stage 3 intelligence)
- [ ] **PR 7:** Moderation Metrics, Flags, & Admin Diagnostics
