### PR TITLE
refactor(web): abstract UI components and search logic

### DIFF
--- a/apps/web/src/app/(public)/search/page.tsx
+++ b/apps/web/src/app/(public)/search/page.tsx
@@ -51,6 +51,27 @@ export async function generateMetadata(
     };
 }
 
+const buildBrowseFilters = (
+    parsed: ReturnType<typeof parsePublicBrowseParams>,
+    resolvedCategoryId?: string
+) => {
+    return {
+        status: 'live' as const,
+        type: parsed.type,
+        page: parsed.page ?? 1,
+        limit: 20,
+        ...(parsed.q ? { search: parsed.q } : {}),
+        ...(resolvedCategoryId ? { categoryId: resolvedCategoryId } : {}),
+        ...(parsed.modelId ? { modelId: parsed.modelId } : {}),
+        ...(parsed.sort ? { sortBy: PUBLIC_BROWSE_SORT_MAP[parsed.sort as SortOption] } : {}),
+        ...(typeof parsed.minPrice === "number" ? { minPrice: parsed.minPrice } : {}),
+        ...(typeof parsed.maxPrice === "number" ? { maxPrice: parsed.maxPrice } : {}),
+        ...(parsed.locationId ? { locationId: parsed.locationId } : {}),
+        ...(parsed.brands ? { brandId: parsed.brands } : {}),
+        ...(typeof parsed.radiusKm === "number" && parsed.locationId ? { radiusKm: parsed.radiusKm } : {}),
+    };
+};
+
 export default async function SearchPage(props: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
     const searchParams = await props.searchParams;
     const parsed = parsePublicBrowseParams(searchParams);
@@ -72,21 +93,7 @@ export default async function SearchPage(props: { searchParams: Promise<{ [key: 
         initialCategories = await getCategories({ fetchOptions: { next: { revalidate: 3600 } } });
         const resolvedCategory = resolveBrowseCategorySelection(rawCategoryInput, initialCategories);
         initialResults = await getAdsPage(
-            {
-                status: 'live',
-                type: parsed.type,
-                page: parsed.page ?? 1,
-                limit: 20,
-                ...(parsed.q ? { search: parsed.q } : {}),
-                ...(resolvedCategory.categoryId ? { categoryId: resolvedCategory.categoryId } : {}),
-                ...(parsed.modelId ? { modelId: parsed.modelId } : {}),
-                ...(parsed.sort ? { sortBy: PUBLIC_BROWSE_SORT_MAP[parsed.sort as SortOption] } : {}),
-                ...(typeof parsed.minPrice === "number" ? { minPrice: parsed.minPrice } : {}),
-                ...(typeof parsed.maxPrice === "number" ? { maxPrice: parsed.maxPrice } : {}),
-                ...(parsed.locationId ? { locationId: parsed.locationId } : {}),
-                ...(parsed.brands ? { brandId: parsed.brands } : {}),
-                ...(typeof parsed.radiusKm === "number" && parsed.locationId ? { radiusKm: parsed.radiusKm } : {}),
-            },
+            buildBrowseFilters(parsed, resolvedCategory.categoryId),
             {
                 endpoint,
                 fetchOptions: { next: { revalidate: 60 } }
@@ -97,21 +104,7 @@ export default async function SearchPage(props: { searchParams: Promise<{ [key: 
         [initialCategories, initialResults] = await Promise.all([
             getCategories({ fetchOptions: { next: { revalidate: 3600 } } }),
             getAdsPage(
-                {
-                    status: 'live',
-                    type: parsed.type,
-                    page: parsed.page ?? 1,
-                    limit: 20,
-                    ...(parsed.q ? { search: parsed.q } : {}),
-                    ...(directCategoryId ? { categoryId: directCategoryId } : {}),
-                    ...(parsed.modelId ? { modelId: parsed.modelId } : {}),
-                    ...(parsed.sort ? { sortBy: PUBLIC_BROWSE_SORT_MAP[parsed.sort as SortOption] } : {}),
-                    ...(typeof parsed.minPrice === "number" ? { minPrice: parsed.minPrice } : {}),
-                    ...(typeof parsed.maxPrice === "number" ? { maxPrice: parsed.maxPrice } : {}),
-                    ...(parsed.locationId ? { locationId: parsed.locationId } : {}),
-                    ...(parsed.brands ? { brandId: parsed.brands } : {}),
-                    ...(typeof parsed.radiusKm === "number" && parsed.locationId ? { radiusKm: parsed.radiusKm } : {}),
-                },
+                buildBrowseFilters(parsed, directCategoryId),
                 {
                     endpoint,
                     fetchOptions: { next: { revalidate: 60 } }

--- a/apps/web/src/components/user/BrandSearchSelect.tsx
+++ b/apps/web/src/components/user/BrandSearchSelect.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { CatalogSearchSelect } from "./CatalogSearchSelect";
+import { EntitySearchCombobox } from "./EntitySearchCombobox";
 
 interface BrandSearchSelectProps {
     brands: string[];
@@ -42,7 +42,7 @@ export function BrandSearchSelect({
     }, [value, brandMap]);
 
     return (
-        <CatalogSearchSelect<string>
+        <EntitySearchCombobox<string>
             items={brands}
             loading={loading}
             value={value}

--- a/apps/web/src/components/user/EntitySearchCombobox.tsx
+++ b/apps/web/src/components/user/EntitySearchCombobox.tsx
@@ -8,7 +8,7 @@ import { Drawer } from "@esparex/ui";
 import { useIsMobile } from "@/components/ui/useMobile";
 import { useKeyboardNavigation } from "@/hooks/useKeyboardNavigation";
 
-export interface CatalogSearchSelectProps<T> {
+export interface EntitySearchComboboxProps<T> {
     items: T[];
     loading?: boolean;
     value: string;
@@ -29,7 +29,7 @@ export interface CatalogSearchSelectProps<T> {
     renderItem?: (item: T, isSelected: boolean) => ReactNode;
 }
 
-export function CatalogSearchSelect<T>({
+export function EntitySearchCombobox<T>({
     items,
     loading = false,
     value,
@@ -48,7 +48,7 @@ export function CatalogSearchSelect<T>({
     getLabel,
     getId,
     renderItem,
-}: CatalogSearchSelectProps<T>) {
+}: EntitySearchComboboxProps<T>) {
     const [search, setSearch] = useState("");
     const [isEditing, setIsEditing] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/components/user/ModelSearchSelect.tsx
+++ b/apps/web/src/components/user/ModelSearchSelect.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useEffect, useCallback } from "react";
-import { CatalogSearchSelect } from "./CatalogSearchSelect";
+import { EntitySearchCombobox } from "./EntitySearchCombobox";
 import { usePostAdCatalog, usePostAdAction } from "@/components/user/post-ad/context";
 import type { DeviceModel } from "@/lib/api/user/masterData";
 
@@ -55,7 +55,7 @@ export function ModelSearchSelect({
     }, [brandId, categoryId, loadModelsForBrand]);
 
     return (
-        <CatalogSearchSelect<DeviceModel>
+        <EntitySearchCombobox<DeviceModel>
             items={availableModels}
             loading={isLoadingModels}
             value={value}

--- a/apps/web/src/components/user/ad-card/AdCardGrid.tsx
+++ b/apps/web/src/components/user/ad-card/AdCardGrid.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { memo } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { AdCardCover, AdCardMeta, AdCardActions } from "./primitives";
+import { CardContent } from "@/components/ui/card";
+import { AdCardCover, AdCardMeta, AdCardActions, AdCardShell } from "./primitives";
 import { cn } from "@/components/ui/utils";
 import {
-  AdCardLinkWrapper,
   type AdCardData,
   useAdCardBase,
 } from "./shared";
@@ -64,34 +63,20 @@ export const AdCardGrid = memo(function AdCardGrid({
   const isBusiness = Boolean(adRecord.isBusiness);
 
   return (
-    <AdCardLinkWrapper href={resolvedHref} enabled={useDeclarativeLink}>
-      {/* article gives screen readers proper document structure for list items */}
-      <article aria-label={ad.title}>
-        <Card
-          tabIndex={useDeclarativeLink ? undefined : 0}
-          role={useDeclarativeLink ? undefined : "button"}
-          className={cn(
-            "overflow-hidden transition-all duration-300 group cursor-pointer",
-            "border-border bg-white shadow-premium rounded-2xl",
-            "hover:shadow-premium-hover hover:-translate-y-1.5",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-            ad.isSpotlight &&
-              "ring-2 ring-amber-400/30 shadow-[0_8px_30px_rgba(245,158,11,0.15)]",
-            className
-          )}
-          onClick={useDeclarativeLink ? undefined : handleCardClick}
-          onKeyDown={
-            useDeclarativeLink
-              ? undefined
-              : (e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleCardClick();
-                  }
-                }
-          }
-        >
-          {/* Image section — AdCardCover handles promotion + verified badges internally */}
+    <AdCardShell
+      ad={ad}
+      resolvedHref={resolvedHref}
+      useDeclarativeLink={useDeclarativeLink}
+      handleCardClick={handleCardClick}
+      className={cn(
+        "duration-300 border-border bg-white shadow-premium rounded-2xl",
+        "hover:shadow-premium-hover hover:-translate-y-1.5",
+        ad.isSpotlight &&
+          "ring-2 ring-amber-400/30 shadow-[0_8px_30px_rgba(245,158,11,0.15)]",
+        className
+      )}
+    >
+      {/* Image section — AdCardCover handles promotion + verified badges internally */}
           <AdCardCover
             ad={ad}
             imageUrl={imageUrl}
@@ -116,9 +101,7 @@ export const AdCardGrid = memo(function AdCardGrid({
           <CardContent className="p-3">
             <AdCardMeta ad={ad} variant="default" />
           </CardContent>
-        </Card>
-      </article>
-    </AdCardLinkWrapper>
+    </AdCardShell>
   );
 }, areAdCardGridPropsEqual);
 

--- a/apps/web/src/components/user/ad-card/AdCardList.tsx
+++ b/apps/web/src/components/user/ad-card/AdCardList.tsx
@@ -2,15 +2,14 @@
 
 import { memo } from "react";
 import { SafeImage } from "@/components/ui/SafeImage";
-import { Card, CardContent } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
 import { Button } from "@esparex/ui";
 import { Heart } from "@/icons/IconRegistry";
 import { haptics } from "@/lib/haptics";
 import { resolveListingCategoryLabel } from "@/lib/listings/listingPresentation";
-import { AdCardMeta } from "./primitives";
+import { AdCardShell, AdCardMeta } from "./primitives";
 import { cn } from "@/components/ui/utils";
 import {
-  AdCardLinkWrapper,
   type AdCardData,
   useAdCardBase,
   getPlanBadge,
@@ -70,30 +69,18 @@ export const AdCardList = memo(function AdCardList({
   const conditionBadge = getConditionBadge(ad);
 
   return (
-    <AdCardLinkWrapper href={resolvedHref} enabled={useDeclarativeLink}>
-      <article aria-label={ad.title}>
-        <Card
-          tabIndex={useDeclarativeLink ? undefined : 0}
-          role={useDeclarativeLink ? undefined : "button"}
-          className={cn(
-            "overflow-hidden hover:shadow-md hover:-translate-y-0.5 transition-all cursor-pointer border border-border rounded-xl group bg-white",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-            ad.isSpotlight ? "ring-2 ring-yellow-500 ring-offset-2" : "",
-            className
-          )}
-          onClick={useDeclarativeLink ? undefined : handleCardClick}
-          onKeyDown={
-            useDeclarativeLink
-              ? undefined
-              : (e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleCardClick();
-                  }
-                }
-          }
-        >
-          <CardContent className="p-3 sm:p-4">
+    <AdCardShell
+      ad={ad}
+      resolvedHref={resolvedHref}
+      useDeclarativeLink={useDeclarativeLink}
+      handleCardClick={handleCardClick}
+      className={cn(
+        "hover:shadow-md hover:-translate-y-0.5 border border-border rounded-xl bg-white",
+        ad.isSpotlight ? "ring-2 ring-yellow-500 ring-offset-2" : "",
+        className
+      )}
+    >
+      <CardContent className="p-3 sm:p-4">
             <div className="flex min-w-0 items-start gap-3 sm:gap-5">
               {/* List View Image */}
               <div className="relative h-28 w-28 sm:h-32 sm:w-36 shrink-0 overflow-hidden rounded-xl bg-muted/20">
@@ -164,10 +151,8 @@ export const AdCardList = memo(function AdCardList({
                 </div>
               </div>
             </div>
-          </CardContent>
-        </Card>
-      </article>
-    </AdCardLinkWrapper>
+      </CardContent>
+    </AdCardShell>
   );
 }, areAdCardListPropsEqual);
 

--- a/apps/web/src/components/user/ad-card/primitives/AdCardShell.tsx
+++ b/apps/web/src/components/user/ad-card/primitives/AdCardShell.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { memo } from "react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/components/ui/utils";
+import {
+  AdCardLinkWrapper,
+  type AdCardData,
+} from "../shared";
+
+export interface AdCardShellProps {
+  ad: AdCardData;
+  resolvedHref?: string;
+  useDeclarativeLink: boolean;
+  handleCardClick: (e?: React.MouseEvent) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const AdCardShell = memo(function AdCardShell({
+  ad,
+  resolvedHref,
+  useDeclarativeLink,
+  handleCardClick,
+  className,
+  children,
+}: AdCardShellProps) {
+  return (
+    <AdCardLinkWrapper href={resolvedHref} enabled={useDeclarativeLink}>
+      {/* article gives screen readers proper document structure for list items */}
+      <article aria-label={ad.title}>
+        <Card
+          tabIndex={useDeclarativeLink ? undefined : 0}
+          role={useDeclarativeLink ? undefined : "button"}
+          className={cn(
+            "overflow-hidden transition-all group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+            className
+          )}
+          onClick={useDeclarativeLink ? undefined : handleCardClick}
+          onKeyDown={
+            useDeclarativeLink
+              ? undefined
+              : (e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleCardClick();
+                  }
+                }
+          }
+        >
+          {children}
+        </Card>
+      </article>
+    </AdCardLinkWrapper>
+  );
+});
+
+AdCardShell.displayName = "AdCardShell";

--- a/apps/web/src/components/user/ad-card/primitives/index.ts
+++ b/apps/web/src/components/user/ad-card/primitives/index.ts
@@ -1,3 +1,4 @@
 export * from "./AdCardCover";
 export * from "./AdCardMeta";
 export * from "./AdCardActions";
+export * from "./AdCardShell";


### PR DESCRIPTION
## Description
Addresses CC-006, CC-007, and CC-008 from the Phase 1 Clean Code Audit. Focuses on abstracting heavily duplicated UI wrappers and URL parameter logic.

## Changes
* Creates `<AdCardShell />` to eliminate wrapper and accessibility duplication between `AdCardGrid` and `AdCardList` views.
* Extracts duplicated URL parameter parsing in `search/page.tsx` into a central `buildBrowseFilters` utility.
* Refactors `CatalogSearchSelect` into a fully generic `<EntitySearchCombobox />`, applying it to both `BrandSearchSelect` and `ModelSearchSelect`.

## Validation
- ✅ Verified `npm run type-check -w @esparex/apps-web` passes.
- ✅ No regressions in search filtering or catalog combobox behaviors.
