### PR TITLE
perf(mobile): replace RN Image with expo-image for disk/memory caching in listings and chat

### DIFF
--- a/apps/mobile/__mocks__/expo-image.js
+++ b/apps/mobile/__mocks__/expo-image.js
@@ -1,0 +1,14 @@
+/**
+ * Jest mock for expo-image.
+ *
+ * expo-image uses native modules (requireNativeViewManager) that are unavailable
+ * in the Jest / react-native test environment. This mock stubs the Image export
+ * with the standard react-native Image component so that component tests continue
+ * to render correctly without requiring a native runtime.
+ */
+const React = require('react');
+const { Image } = require('react-native');
+
+module.exports = {
+  Image,
+};

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^expo-modules-core.*$': '<rootDir>/__mocks__/expo-modules-core-refs.js',
+    '^expo-image$': '<rootDir>/__mocks__/expo-image.js',
     '^test-renderer$': 'react-test-renderer'
   }
 };

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-build-properties": "~0.13.3",
     "expo-crypto": "~14.0.2",
     "expo-device": "~7.0.3",
+    "expo-image": "~2.0.7",
     "expo-image-picker": "~16.0.6",
     "expo-notifications": "~0.29.14",
     "expo-secure-store": "~14.0.1",

--- a/apps/mobile/src/features/chat/presentation/screens/ConversationListScreen.tsx
+++ b/apps/mobile/src/features/chat/presentation/screens/ConversationListScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, FlatList, TouchableOpacity, RefreshControl, Image } from 'react-native';
+import { View, FlatList, TouchableOpacity, RefreshControl } from 'react-native';
+import { Image } from 'expo-image';
 import { Screen, Container, AppText, Card, AppIcon } from '@esparex/mobile-ui';
 import { useConversations } from '../hooks/useConversations';
 import { IConversationDTO } from '@esparex/contracts';
@@ -36,7 +37,11 @@ export const ConversationListScreen: React.FC<ConversationListScreenProps> = ({
               {item.ad.thumbnail ? (
                 <Image
                   source={{ uri: item.ad.thumbnail }}
-                  className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800"
+                  contentFit="cover"
+                  cachePolicy="memory-disk"
+                  transition={150}
+                  style={{ width: 48, height: 48, borderRadius: 8 }}
+                  accessibilityLabel={`Thumbnail for ${item.ad.title}`}
                 />
               ) : (
                 <View className="w-12 h-12 rounded-full bg-sky-100 dark:bg-sky-900/40 items-center justify-center">

--- a/apps/mobile/src/features/listings/presentation/components/ListingCard.tsx
+++ b/apps/mobile/src/features/listings/presentation/components/ListingCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, TouchableOpacity, Image } from 'react-native';
+import { View, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
 import { AppText, Card, Badge, AppIcon } from '@esparex/mobile-ui';
 import { Listing } from '../../domain/Listing';
 
@@ -23,8 +24,11 @@ export const ListingCard = React.memo<ListingCardProps>(({ listing, onPress }) =
         {primaryImage ? (
           <Image
             source={{ uri: primaryImage }}
-            resizeMode="cover"
+            contentFit="cover"
+            transition={200}
+            cachePolicy="memory-disk"
             className="w-full h-48 bg-slate-800"
+            accessibilityLabel={`Photo of ${listing.title}`}
           />
         ) : (
           <View className="w-full h-48 bg-slate-800 items-center justify-center">

--- a/apps/mobile/src/features/listings/presentation/components/details/ImageCarousel.tsx
+++ b/apps/mobile/src/features/listings/presentation/components/details/ImageCarousel.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import { View, Image, FlatList, Dimensions, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import { View, FlatList, Dimensions, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import { Image } from 'expo-image';
 import { Center, AppIcon, AppText } from '@esparex/mobile-ui';
 
 const { width } = Dimensions.get('window');
@@ -35,12 +36,14 @@ export const ImageCarousel = ({ images }: ImageCarouselProps) => {
         pagingEnabled
         showsHorizontalScrollIndicator={false}
         onScroll={handleScroll}
-        scrollEventThrottle={16}
+        scrollEventThrottle={100}
         renderItem={({ item }) => (
           <Image
             source={{ uri: item }}
             style={{ width, height: '100%' }}
-            resizeMode="cover"
+            contentFit="cover"
+            cachePolicy="memory-disk"
+            transition={150}
           />
         )}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
         "expo-build-properties": "~0.13.3",
         "expo-crypto": "~14.0.2",
         "expo-device": "~7.0.3",
+        "expo-image": "~2.0.7",
         "expo-image-picker": "~16.0.6",
         "expo-notifications": "~0.29.14",
         "expo-secure-store": "~14.0.1",
@@ -25555,6 +25556,23 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/expo-image": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.0.7.tgz",
+      "integrity": "sha512-kv40OIJOkItwznhdqFmKxTMC5O8GkpyTf8ng7Py4Hy6IBiH59dkeP6vUZQhzPhJOm5v1kZK4XldbskBosqzOug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-image-loader": {


### PR DESCRIPTION
## Problem Statement
`react-native` `Image` was used in `ListingCard`, `ImageCarousel`, and `ConversationListScreen`.
It has no disk cache, no memory cache, and no progressive decode. Every list scroll re-fetches
images from the network. `scrollEventThrottle={16}` in `ImageCarousel` fired at 60fps
unnecessarily, adding JS thread pressure.

## Changes (Track 1 PR 1 — Image Performance)
- **`ListingCard.tsx`**: `expo-image` with `cachePolicy="memory-disk"`, `contentFit="cover"`, `transition={200}`
- **`ImageCarousel.tsx`**: `expo-image` with `cachePolicy="memory-disk"`, `transition={150}`. `scrollEventThrottle` 16 → 100
- **`ConversationListScreen.tsx`**: Ad thumbnail `expo-image` with `cachePolicy="memory-disk"`, `transition={150}`
- **`jest.config.js`** + **`__mocks__/expo-image.js`**: Native-safe Jest mock (falls back to `react-native Image` in test environment)

**Intentionally excluded**: `StepPreview` and `ImagePickerComponents` — these render local camera
roll URI drafts during upload flow. Caching local file URIs provides no performance benefit.

0 new feature files. 5 files modified (3 source + 2 test infrastructure).

## Verification
- `npm run type-check -w @esparex/apps-mobile` — 0 errors ✅
- `npm run test -w @esparex/apps-mobile` — 43 suites / 147 tests passed ✅
- `repo:gate` — 129 monorepo test suites green ✅
