### PR TITLE
style(web): redesign offline fallback page into compact responsive desktop card

### DIFF
--- a/apps/web/src/app/offline/page.tsx
+++ b/apps/web/src/app/offline/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { WifiOff, Home } from "lucide-react";
 import { OfflineReloadButton } from "@/components/common/OfflineReloadButton";
 
 export const metadata: Metadata = {
@@ -9,34 +10,51 @@ export const metadata: Metadata = {
 
 export default function OfflinePage() {
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
-            <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
-                <svg
-                    className="h-10 w-10 text-muted-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    aria-hidden="true"
-                >
-                    <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M3 3l18 18M8.111 8.111A7.5 7.5 0 0119.5 12M4.929 4.929A13.5 13.5 0 0119.07 19.07M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                </svg>
-            </div>
-            <h1 className="mb-2 text-2xl font-bold text-foreground">You&apos;re offline</h1>
-            <p className="mb-8 max-w-sm text-sm text-muted-foreground">
-                It looks like you&apos;ve lost your internet connection. Check your network and try again.
-            </p>
-            <OfflineReloadButton />
-            <Link
-                href="/"
-                className="inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm text-muted-foreground underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring rounded-lg"
+        <main
+            className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-6 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100"
+            style={{ fontFamily: "system-ui, -apple-system, sans-serif" }}
+        >
+            <div
+                className="w-full max-w-md mx-auto bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800/80 rounded-2xl shadow-xl p-8 sm:p-10 text-center transition-all"
+                style={{ maxWidth: "480px" }}
             >
-                Go to homepage
-            </Link>
-        </div>
+                {/* Icon Badge with explicit width/height constraints */}
+                <div
+                    className="mb-6 mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50 dark:bg-amber-950/40 border border-amber-200/60 dark:border-amber-800/40 text-amber-600 dark:text-amber-400 shadow-2xs"
+                    style={{ width: "64px", height: "64px", maxWidth: "64px", maxHeight: "64px" }}
+                >
+                    <WifiOff
+                        className="h-8 w-8 text-amber-600 dark:text-amber-400 shrink-0"
+                        width={32}
+                        height={32}
+                        style={{ width: "32px", height: "32px", maxWidth: "32px", maxHeight: "32px" }}
+                        aria-hidden="true"
+                    />
+                </div>
+
+                {/* Main Heading */}
+                <h1 className="mb-2.5 text-xl sm:text-2xl font-bold tracking-tight text-slate-900 dark:text-white">
+                    You&apos;re offline
+                </h1>
+
+                {/* Subtitle */}
+                <p className="mb-8 text-sm leading-relaxed text-slate-600 dark:text-slate-400 max-w-xs mx-auto">
+                    It looks like you&apos;ve lost your internet connection. Check your network connection and try again.
+                </p>
+
+                {/* Action Buttons */}
+                <div className="flex flex-col sm:flex-row items-center justify-center gap-3 w-full">
+                    <OfflineReloadButton />
+                    <Link
+                        href="/"
+                        className="w-full sm:w-auto inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700/80 px-6 text-sm font-semibold text-slate-700 dark:text-slate-200 transition-all shadow-xs cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                        style={{ fontFamily: "system-ui, -apple-system, sans-serif" }}
+                    >
+                        <Home className="h-4 w-4 shrink-0" width={16} height={16} />
+                        <span>Go to homepage</span>
+                    </Link>
+                </div>
+            </div>
+        </main>
     );
 }

--- a/apps/web/src/components/common/OfflineReloadButton.tsx
+++ b/apps/web/src/components/common/OfflineReloadButton.tsx
@@ -1,12 +1,26 @@
 "use client";
 
+import { RotateCw } from "lucide-react";
+import { useState } from "react";
+
 export function OfflineReloadButton() {
+    const [isRefreshing, setIsRefreshing] = useState(false);
+
+    const handleReload = () => {
+        setIsRefreshing(true);
+        window.location.reload();
+    };
+
     return (
         <button
-            onClick={() => window.location.reload()}
-            className="mb-4 inline-flex h-11 items-center rounded-xl bg-primary hover:bg-primary/90 px-6 text-sm font-semibold text-primary-foreground transition active:scale-95 shadow-sm"
+            type="button"
+            onClick={handleReload}
+            disabled={isRefreshing}
+            className="w-full sm:w-auto inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800 px-6 text-sm font-semibold text-white transition-all shadow-md hover:shadow-lg disabled:opacity-75 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
         >
-            Try again
+            <RotateCw className={`h-4 w-4 shrink-0 ${isRefreshing ? "animate-spin" : ""}`} width={16} height={16} />
+            <span>{isRefreshing ? "Checking connection…" : "Try again"}</span>
         </button>
     );
 }


### PR DESCRIPTION
## Summary
Redesign the Offline fallback page (`/offline`) into a compact, responsive desktop card with defensive SVG sizing constraints.

### Key Changes
- **SVG Constraint & Defensive Styles**: Add explicit `width={32} height={32}` and `style={{ maxWidth: '32px', maxHeight: '32px' }}` to prevent unstyled icon scaling if CSS fails to load offline.
- **Desktop Responsiveness**: Constrain page container with `max-w-md w-full mx-auto` (`480px` max width) so it renders as a sleek centered card on desktop displays rather than filling the whole monitor.
- **Button Styling & Interactivity**: Upgrade `OfflineReloadButton` with `RotateCw` icon and animated loading state (`Checking connection...`). Add styled secondary button for returning to homepage.

### Verification
- `npm run type-check`: 0 errors
- `npm run repo:gate`: 18/18 quality gates passed (100% Health Score)
- `npm run build -w @esparex/apps-web`: 100% clean production build