### PR TITLE
feat(mobile): add WCAG 2.2 AA accessibility labels to auth, listings and smart alert screens

### DIFF
--- a/apps/mobile/src/features/auth/screens/LoginScreen.tsx
+++ b/apps/mobile/src/features/auth/screens/LoginScreen.tsx
@@ -30,7 +30,11 @@ export const LoginScreen = () => {
       title="Welcome Back"
       description="Enter your credentials to continue"
       footer={
-        <TouchableOpacity onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.SIGNUP })}>
+        <TouchableOpacity
+          onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.SIGNUP })}
+          accessibilityRole="button"
+          accessibilityLabel="Don't have an account? Sign up"
+        >
           <AppText variant="body" className="text-slate-500">
             Don't have an account? <AppText className="text-sky-500 font-semibold">Sign up</AppText>
           </AppText>
@@ -52,7 +56,12 @@ export const LoginScreen = () => {
         onChangeText={setPassword}
         secureTextEntry
       />
-      <TouchableOpacity onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.FORGOT_PASSWORD })} className="self-end mb-2">
+      <TouchableOpacity
+        onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.FORGOT_PASSWORD })}
+        className="self-end mb-2"
+        accessibilityRole="button"
+        accessibilityLabel="Forgot Password?"
+      >
         <AppText variant="caption" className="text-sky-500">Forgot Password?</AppText>
       </TouchableOpacity>
       

--- a/apps/mobile/src/features/auth/screens/OTPScreen.tsx
+++ b/apps/mobile/src/features/auth/screens/OTPScreen.tsx
@@ -23,7 +23,11 @@ export const OTPScreen = () => {
       title="Verify Account"
       description="Enter the 6-digit code sent to your email"
       footer={
-        <TouchableOpacity onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.LOGIN })}>
+        <TouchableOpacity
+          onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.LOGIN })}
+          accessibilityRole="button"
+          accessibilityLabel="Back to Login"
+        >
           <AppText variant="body" className="text-slate-500">
             Back to <AppText className="text-sky-500 font-semibold">Login</AppText>
           </AppText>

--- a/apps/mobile/src/features/auth/screens/SignupScreen.tsx
+++ b/apps/mobile/src/features/auth/screens/SignupScreen.tsx
@@ -23,7 +23,11 @@ export const SignupScreen = () => {
       title="Create Account"
       description="Sign up to get started"
       footer={
-        <TouchableOpacity onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.LOGIN })}>
+        <TouchableOpacity
+          onPress={() => navigate(ROUTES.AUTH_STACK, { screen: ROUTES.LOGIN })}
+          accessibilityRole="button"
+          accessibilityLabel="Already have an account? Login"
+        >
           <AppText variant="body" className="text-slate-500">
             Already have an account? <AppText className="text-sky-500 font-semibold">Login</AppText>
           </AppText>

--- a/apps/mobile/src/features/listings/presentation/components/FilterBar.tsx
+++ b/apps/mobile/src/features/listings/presentation/components/FilterBar.tsx
@@ -55,6 +55,8 @@ export const FilterBar = React.memo<FilterBarProps>(({
           <TouchableOpacity
             onPress={onRemoveSort}
             className="flex-row items-center bg-sky-50 dark:bg-sky-950/40 px-3 py-1.5 rounded-full border border-sky-200 dark:border-sky-800"
+            accessibilityRole="button"
+            accessibilityLabel={`Remove sort by ${filters.sortBy} filter`}
           >
             <AppText variant="caption" className="text-sky-700 dark:text-sky-300 font-medium mr-1">
               Sort: {filters.sortBy}
@@ -68,6 +70,8 @@ export const FilterBar = React.memo<FilterBarProps>(({
           <TouchableOpacity
             onPress={onRemoveCondition}
             className="flex-row items-center bg-sky-50 dark:bg-sky-950/40 px-3 py-1.5 rounded-full border border-sky-200 dark:border-sky-800"
+            accessibilityRole="button"
+            accessibilityLabel={`Remove condition ${filters.condition} filter`}
           >
             <AppText variant="caption" className="text-sky-700 dark:text-sky-300 font-medium mr-1">
               Condition: {filters.condition}
@@ -81,6 +85,8 @@ export const FilterBar = React.memo<FilterBarProps>(({
           <TouchableOpacity
             onPress={onRemovePrice}
             className="flex-row items-center bg-sky-50 dark:bg-sky-950/40 px-3 py-1.5 rounded-full border border-sky-200 dark:border-sky-800"
+            accessibilityRole="button"
+            accessibilityLabel={`Remove price filter`}
           >
             <AppText variant="caption" className="text-sky-700 dark:text-sky-300 font-medium mr-1">
               Price: ₹{filters.minPrice || 0} - ₹{filters.maxPrice || 'Any'}

--- a/apps/mobile/src/features/listings/presentation/components/ListingCard.tsx
+++ b/apps/mobile/src/features/listings/presentation/components/ListingCard.tsx
@@ -12,7 +12,13 @@ export const ListingCard = React.memo<ListingCardProps>(({ listing, onPress }) =
   const primaryImage = listing.images.find((img) => img.isPrimary)?.url || listing.images[0]?.url;
 
   return (
-    <TouchableOpacity onPress={() => onPress(listing.id)} activeOpacity={0.7} className="mb-4">
+    <TouchableOpacity
+      onPress={() => onPress(listing.id)}
+      activeOpacity={0.7}
+      className="mb-4"
+      accessibilityRole="button"
+      accessibilityLabel={`${listing.title}, ${listing.price.formatted}${listing.location?.display ? `, ${listing.location.display}` : ''}`}
+    >
       <Card className="overflow-hidden">
         {primaryImage ? (
           <Image

--- a/apps/mobile/src/features/smartAlert/presentation/screens/SmartAlertsScreen.tsx
+++ b/apps/mobile/src/features/smartAlert/presentation/screens/SmartAlertsScreen.tsx
@@ -31,7 +31,12 @@ export function SmartAlertsScreen({ onUpgradePlan }: SmartAlertsScreenProps) {
     <Card style={styles.alertCard}>
       <View style={styles.cardHeader}>
         <Text style={styles.alertName}>{item.name}</Text>
-        <TouchableOpacity onPress={() => handleDelete(item)}>
+        <TouchableOpacity
+          onPress={() => handleDelete(item)}
+          accessibilityRole="button"
+          accessibilityLabel={`Delete smart alert ${item.name}`}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
           <Text style={styles.deleteText}>Delete</Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
## Problem Statement
Feature screens in `apps/mobile` lacked `accessibilityRole` and `accessibilityLabel` on navigation 
links, listing cards, and filter chip controls. Screen readers (VoiceOver/TalkBack) could not 
announce the purpose of these interactive elements.

## Changes (Track 2 PR 3 — Feature Screen Accessibility WCAG 4.1.2 / 2.5.8)
- **`LoginScreen.tsx`**: `accessibilityRole` + label on "Sign Up" and "Forgot Password" links
- **`OTPScreen.tsx`**: `accessibilityRole` + label on "Back to Login" link
- **`SignupScreen.tsx`**: `accessibilityRole` + label on "Already have an account?" link
- **`ListingCard.tsx`**: dynamic `accessibilityLabel` announcing title + price + location
- **`FilterBar.tsx`**: descriptive `accessibilityLabel` on Sort / Condition / Price chip remove buttons
- **`SmartAlertsScreen.tsx`**: `accessibilityRole` + `accessibilityLabel` + `hitSlop` on Delete button

0 new files created. 6 existing files modified.

## Verification
- `npm run type-check -w @esparex/apps-mobile` — 0 errors ✅
- `npm run test -w @esparex/apps-mobile` — 43 suites / 147 tests passed ✅
- `repo:gate` — 129 monorepo test suites green ✅
