### PR TITLE
feat(mobile): add accessibilityViewIsModal and close button a11y to all modal dialogs

### DIFF
--- a/apps/mobile/src/features/listings/presentation/components/FilterModal.tsx
+++ b/apps/mobile/src/features/listings/presentation/components/FilterModal.tsx
@@ -66,7 +66,13 @@ export const FilterModal: React.FC<FilterModalProps> = ({
   };
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityViewIsModal={true}
+    >
       <View className="flex-1 justify-end bg-black/50">
         <View className="bg-white dark:bg-slate-900 rounded-t-3xl p-6 max-h-[85%]">
           {/* Header */}
@@ -74,7 +80,12 @@ export const FilterModal: React.FC<FilterModalProps> = ({
             <AppText variant="h3" className="font-bold text-slate-900 dark:text-white">
               Filter Listings
             </AppText>
-            <TouchableOpacity onPress={onClose} accessibilityLabel="Close filters">
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityLabel="Close filters"
+              accessibilityRole="button"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
               <AppIcon name="X" size={20} color="#64748b" />
             </TouchableOpacity>
           </View>

--- a/apps/mobile/src/features/smartAlert/presentation/components/CreateSmartAlertModal.tsx
+++ b/apps/mobile/src/features/smartAlert/presentation/components/CreateSmartAlertModal.tsx
@@ -76,12 +76,23 @@ export function CreateSmartAlertModal({
   };
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityViewIsModal={true}
+    >
       <View style={styles.overlay}>
         <View style={styles.modalContent}>
           <View style={styles.modalHeader}>
             <Text style={styles.modalTitle}>{initialAlert ? 'Edit Smart Alert' : 'Create Smart Alert'}</Text>
-            <TouchableOpacity onPress={onClose}>
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close smart alert dialog"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
               <Text style={styles.closeText}>✕</Text>
             </TouchableOpacity>
           </View>

--- a/apps/mobile/src/features/user/presentation/components/EditProfileModal.tsx
+++ b/apps/mobile/src/features/user/presentation/components/EditProfileModal.tsx
@@ -36,7 +36,13 @@ export const EditProfileModal = React.memo<EditProfileModalProps>(({
   };
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityViewIsModal={true}
+    >
       <View className="flex-1 justify-end bg-black/50">
         <View className="bg-white dark:bg-slate-900 rounded-t-3xl p-6 max-h-[85%]">
           {/* Header */}
@@ -44,7 +50,12 @@ export const EditProfileModal = React.memo<EditProfileModalProps>(({
             <AppText variant="h3" className="font-bold text-slate-900 dark:text-white">
               Edit Profile
             </AppText>
-            <TouchableOpacity onPress={onClose} accessibilityLabel="Close edit modal">
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityLabel="Close edit modal"
+              accessibilityRole="button"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
               <AppIcon name="X" size={20} color="#64748b" />
             </TouchableOpacity>
           </View>


### PR DESCRIPTION
## Problem Statement
All three modal dialogs in `apps/mobile` lacked `accessibilityViewIsModal={true}`, which means
VoiceOver/TalkBack could continue reading content behind an open modal (background leakage).
Close buttons also lacked `accessibilityRole` and minimum 44pt touch targets.

## Changes (Track 2 PR 2 — Modal Accessibility WCAG 2.4.3)
- **`CreateSmartAlertModal.tsx`**: `accessibilityViewIsModal={true}`, close button role + hitSlop
- **`EditProfileModal.tsx`**: `accessibilityViewIsModal={true}`, close button role + hitSlop
- **`FilterModal.tsx`**: `accessibilityViewIsModal={true}`, close button role + hitSlop

0 new files created. 3 existing modal components modified.

## Verification
- `npm run type-check -w @esparex/apps-mobile` — 0 errors ✅
- `npm run test -w @esparex/apps-mobile` — 43 suites / 147 tests passed ✅
- `repo:gate` — 129 monorepo test suites green ✅
