### PR TITLE
fix(mobile): Eliminate React act(...) test warning in useUnreadCount.spec.tsx

### DIFF
--- a/apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx
+++ b/apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx
@@ -21,16 +21,6 @@ const mockGetNotifications = services.notificationService
   typeof services.notificationService.getNotifications
 >;
 
-const makeWrapper = () => {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  const Wrapper = ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  );
-  return Wrapper;
-};
-
 const sampleNotifications: AppNotification[] = [
   {
     id: 'n-1',
@@ -59,14 +49,32 @@ const sampleNotifications: AppNotification[] = [
 ];
 
 describe('useNotifications', () => {
-  beforeEach(() => jest.clearAllMocks());
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 
   it('returns notifications from the service', async () => {
     mockGetNotifications.mockResolvedValueOnce(sampleNotifications);
 
-    const { result } = renderHook(() => useNotifications(), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(() => useNotifications(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(sampleNotifications);
@@ -76,46 +84,83 @@ describe('useNotifications', () => {
   it('returns empty array when service resolves with empty list', async () => {
     mockGetNotifications.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useNotifications(), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(() => useNotifications(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([]);
+    expect(mockGetNotifications).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('useUnreadNotificationsCount', () => {
-  beforeEach(() => jest.clearAllMocks());
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 
   it('returns count of unread notifications', async () => {
     mockGetNotifications.mockResolvedValueOnce(sampleNotifications);
 
-    const { result } = renderHook(() => useUnreadNotificationsCount(), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(
+      () => ({
+        count: useUnreadNotificationsCount(),
+        query: useNotifications(),
+      }),
+      { wrapper }
+    );
 
-    await waitFor(() => expect(result.current).toBe(2));
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.count).toBe(2);
+    expect(mockGetNotifications).toHaveBeenCalledTimes(1);
   });
 
   it('returns 0 when all notifications are read', async () => {
     const allRead = sampleNotifications.map((n) => ({ ...n, isRead: true }));
     mockGetNotifications.mockResolvedValueOnce(allRead);
 
-    const { result } = renderHook(() => useUnreadNotificationsCount(), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(
+      () => ({
+        count: useUnreadNotificationsCount(),
+        query: useNotifications(),
+      }),
+      { wrapper }
+    );
 
-    await waitFor(() => expect(result.current).toBe(0));
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.count).toBe(0);
+    expect(mockGetNotifications).toHaveBeenCalledTimes(1);
   });
 
   it('returns 0 when notifications list is empty', async () => {
     mockGetNotifications.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useUnreadNotificationsCount(), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(
+      () => ({
+        count: useUnreadNotificationsCount(),
+        query: useNotifications(),
+      }),
+      { wrapper }
+    );
 
-    await waitFor(() => expect(result.current).toBe(0));
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.count).toBe(0);
+    expect(mockGetNotifications).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 🛠️ Summary of Changes

### Problem
In `apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx`, assertions for zero unread counts (`expect(result.current).toBe(0)`) resolved synchronously on initial mount before asynchronous `useQuery` data resolution completed. This left microtask state updates uncaptured, triggering the following warning:
```text
Warning: An update to TestComponent inside a test was not wrapped in act(...).
```

### Solution
1. **Query Resolution Tracking**: Updated test cases in `useUnreadCount.spec.tsx` to render both `useUnreadNotificationsCount()` and `useNotifications()`, properly awaiting `query.isSuccess` within `waitFor(...)` before asserting on unread counts.
2. **Proper QueryClient Lifecycle**: Configured explicit `queryClient.clear()` in `afterEach` and `gcTime: 0` to prevent dangling timers or unhandled microtask updates.
3. **Verified Result**: All 5 test cases in `useUnreadCount.spec.tsx` and all 44 test suites across `apps/mobile` pass cleanly with **0 act(...) warnings** from this hook.

---

### Repository Impact Statement
```text
Repository Impact Statement
---------------------------
Problem: React Native test warning: An update to TestComponent inside a test was not wrapped in act(...).
Existing SSOT: apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx
New Files: 0
Existing Files Modified: 1
Duplicate Risk: None
Reason: Clean test fixture refinement.
```

---

### Verification
- [x] `npm test apps/mobile/src/features/notifications/presentation/hooks/__tests__/useUnreadCount.spec.tsx -w @esparex/apps-mobile` passed with 0 warnings.
- [x] `npm test -w @esparex/apps-mobile` (44 test suites, 151 tests) passed.
- [x] `npm run type-check` passed with 0 errors across all 9 workspaces.
- [x] `npm run repo:gate` passed with **100% Health Score**.