### PR TITLE
perf(mobile): add FlatList render budget props and remove inaccurate getItemLayout

### DIFF
--- a/apps/mobile/src/features/chat/presentation/screens/ChatThreadScreen.tsx
+++ b/apps/mobile/src/features/chat/presentation/screens/ChatThreadScreen.tsx
@@ -125,6 +125,10 @@ export const ChatThreadScreen: React.FC<ChatThreadScreenProps> = ({
             contentContainerStyle={{ padding: 16, paddingBottom: 20 }}
             showsVerticalScrollIndicator={false}
             onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
+            windowSize={10}
+            maxToRenderPerBatch={10}
+            initialNumToRender={15}
+            removeClippedSubviews={true}
           />
 
           {/* Input Composer */}

--- a/apps/mobile/src/features/listings/presentation/screens/MarketplaceScreen.tsx
+++ b/apps/mobile/src/features/listings/presentation/screens/MarketplaceScreen.tsx
@@ -71,14 +71,7 @@ export const MarketplaceScreen = () => {
 
   const keyExtractor = useCallback((item: Listing) => item.id, []);
 
-  const getItemLayout = useCallback(
-    (_: ArrayLike<Listing> | null | undefined, index: number) => ({
-      length: 300,
-      offset: 300 * index,
-      index,
-    }),
-    [],
-  );
+
 
   if (isError) {
     return (
@@ -114,7 +107,6 @@ export const MarketplaceScreen = () => {
             data={listings}
             renderItem={renderItem}
             keyExtractor={keyExtractor}
-            getItemLayout={getItemLayout}
             contentContainerStyle={{ padding: 16, paddingBottom: 100 }}
             showsVerticalScrollIndicator={false}
             removeClippedSubviews={true}

--- a/apps/mobile/src/features/listings/presentation/screens/SavedAdsScreen.tsx
+++ b/apps/mobile/src/features/listings/presentation/screens/SavedAdsScreen.tsx
@@ -41,6 +41,11 @@ export function SavedAdsScreen({ onPressListing, onExploreListings }: SavedAdsSc
             keyExtractor={(item) => item.id}
             renderItem={renderItem}
             refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} colors={['#2563eb']} tintColor="#2563eb" />}
+            showsVerticalScrollIndicator={false}
+            removeClippedSubviews={true}
+            windowSize={5}
+            maxToRenderPerBatch={5}
+            initialNumToRender={5}
             ListEmptyComponent={
               <Card style={styles.emptyCard}>
                 <Text style={styles.emptyTitle}>No Saved Ads Yet</Text>

--- a/apps/mobile/src/features/listings/presentation/screens/SearchScreen.tsx
+++ b/apps/mobile/src/features/listings/presentation/screens/SearchScreen.tsx
@@ -41,14 +41,6 @@ export const SearchScreen = () => {
 
   const keyExtractor = useCallback((item: Listing) => item.id, []);
 
-  const getItemLayout = useCallback(
-    (_: ArrayLike<Listing> | null | undefined, index: number) => ({
-      length: 300,
-      offset: 300 * index,
-      index,
-    }),
-    [],
-  );
 
   const listings = data?.pages.flat() ?? [];
   const hasSearched = debouncedQuery.length > 0;
@@ -87,7 +79,6 @@ export const SearchScreen = () => {
         data={listings}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        getItemLayout={getItemLayout}
         contentContainerStyle={{ padding: 16, paddingBottom: 100 }}
         showsVerticalScrollIndicator={false}
         removeClippedSubviews

--- a/apps/mobile/src/features/notifications/presentation/screens/NotificationScreen.tsx
+++ b/apps/mobile/src/features/notifications/presentation/screens/NotificationScreen.tsx
@@ -133,6 +133,10 @@ export const NotificationScreen = () => {
           renderItem={renderNotificationItem}
           showsVerticalScrollIndicator={false}
           refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+          removeClippedSubviews={true}
+          windowSize={5}
+          maxToRenderPerBatch={8}
+          initialNumToRender={10}
           ListEmptyComponent={
             !isLoading ? (
               <View className="items-center justify-center py-16 px-4">

--- a/apps/mobile/src/features/payment/presentation/screens/TransactionHistoryScreen.tsx
+++ b/apps/mobile/src/features/payment/presentation/screens/TransactionHistoryScreen.tsx
@@ -44,6 +44,11 @@ export function TransactionHistoryScreen() {
             data={transactions || []}
             keyExtractor={(item) => item.id || item.orderId}
             renderItem={renderTransactionItem}
+            showsVerticalScrollIndicator={false}
+            removeClippedSubviews={true}
+            windowSize={5}
+            maxToRenderPerBatch={8}
+            initialNumToRender={10}
             ListEmptyComponent={
               <Card style={styles.emptyCard}>
                 <Text style={styles.emptyText}>No previous credit purchases found.</Text>


### PR DESCRIPTION
## Problem Statement
Four FlatList screens in `apps/mobile` had no render-budget constraints — they rendered all items
on mount with no windowing, no batch limits, and no clipped-view optimization. Two additional
screens had a hardcoded `getItemLayout` of 300px for a variable-height `ListingCard`, causing
scroll position jumps during infinite-load pagination.

## Changes (Track 1 PR 2 — List & Query Performance)

### FlatList render-budget tuning
- **`ChatThreadScreen`**: `windowSize=10`, `maxToRenderPerBatch=10`, `initialNumToRender=15`, `removeClippedSubviews`
  - Higher initialNumToRender for chat — threads scroll from bottom, users expect instant history
- **`SavedAdsScreen`**: `windowSize=5`, `maxToRenderPerBatch=5`, `initialNumToRender=5`, `removeClippedSubviews`
- **`NotificationScreen`**: `windowSize=5`, `maxToRenderPerBatch=8`, `initialNumToRender=10`, `removeClippedSubviews`
- **`TransactionHistoryScreen`**: `windowSize=5`, `maxToRenderPerBatch=8`, `initialNumToRender=10`, `removeClippedSubviews`

### getItemLayout correction
- **`MarketplaceScreen`**: Removed `getItemLayout`. `ListingCard` height varies by location row,
  title wrap, and badge content — the 300px constant caused scroll jumps during pagination.
- **`SearchScreen`**: Same fix.

0 new files created. 6 existing files modified.

## Verification
- `npm run type-check -w @esparex/apps-mobile` — 0 errors ✅
- `npm run test -w @esparex/apps-mobile` — 43 suites / 147 tests passed ✅
- `repo:gate` — 129 monorepo test suites green ✅
