### PR TITLE
fix(web): remove sticky overlay from Breadcrumbs to prevent image overlap

### DIFF
--- a/apps/web/src/components/user/Breadcrumbs.tsx
+++ b/apps/web/src/components/user/Breadcrumbs.tsx
@@ -12,7 +12,7 @@ interface BreadcrumbsProps {
 
 export function Breadcrumbs({ items }: BreadcrumbsProps) {
   return (
-    <nav className="w-full px-3 md:px-6 lg:px-8 py-1.5 bg-slate-50/90 backdrop-blur-md border-b border-slate-200/60 sticky top-14 md:top-16 z-30">
+    <nav className="w-full px-3 md:px-6 lg:px-8 py-2.5 bg-slate-50 border-b border-slate-200/60">
       <div className="max-w-7xl mx-auto">
         <ol className="flex items-center gap-1.5 text-tiny sm:text-xs font-normal flex-wrap">
           {items.map((item, index) => (


### PR DESCRIPTION
## Summary

Fixes the visual layout bug where the Breadcrumbs navigation bar overlapped directly on top of the listing image card (`AdImageCarousel`).

---

## Root Cause

`Breadcrumbs.tsx` applied `sticky top-14 md:top-16 z-30` with a translucent background (`bg-slate-50/90 backdrop-blur-md`).

Because the main content scroll container in `PageLayout` renders below the header, applying a sticky top offset forced the breadcrumb bar to float inside the page content area, overlaying the top portion of the listing image card when scrolling or loading.

---

## Fix

Removed sticky positioning, z-index elevation, and backdrop blur from `Breadcrumbs.tsx`. Breadcrumbs now render in standard document flow (`bg-slate-50 border-b border-slate-200/60`) above the listing detail content, eliminating all visual overlap over `AdImageCarousel`.

---

## Definition of Done

- [x] Verified with `npm run type-check -w @esparex/apps-web`.
- [x] Pre-push verification (type-check, unit tests, repo gates) passed 100% green.

Closes #126