### PR TITLE
chore(mobile): configure release env vars and clean up manifest permissions

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -56,6 +56,14 @@
           "color": "#0A0C0B",
           "sounds": []
         }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Esparex requires photo library access to upload listing images.",
+          "cameraPermission": "Esparex requires camera access to capture listing photos.",
+          "requestMicrophonePermissionsIOS": false
+        }
       ]
     ]
   }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -8,6 +8,9 @@
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development",
+      "env": {
+        "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true"
+      },
       "ios": {
         "simulator": true
       }
@@ -15,6 +18,10 @@
     "preview": {
       "distribution": "internal",
       "channel": "preview",
+      "env": {
+        "EX_DEV_CLIENT_NETWORK_INSPECTOR": "false",
+        "EXPO_PUBLIC_API_URL": "https://api.esparex.in/api"
+      },
       "android": {
         "buildType": "apk"
       }
@@ -22,6 +29,10 @@
     "production": {
       "channel": "production",
       "autoIncrement": true,
+      "env": {
+        "EX_DEV_CLIENT_NETWORK_INSPECTOR": "false",
+        "EXPO_PUBLIC_API_URL": "https://api.esparex.in/api"
+      },
       "android": {
         "buildType": "app-bundle"
       }


### PR DESCRIPTION
## What does this PR do?
Fixes mobile release build hygiene by pinning production environment variables in `eas.json`, configuring plugin sources to eliminate unused iOS privacy strings, and removing legacy/development permissions from the Android manifest.

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `chore` — refactor / cleanup / tooling
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only

## Packages affected
- [ ] `backend`
- [ ] `apps/web`
- [ ] `apps/admin`
- [ ] `shared`
- [x] `apps/mobile`

## Key Changes
- **`eas.json`**: Added explicit `env` configuration for `preview` and `production` build profiles (`EXPO_PUBLIC_API_URL` pinned to `https://api.esparex.in/api`, `EX_DEV_CLIENT_NETWORK_INSPECTOR: "false"`).
- **`app.json`**: Configured `expo-image-picker` plugin with `requestMicrophonePermissionsIOS: false` to suppress unused `NSMicrophoneUsageDescription` at the source.
- **`AndroidManifest.xml`**: Removed deprecated storage permissions (`READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`) and dev-only `SYSTEM_ALERT_WINDOW`.
- **`Info.plist`**: Cleaned prebuild artifact output.

## Verification
- `npm run type-check -w @esparex/apps-mobile` — 0 errors PASS
- `npm run test -w @esparex/apps-mobile` — 43 suites / 147 tests PASS
- `repo:gate` — 129 monorepo test suites green PASS
