### PR TITLE
style(web): standardize UI layouts and design tokens across web app

### DIFF
--- a/apps/web/src/app/(private)/account/business/apply/page.tsx
+++ b/apps/web/src/app/(private)/account/business/apply/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { Button } from "@esparex/ui";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CheckCircle2, LayoutDashboard, Wrench, Phone } from "@/icons/IconRegistry";
-import { PageContainer } from "@/components/ui/PageContainer";
 import { BusinessProfileFlow } from "@/components/user/business-registration/BusinessProfileFlow";
 import { BusinessApplicationStatus } from "@/components/user/profile/BusinessApplicationStatus";
 import { useCurrentUser as useUser } from "@/hooks/useCurrentUser";
@@ -39,7 +38,7 @@ export default function BusinessApplyPage() {
 
     if (businessError) {
         return (
-            <PageContainer variant="compact" className="py-12">
+            <div className="w-full max-w-3xl mx-auto py-12">
                 <Card className="rounded-2xl border-slate-200 bg-white p-6 shadow-sm">
                     <CardHeader className="p-0 mb-4">
                         <CardTitle className="text-lg font-semibold text-foreground">Unable to verify business status</CardTitle>
@@ -53,14 +52,14 @@ export default function BusinessApplyPage() {
                         </Button>
                     </CardContent>
                 </Card>
-            </PageContainer>
+            </div>
         );
     }
 
     // Require mobile verification before registration
     if (user && !user.isPhoneVerified) {
         return (
-            <PageContainer variant="compact" className="py-12 space-y-4">
+            <div className="w-full max-w-3xl mx-auto py-12 space-y-4">
                 <Card className="rounded-3xl border-amber-200 bg-amber-50/50 p-6">
                     <CardHeader className="p-0 mb-3 flex flex-row items-center gap-3">
                         <Phone className="h-6 w-6 text-amber-600 shrink-0" />
@@ -78,7 +77,7 @@ export default function BusinessApplyPage() {
                         </Button>
                     </CardContent>
                 </Card>
-            </PageContainer>
+            </div>
         );
     }
 
@@ -110,7 +109,7 @@ export default function BusinessApplyPage() {
     // State 1: Approved Business (Informational View)
     if (status === "live" || status === "active") {
         return (
-            <PageContainer variant="compact" className="py-12 space-y-4">
+            <div className="w-full max-w-3xl mx-auto py-12 space-y-4">
                 <Card className="rounded-3xl border-emerald-100 bg-gradient-to-br from-emerald-50 to-teal-50 p-6 shadow-sm">
                     <CardHeader className="p-0 mb-4 flex flex-row items-start gap-4">
                         <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-600 text-white shrink-0">
@@ -146,14 +145,14 @@ export default function BusinessApplyPage() {
                         </div>
                     </CardContent>
                 </Card>
-            </PageContainer>
+            </div>
         );
     }
 
     // State 2 & 3: Pending or Rejected Business Application Status
     if (hasExistingBusiness && (status === "pending" || status === "rejected" || status === "suspended")) {
         return (
-            <PageContainer variant="compact" className="py-12">
+            <div className="w-full max-w-3xl mx-auto py-12">
                 <BusinessApplicationStatus
                     businessData={businessData}
                     onEditApplication={() => setIsEditing(true)}
@@ -163,7 +162,7 @@ export default function BusinessApplyPage() {
                         await retryBusiness();
                     }}
                 />
-            </PageContainer>
+            </div>
         );
     }
 

--- a/apps/web/src/components/home/CategoryBrowser.tsx
+++ b/apps/web/src/components/home/CategoryBrowser.tsx
@@ -75,7 +75,7 @@ export function CategoryBrowser({ categories }: CategoryBrowserProps) {
                                     className="
                                         group flex flex-col items-center justify-center gap-1.5 
                                         h-[76px] md:h-32 rounded-lg md:rounded-[20px] border border-slate-100 bg-white/95 
-                                        shadow-[0_1px_4px_rgba(15,23,42,0.01)] hover:shadow-premium-hover 
+                                        shadow-sm hover:shadow-premium-hover 
                                         transition-all duration-300 hover:border-slate-200/80 hover:-translate-y-0.5 
                                         active:scale-[0.98] p-1.5 md:p-4 min-w-0 w-full
                                     "

--- a/apps/web/src/components/home/HomeFeedClient.tsx
+++ b/apps/web/src/components/home/HomeFeedClient.tsx
@@ -121,8 +121,8 @@ export function HomeFeedClient({ initialData }: HomeFeedProps) {
                 )}
 
                 {isError && recommendedAds.length === 0 && (
-                    <div className="rounded-xl border border-red-100 bg-red-50 p-6 text-center">
-                        <p className="text-sm text-red-700 mb-3">
+                    <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-6 text-center">
+                        <p className="text-sm text-destructive mb-3">
                             Failed to load recommended ads. Please try again.
                         </p>
                         <Button variant="outline" onClick={() => refetch()}>
@@ -163,7 +163,7 @@ export function HomeFeedClient({ initialData }: HomeFeedProps) {
                                         });
                                     }}
                                     disabled={isFetching}
-                                    className="bg-blue-600 hover:bg-blue-700 rounded-xl px-8 h-11 font-semibold shadow-md shadow-blue-100 transition-all active:scale-95"
+                                    className="bg-primary hover:bg-primary/90 text-primary-foreground rounded-xl px-8 h-11 font-semibold shadow-sm transition-all active:scale-95"
                                 >
                                     {isFetching ? (
                                         <>

--- a/apps/web/src/components/user/ProfileSettingsSidebar.tsx
+++ b/apps/web/src/components/user/ProfileSettingsSidebar.tsx
@@ -12,7 +12,6 @@ import { useProfileSettings } from "@/hooks/useProfileSettings";
 import type { ProfileUser } from "@/components/user/profile/types";
 
 // UI Components
-import { PageContainer } from "@/components/ui/PageContainer";
 import { Button } from "@esparex/ui";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -323,7 +322,7 @@ export function ProfileSettingsSidebar({
   };
 
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
       {/* UNIFIED RESPONSIVE ACCOUNT HEADER (Single Instance) */}
       <AccountHeader
         activeTab={activeTab}
@@ -345,7 +344,7 @@ export function ProfileSettingsSidebar({
         }
       />
 
-      <PageContainer variant="wide" className="pt-1 pb-20 md:pb-10">
+      <div className="w-full max-w-7xl mx-auto pt-1 md:py-6">
         {/* LAYOUT CONTAINER */}
         <div className="flex flex-col md:grid md:grid-cols-[240px_1fr] md:gap-6">
           {/* LEFT SIDEBAR (Desktop Only) */}
@@ -385,7 +384,7 @@ export function ProfileSettingsSidebar({
             {renderContent()}
           </section>
         </div>
-      </PageContainer>
+      </div>
 
       <MobileAccountBottomNav activeTab={activeTab} onTabChange={handleTabChange} unreadCount={chatUnreadCount} />
 


### PR DESCRIPTION
This PR completes the Phase 2 UI/UX cleanup for the web application, standardizing several layouts and design tokens.

**Changes:**
- Removed nested `PageContainer` from `ProfileSettingsSidebar` and `business/apply/page.tsx`, replacing them with standard structural containers to prevent conflicting layout bounds.
- Moved mobile bottom navigation padding constraint to the outermost wrapper of `ProfileSettingsSidebar` to resolve overlapping scroll spacing and properly account for `env(safe-area-inset-bottom)`.
- Migrated hardcoded colors (red/blue) in `HomeFeedClient` to the design system tokens (`destructive` and `primary`).
- Migrated arbitrary box-shadow in `CategoryBrowser` to the canonical `shadow-sm` token.

**Validation:**
- Successfully passes `npm run build`.
- Passes strict type-checking and ESLint constraints.
- Fixes iOS safe-area layout overlap on the mobile account menu.
