### PR TITLE
chore: add mobile build output patterns to root .gitignore and fix flaky test timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,9 @@ tech-debt-insights.md
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Mobile build outputs (iOS simulator bundle, Android APK, NativeWind types)
+*.app/
+*.apk
+*.ipa
+nativewind-env.d.ts

--- a/core/src/domains/payments/__tests__/InvoicePdfService.spec.ts
+++ b/core/src/domains/payments/__tests__/InvoicePdfService.spec.ts
@@ -65,5 +65,5 @@ describe('InvoicePdfService', () => {
 
         const result = await generateInvoicePdf(sampleInvoice);
         expect(result === undefined || typeof result === 'string').toBe(true);
-    });
+    }, 30_000);
 });


### PR DESCRIPTION
## Summary

Resolves 77 phantom untracked changes showing in the IDE source control panel, and fixes a flaky pre-push test gate failure.

---

## Changes

### 1. Root `.gitignore` — Mobile Build Output Patterns

**Problem**: Three categories of mobile build artifacts were untracked but not covered by the root `.gitignore`, causing the IDE source control panel to show 77 changes on a clean working tree.

| File / Pattern | Origin | File Count |
|---|---|---|
| `Esparex.app/` | iOS simulator build via `expo run:ios` | 73 files |
| `esparex-release.apk` | Android release build export | 1 file |
| `nativewind-env.d.ts` | Auto-generated by Metro/NativeWind | 1 file |

**Fix**: Added `*.app/`, `*.apk`, `*.ipa`, and `nativewind-env.d.ts` to root `.gitignore`.

**Verification**:
- `git status` before: 77 untracked items
- `git status` after: clean working tree ✅

---

### 2. `InvoicePdfService.spec.ts` — Flaky Test Timeout Fix

**Problem**: The `handles skipped S3 upload gracefully when S3 fails or is unconfigured` test was exceeding Jest's default 5000ms timeout. `generateInvoicePdf` makes a real network attempt to S3 before the catch block returns `undefined` — this can take longer than 5s on slow network or CI runners.

**Fix**: Added an explicit `30_000` ms timeout to the single affected test case. No implementation changes.

**Verification**:
- First push run: FAIL (timeout at 5000ms)
- Second push run: PASS (completed in ~103s total suite, within 30s per-test limit) ✅

---

## Test Results

| Suite | Result |
|---|---|
| `@esparex/core` — 64 suites | ✅ All passed |
| `@esparex/apps-web` / shared — 52 files | ✅ 202 tests passed |
| `@esparex/apps-mobile` — 44 suites | ✅ 151 tests passed |
| repo:gate (17 checks) | ✅ All passed |