### PR TITLE
feat(mobile-ui): add WCAG 2.2 AA accessibility props to AppButton and AppInput primitives

### DIFF
--- a/packages/mobile-ui/src/atoms/AppButton.tsx
+++ b/packages/mobile-ui/src/atoms/AppButton.tsx
@@ -65,11 +65,21 @@ export const AppButton: React.FC<AppButtonProps> = ({
 
   const textStyle = `${getTextColor()} font-semibold ${size === 'lg' ? 'text-lg' : size === 'sm' ? 'text-sm' : 'text-base'}`;
 
+  const computedHitSlop = props.hitSlop || (size === 'sm' ? { top: 8, bottom: 8, left: 8, right: 8 } : undefined);
+
   return (
     <TouchableOpacity
       className={getContainerStyles()}
       disabled={disabled || loading}
       activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityLabel={props.accessibilityLabel || label}
+      accessibilityState={{
+        disabled: !!(disabled || loading),
+        busy: !!loading,
+        ...(props.accessibilityState || {}),
+      }}
+      hitSlop={computedHitSlop}
       {...(props as any)}
     >
       {loading ? (

--- a/packages/mobile-ui/src/atoms/AppInput.tsx
+++ b/packages/mobile-ui/src/atoms/AppInput.tsx
@@ -41,12 +41,19 @@ export const AppInput = forwardRef<TextInput, AppInputProps>(({
           ref={ref}
           className={`${baseInput} ${className}`}
           placeholderTextColor="#94a3b8"
+          accessibilityRole="text"
+          accessibilityLabel={props.accessibilityLabel || label || props.placeholder}
+          accessibilityState={{
+            invalid: hasError,
+            ...(props.accessibilityState || {}),
+          }}
+          accessibilityHint={props.accessibilityHint || error}
           {...(props as any)}
         />
         {rightIcon && <View className="ml-2" {...({} as any)}>{rightIcon}</View>}
       </View>
       {error && (
-        <AppText variant="caption" color="error" className="mt-1">
+        <AppText variant="caption" color="error" className="mt-1" accessibilityLiveRegion="polite">
           {error}
         </AppText>
       )}


### PR DESCRIPTION
## Problem Statement
Foundational React Native primitives in `@esparex/mobile-ui` (`AppButton` and `AppInput`) lacked default accessibility roles, labels, invalid states, polite error announcements, and target size hitSlop. Updating these foundational primitives immediately elevates accessibility across all consumer screens in `apps/mobile`.

## Summary of Changes (Track 2 PR 1 — Shared UI Primitives Accessibility)
- **`AppButton.tsx`**:
  - Injected `accessibilityRole="button"` and default `accessibilityLabel={label}`.
  - Provided `accessibilityState={{ disabled, busy: loading }}` for screen readers.
  - Applied selective `hitSlop` on small button sizes to guarantee minimum 44×44 pt touch targets (WCAG 2.5.8).
- **`AppInput.tsx`**:
  - Injected `accessibilityRole="text"` and associated field labels (`accessibilityLabel={label || placeholder}`).
  - Provided `accessibilityState={{ invalid: hasError }}` and `accessibilityHint={error}`.
  - Added `accessibilityLiveRegion="polite"` on error text for immediate validation error announcements (WCAG 3.3.1 / 4.1.3).

## Verification
- **Automated Type-Check**: `npm run type-check -w @esparex/mobile-ui` and `npm run type-check -w @esparex/apps-mobile` passed with 0 compilation errors.
- **Unit Tests**: All 43 mobile unit test suites (147 unit tests) passed 100%.
- **Pre-Push Gate**: `repo:gate` passed 100% (129 monorepo test suites green).
