### PR TITLE
chore(mobile): configure EAS build profiles for preview APK and production AAB/IPA (#R3.1)

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,19 +1,31 @@
 {
   "cli": {
-    "version": ">= 12.5.0"
+    "version": ">= 12.5.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "ios": {
         "simulator": true
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview",
+      "android": {
+        "buildType": "apk"
+      }
     },
-    "production": {}
+    "production": {
+      "channel": "production",
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
   },
   "submit": {
     "production": {}


### PR DESCRIPTION
## Summary

Configures Expo Application Services (EAS) build profiles for `apps/mobile` to enable preview APK generation, production App Bundle (AAB) builds, remote app versioning, and environment release channels.

## Changes Included

- **EAS CLI Config**: Enabled `appVersionSource: "remote"` in `apps/mobile/eas.json`.
- **Development Channel**: Added explicit `channel: "development"` setting for internal simulator builds.
- **Preview Channel**: Configured `distribution: "internal"` with `android.buildType: "apk"` for testing APK generation.
- **Production Channel**: Configured `autoIncrement: true` and `android.buildType: "app-bundle"` for Play Store / App Store release builds.

## Verification Executed

- [x] `npm run type-check` (Passed across all 6 monorepo packages)
- [x] `eas.json` schema validation passed
- [x] Pre-push governance gate (`repo:gate`) verified

## Contract & Governance Impact Checklist

- [x] **Mobile App** — EAS build configuration aligned for Release 1 R3.1
- [x] **Backend / Contracts** — Unchanged
- [x] **CI/CD** — EAS build profile channels configured
