### PR TITLE
fix(ui): migrate interactive overlay container heights from static vh to dvh

### DIFF
--- a/apps/web/src/components/location/LocationOverlayHost.tsx
+++ b/apps/web/src/components/location/LocationOverlayHost.tsx
@@ -71,7 +71,7 @@ export function LocationOverlayHost({
             <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
                 <SheetContent
                     side="bottom"
-                    className="h-[60vh] max-h-[440px] overflow-hidden rounded-t-2xl border-t-0 p-0 pb-[max(0.5rem,env(safe-area-inset-bottom))] shadow-2xl mx-auto max-w-sm w-full sm:h-[70vh] sm:max-h-[520px]"
+                    className="h-[60dvh] max-h-[440px] overflow-hidden rounded-t-2xl border-t-0 p-0 pb-[max(0.5rem,env(safe-area-inset-bottom))] shadow-2xl mx-auto max-w-sm w-full sm:h-[70dvh] sm:max-h-[520px]"
                 >
                     <SheetTitle className="sr-only">Select Location</SheetTitle>
                     <SheetDescription className="sr-only">Choose your city</SheetDescription>
@@ -85,7 +85,7 @@ export function LocationOverlayHost({
         <div
             ref={dropdownRef}
             style={{ zIndex: Z_INDEX.userHeaderDropdown, ...dropdownStyle }}
-            className="max-h-[52vh] bg-popover border rounded-xl shadow-lg overflow-hidden transition-all duration-200 flex flex-col opacity-100 visible translate-y-0"
+            className="max-h-[52dvh] bg-popover border rounded-xl shadow-lg overflow-hidden transition-all duration-200 flex flex-col opacity-100 visible translate-y-0"
             onClick={(e) => e.stopPropagation()}
         >
             <div className="flex-1 overflow-hidden">

--- a/apps/web/src/components/user/BrowseFiltersBar.tsx
+++ b/apps/web/src/components/user/BrowseFiltersBar.tsx
@@ -97,7 +97,7 @@ export const BrowseFiltersHeaderTrigger = memo(function BrowseFiltersHeaderTrigg
         </Button>
       }
     >
-      <div className="flex flex-col h-[75vh] max-h-[560px] -mx-4 -mb-4">
+      <div className="flex flex-col h-[75dvh] max-h-[560px] -mx-4 -mb-4">
         {/* Search Bar Header */}
         <div className="px-4 py-2 border-b border-slate-100">
           <div className="relative">

--- a/apps/web/src/components/user/profile/dialogs/CreateSmartAlertDialog.tsx
+++ b/apps/web/src/components/user/profile/dialogs/CreateSmartAlertDialog.tsx
@@ -141,7 +141,7 @@ export function CreateSmartAlertDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-sm sm:max-w-[400px] w-[94vw] h-[92vh] sm:h-[88vh] max-h-[680px] flex flex-col rounded-3xl p-4 sm:p-5 gap-0 shadow-2xl max-sm:rounded-b-3xl">
+            <DialogContent className="max-w-sm sm:max-w-[400px] w-[94vw] h-[92dvh] sm:h-[88dvh] max-h-[680px] flex flex-col rounded-3xl p-4 sm:p-5 gap-0 shadow-2xl max-sm:rounded-b-3xl">
                 <DialogHeader className="space-y-1 text-left pb-2.5 border-b border-slate-100 shrink-0">
                     <DialogTitle className="flex items-center gap-2 text-base font-bold">
                         <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-blue-100/80 text-blue-600">


### PR DESCRIPTION
## Problem Statement
On mobile browsers (iOS Safari & Android Chrome), static viewport height units (`vh`) include the height of off-screen virtual keyboards. When a user taps an input field inside a modal using static `vh`, the soft keyboard opens and pushes the bottom input fields and submit CTA buttons off-screen.

## Summary of Changes (PR 3 — Dynamic Overlay Heights)
- **`CreateSmartAlertDialog.tsx`** (`apps/web/.../CreateSmartAlertDialog.tsx`): Updated container height from `h-[92vh] sm:h-[88vh]` to dynamic `h-[92dvh] sm:h-[88dvh]`.
- **`BrowseFiltersBar.tsx`** (`apps/web/.../BrowseFiltersBar.tsx`): Updated search drawer height from `h-[75vh]` to `h-[75dvh]`.
- **`LocationOverlayHost.tsx`** (`apps/web/.../LocationOverlayHost.tsx`): Updated location search overlay heights from `h-[60vh]` / `max-h-[52vh]` to `h-[60dvh]` / `max-h-[52dvh]`.
- **Preserved Non-Interactive Layouts**: Preserved non-interactive image carousels (`AdImageCarousel.tsx`) and page placeholder shells (`ErrorFallback.tsx`, `PostAdShell.tsx`) as `vh` to maintain stable aspect ratios.

## Verification & Impact
- **Automated Type-Check**: `npm run type-check` passed with 0 compilation errors across all monorepo packages.
- **Pre-Push Gate**: `repo:gate` passed 100% of unit tests.
- **UX Impact**: Interactive overlays dynamically adjust height when virtual soft keyboards appear, keeping input fields and submit buttons visible and accessible.
