### PR TITLE
feat(design-system): typography SSOT unification and alias scale harmonization

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -18,8 +18,6 @@
   --text-h2: 1.5rem;         /* 24px */
   --text-h3: 1.25rem;        /* 20px */
   --text-h4: 1.125rem;       /* 18px */
-  --text-h5: 1rem;           /* 16px */
-  --text-h6: 0.9375rem;      /* 15px */
   --text-body-lg: 1rem;      /* 16px */
   --text-body: 0.875rem;     /* 14px */
   --text-small: 0.8125rem;   /* 13px */
@@ -247,13 +245,13 @@
   }
 
   h5 {
-    font-size: var(--text-h5); /* 16px */
+    font-size: var(--text-body-lg); /* 16px */
     font-weight: 600;
     line-height: 1.4;
   }
 
   h6 {
-    font-size: var(--text-h6); /* 15px */
+    font-size: var(--text-body); /* 14px */
     font-weight: 600;
     line-height: 1.4;
   }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -17,6 +17,14 @@ const config = {
 			fontSize: {
 				...typography.fontSizes,
 				'2xs': ['0.625rem', { lineHeight: '1rem' }],  // 10px legacy fallback
+				// Standard Tailwind scale harmonization mapped to canonical design tokens
+				xs: typography.fontSizes.caption,   // 12px / 0.75rem (lineHeight: 1.4)
+				sm: typography.fontSizes.body,      // 14px / 0.875rem (lineHeight: 1.55)
+				base: typography.fontSizes['body-lg'], // 16px / 1rem (lineHeight: 1.5)
+				lg: typography.fontSizes.h4,        // 18px / 1.125rem (lineHeight: 1.4)
+				xl: typography.fontSizes.h3,        // 20px / 1.25rem (lineHeight: 1.35)
+				'2xl': typography.fontSizes.h2,     // 24px / 1.5rem (lineHeight: 1.3)
+				'3xl': typography.fontSizes.h1,     // 30px / 1.875rem (lineHeight: 1.25)
 			},
 			fontWeight: typography.fontWeights,
 			colors: {

--- a/packages/design-tokens/src/typography.ts
+++ b/packages/design-tokens/src/typography.ts
@@ -9,6 +9,7 @@ export const typography = {
     'h2': ['1.5rem', { lineHeight: '1.3', letterSpacing: '-0.01em' }],     // 24px
     'h3': ['1.25rem', { lineHeight: '1.35', letterSpacing: '-0.01em' }],    // 20px
     'h4': ['1.125rem', { lineHeight: '1.4', letterSpacing: '0' }],          // 18px
+    'body-lg': ['1rem', { lineHeight: '1.5', letterSpacing: '0' }],         // 16px
     'body': ['0.875rem', { lineHeight: '1.55', letterSpacing: '0' }],       // 14px
     'small': ['0.8125rem', { lineHeight: '1.5', letterSpacing: '0' }],      // 13px
     'caption': ['0.75rem', { lineHeight: '1.4', letterSpacing: '0' }],      // 12px

--- a/packages/ui/src/tokens/typography.ts
+++ b/packages/ui/src/tokens/typography.ts
@@ -20,6 +20,6 @@ export const TYPOGRAPHY_TOKENS = {
   fontWeight: TYPOGRAPHY_FONT_WEIGHT,
 };
 
-export type TypographyFontSize = 'display' | 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'small' | 'caption' | 'tiny';
+export type TypographyFontSize = 'display' | 'h1' | 'h2' | 'h3' | 'h4' | 'body-lg' | 'body' | 'small' | 'caption' | 'tiny';
 export type TypographyFontWeight = 'normal' | 'medium' | 'semibold' | 'bold';
 


### PR DESCRIPTION
## Summary
Establishes a unified Typography Single Source of Truth (SSOT) across the Esparex design tokens package, harmonizes Tailwind CSS default alias scales, and synchronizes CSS variable definitions to permanently eliminate typography drift.

Closes #436

## Phase 1 Implementation Details
- **Design Tokens SSOT**: Added `body-lg` (`1rem` / 16px, `lineHeight: 1.5`) to `@esparex/design-tokens/src/typography.ts` to officially support lead paragraph and intermediate marketing text.
- **UI Typography Tokens**: Updated `TypographyFontSize` in `packages/ui/src/tokens/typography.ts` to include `body-lg`.
- **Tailwind Scale Harmonization**: Mapped standard Tailwind size aliases (`xs`, `sm`, `base`, `lg`, `xl`, `2xl`, `3xl`) in `apps/web/tailwind.config.js` directly to canonical tokens to prevent font size and line height divergence across components.
- **Global CSS Variables**: Cleaned up obsolete `--text-h5` and `--text-h6` CSS variables in `apps/web/src/styles/globals.css` and mapped base HTML headings to the unified scale.

## Verification
- Monorepo Type Check: `npm run type-check` passed (exit code 0 across 9 workspaces)
- Monorepo Production Build: `npm run build` passed (exit code 0 across all apps/packages)
- Monorepo Test Suites: `npm test` passed 100% green