### PR TITLE
fix(vercel): build design-tokens before admin next build

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "npm install --include=dev",
-  "buildCommand": "NEXT_DISABLE_WEBPACK_CACHE=1 next build",
+  "buildCommand": "npm run build -w @esparex/design-tokens && NEXT_DISABLE_WEBPACK_CACHE=1 next build",
   "outputDirectory": ".next",
   "env": {
     "HUSKY": "0"


### PR DESCRIPTION
## Summary

Permanently fixes the recurring `Module not found: Can't resolve '@esparex/design-tokens'` Vercel build failure on `apps/admin`.

---

## Root Cause

`@esparex/design-tokens` compiles to `dist/` at build time, but `dist/` is gitignored:

```gitignore
# .gitignore
dist
!packages/design-tokens/dist/css-variables.css
```

Vercel clones the repository — `dist/` is never present. When `next build` runs, `@esparex/ui` imports `@esparex/design-tokens`, which Node resolves to `./dist/index.js` (the `main` field in `package.json`). That file does not exist. Build fails.

The local `prebuild` npm script (`npm run build -w @esparex/design-tokens`) does run before `npm run build` locally, but **Vercel uses the `buildCommand` from `vercel.json` directly**, bypassing npm lifecycle hooks.

---

## Why This Occurred on Every PR

Every PR touching `@esparex/ui` triggered the same failure path:

```
Vercel clone (no dist/)
  → npm install (no dist/ generated)
  → next build
  → @esparex/ui imports @esparex/design-tokens
  → ./dist/index.js not found
  → ❌ Module not found
```

---

## Fix

`apps/web/vercel.json` already had this correct pattern (fixed in `5af5987c`). This PR aligns `apps/admin/vercel.json` to the same approach.

```diff
- "buildCommand": "NEXT_DISABLE_WEBPACK_CACHE=1 next build"
+ "buildCommand": "npm run build -w @esparex/design-tokens && NEXT_DISABLE_WEBPACK_CACHE=1 next build"
```

---

## Precondition Verification

| Condition | Result |
|---|---|
| `apps/admin` has its own Vercel project | ✅ Confirmed — separate `apps/admin/vercel.json` |
| Vercel uses `apps/admin/vercel.json` | ✅ Confirmed — no root `vercel.json` exists |
| `@esparex/design-tokens` is a local workspace package | ✅ Confirmed — `"private": true`, resolved via `"*"` workspace dep |
| `apps/web` already uses this same pattern successfully | ✅ Confirmed — `apps/web/vercel.json` buildCommand prepends `design-tokens` build |
| No Turborepo/Nx pipeline handles build ordering | ✅ Confirmed — no `turbo.json` or `nx.json` at root |

---

## Verification Results

### Simulated Clean Vercel Environment

```bash
# Deleted dist/ to simulate Vercel's fresh clone
rm -rf packages/design-tokens/dist/

# Ran buildCommand exactly as Vercel does
npm run build -w @esparex/design-tokens
# ✅ Generated dist/index.js, dist/index.d.ts, and all 18 output files

NEXT_DISABLE_WEBPACK_CACHE=1 next build  # (admin)
# ✅ Compiled successfully — all routes generated, 0 errors
```

### Automated Gates

| Command | Result |
|---|---|
| `npm run build -w @esparex/design-tokens` | ✅ dist/ generated cleanly |
| `npm run build -w @esparex/apps-admin` | ✅ Compiled successfully |
| `npm run type-check` | ✅ 0 errors across 9 workspaces |

---

## What This Does NOT Change

- No source code changes
- No API contract changes
- No UI component changes
- No TypeScript type changes
- No test changes
- `apps/web/vercel.json` unchanged (already correct)
- `packages/design-tokens` source unchanged
- `.gitignore` unchanged

---

## Files Changed

| File | Change |
|---|---|
| `apps/admin/vercel.json` | Prepend `npm run build -w @esparex/design-tokens &&` to buildCommand |

---

## Definition of Done

- [x] Root cause identified and documented with evidence.
- [x] Preconditions verified before implementation.
- [x] Fix simulated on clean environment (dist/ deleted, buildCommand re-run, admin build succeeded).
- [x] `npm run type-check` — 0 errors.
- [x] No source code changes, no contract changes, no regressions.

---

Closes #123