### PR TITLE
fix(web): add vercel.live to Content-Security-Policy header

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -127,6 +127,10 @@ const connectSrc = [
     'https://*.s3.ap-south-1.amazonaws.com',
     'https://s3.ap-south-1.amazonaws.com',
     'https://esparexdev.s3.ap-south-1.amazonaws.com', // Explicitly add known bucket
+    'https://vercel.live',
+    'wss://vercel.live',
+    'https://*.vercel.live',
+    'wss://*.vercel.live',
     ...dynamicApiConnectSources,
 ].join(' '); // Forced update for CSP
 
@@ -137,6 +141,8 @@ const scriptSrc = [
     ...(process.env.NODE_ENV === 'development' ? ["'unsafe-eval'"] : []),
     'https://maps.googleapis.com',
     'https://maps.gstatic.com',
+    'https://vercel.live',
+    'https://*.vercel.live',
 ].join(' ');
 
 /** @type {import('next').NextConfig} */
@@ -207,7 +213,7 @@ const nextConfig = {
                             `connect-src ${connectSrc}`,
 
                             "frame-ancestors 'self'",
-                            "frame-src 'self' https://www.openstreetmap.org",
+                            "frame-src 'self' https://www.openstreetmap.org https://vercel.live https://*.vercel.live",
                             "base-uri 'self'",
                             "form-action 'self'"
                         ].join('; ')


### PR DESCRIPTION
## Summary

Fixes the browser Content Security Policy error when Vercel Live Preview or Feedback toolbar scripts (`https://vercel.live/_next-live/feedback/feedback.js`) are loaded.

---

## Root Cause

Vercel injects live preview scripts (`https://vercel.live/_next-live/feedback/feedback.js`) and WebSocket connections (`wss://vercel.live`) on deployment preview builds.

The Content Security Policy header in `apps/web/next.config.mjs` did not include `https://vercel.live` or `https://*.vercel.live` in its `script-src`, `connect-src`, or `frame-src` directives, causing the browser to block script execution.

---

## Fix

Added Vercel Live origins to the CSP configuration in `apps/web/next.config.mjs`:

```diff
// script-src
+ 'https://vercel.live',
+ 'https://*.vercel.live',

// connect-src
+ 'https://vercel.live',
+ 'wss://vercel.live',
+ 'https://*.vercel.live',
+ 'wss://*.vercel.live',

// frame-src
+ 'https://vercel.live',
+ 'https://*.vercel.live',
```

---

## Definition of Done

- [x] Tested with `npm run type-check -w @esparex/apps-web`.
- [x] Zero breaking changes to existing CSP rules.
- [x] Pre-push verification (type-check, tests, repo gates) passed 100% green.

Closes #125