### PR TITLE
refactor(ui): remediate arbitrary typography utilities to canonical SSOT tokens

### DIFF
--- a/apps/admin/src/app/(protected)/(system)/users/page.tsx
+++ b/apps/admin/src/app/(protected)/(system)/users/page.tsx
@@ -249,23 +249,23 @@ export default function UsersPage() {
 
                     <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5 max-w-3xl">
                         <Link href={ADMIN_UI_ROUTES.users()} className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 shadow-2xs transition hover:border-slate-300 hover:shadow-xs">
-                            <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground-tertiary">Total Users</p>
+                            <p className="text-tiny font-semibold uppercase tracking-wider text-foreground-tertiary">Total Users</p>
                             <p className="mt-0.5 text-base font-bold text-foreground">{overview.totalUsers.toLocaleString()}</p>
                         </Link>
                         <Link href={ADMIN_UI_ROUTES.users({ role: "user" })} className="rounded-md border border-emerald-200 bg-emerald-50/40 px-2.5 py-1.5 shadow-2xs transition hover:border-emerald-300 hover:shadow-xs">
-                            <p className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700">Individuals</p>
+                            <p className="text-tiny font-semibold uppercase tracking-wider text-emerald-700">Individuals</p>
                             <p className="mt-0.5 text-base font-bold text-emerald-700">{overview.individuals.toLocaleString()}</p>
                         </Link>
                         <Link href={ADMIN_UI_ROUTES.users({ role: "business" })} className="rounded-md border border-blue-200 bg-blue-50/40 px-2.5 py-1.5 shadow-2xs transition hover:border-blue-300 hover:shadow-xs">
-                            <p className="text-[10px] font-semibold uppercase tracking-wider text-blue-700">Businesses</p>
+                            <p className="text-tiny font-semibold uppercase tracking-wider text-blue-700">Businesses</p>
                             <p className="mt-0.5 text-base font-bold text-blue-700">{overview.businesses.toLocaleString()}</p>
                         </Link>
                         <Link href={ADMIN_UI_ROUTES.users({ role: "business", isVerified: "true" })} className="rounded-md border border-indigo-200 bg-indigo-50/40 px-2.5 py-1.5 shadow-2xs transition hover:border-indigo-300 hover:shadow-xs">
-                            <p className="text-[10px] font-semibold uppercase tracking-wider text-indigo-700">Verified Businesses</p>
+                            <p className="text-tiny font-semibold uppercase tracking-wider text-indigo-700">Verified Businesses</p>
                             <p className="mt-0.5 text-base font-bold text-indigo-700">{overview.verifiedBusinesses.toLocaleString()}</p>
                         </Link>
                         <Link href={ADMIN_UI_ROUTES.users({ status: "suspended" })} className="rounded-md border border-red-200 bg-red-50/40 px-2.5 py-1.5 shadow-2xs transition hover:border-red-300 hover:shadow-xs">
-                            <p className="text-[10px] font-semibold uppercase tracking-wider text-red-700">Blocked Users</p>
+                            <p className="text-tiny font-semibold uppercase tracking-wider text-red-700">Blocked Users</p>
                             <p className="mt-0.5 text-base font-bold text-red-700">{overview.blockedUsers.toLocaleString()}</p>
                         </Link>
                     </div>

--- a/apps/mobile/src/features/chat/presentation/components/MobileChatMessageReceipt.tsx
+++ b/apps/mobile/src/features/chat/presentation/components/MobileChatMessageReceipt.tsx
@@ -23,7 +23,7 @@ export const MobileChatMessageReceipt: React.FC<MobileChatMessageReceiptProps> =
     return (
       <View className="flex-row items-center ml-1.5 opacity-80" accessibilityLabel="Message sending">
         <AppIcon name="Clock" size={11} color={base.brand[200] || '#93c5fd'} />
-        <AppText variant="tiny" className="text-brand-100 text-[10px] ml-0.5">
+        <AppText variant="tiny" className="text-brand-100 ml-0.5">
           Sending...
         </AppText>
       </View>
@@ -45,7 +45,7 @@ export const MobileChatMessageReceipt: React.FC<MobileChatMessageReceiptProps> =
         accessibilityRole="button"
       >
         <AppIcon name="AlertTriangle" size={11} color="#fca5a5" />
-        <AppText variant="tiny" className="text-red-200 text-[10px] font-semibold ml-1">
+        <AppText variant="tiny" className="text-red-200 font-semibold ml-1">
           Failed · Retry
         </AppText>
       </TouchableOpacity>

--- a/apps/web/src/components/chat/ConversationHeader.tsx
+++ b/apps/web/src/components/chat/ConversationHeader.tsx
@@ -73,10 +73,10 @@ export function ConversationHeader({
             <div className="flex items-center gap-2">
               <h3 className="text-sm font-semibold text-slate-900 truncate">{otherPartyName}</h3>
               {isCounterpartyOnline && (
-                <span className="text-[11px] font-medium text-emerald-600">Online</span>
+                <span className="text-tiny font-medium text-emerald-600">Online</span>
               )}
               {isOtherTyping && (
-                <span className="text-[11px] font-medium text-blue-600 animate-pulse">typing…</span>
+                <span className="text-tiny font-medium text-blue-600 animate-pulse">typing…</span>
               )}
             </div>
             {isArchived && (

--- a/apps/web/src/components/user/profile/cards/DynamicPlanCard.tsx
+++ b/apps/web/src/components/user/profile/cards/DynamicPlanCard.tsx
@@ -30,7 +30,7 @@ export function DynamicPlanCard({ plan, isCurrent, onSelect }: DynamicPlanCardPr
       }`}
     >
       {plan.popular && !isCurrent && (
-        <div className="absolute top-0 right-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-extrabold text-[10px] uppercase tracking-wider px-2.5 py-0.5 rounded-bl-xl shadow-xs">
+        <div className="absolute top-0 right-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-extrabold text-tiny uppercase tracking-wider px-2.5 py-0.5 rounded-bl-xl shadow-xs">
           Popular
         </div>
       )}

--- a/apps/web/src/components/user/profile/dialogs/InvoicePreviewDialog.tsx
+++ b/apps/web/src/components/user/profile/dialogs/InvoicePreviewDialog.tsx
@@ -88,7 +88,7 @@ export function InvoicePreviewDialog({
                         <div>
                             <DialogTitle id="invoice-preview-title" className="text-sm sm:text-base font-bold text-white flex items-center gap-2">
                                 Invoice #{orderId.slice(-8).toUpperCase()}
-                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-500/30">
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-tiny font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-500/30">
                                     <CheckCircle2 className="w-3 h-3" /> PAID
                                 </span>
                             </DialogTitle>

--- a/apps/web/src/components/user/profile/dialogs/PlanCheckoutGstSection.tsx
+++ b/apps/web/src/components/user/profile/dialogs/PlanCheckoutGstSection.tsx
@@ -33,7 +33,7 @@ export function PlanCheckoutGstSection({
 
             {wantsGst && (
                 <div className="pl-6 flex flex-col gap-1.5 pt-1">
-                    <Label htmlFor="checkout-gstin" className="text-[11px] font-semibold text-slate-700">
+                    <Label htmlFor="checkout-gstin" className="text-caption font-semibold text-slate-700">
                         GSTIN Number
                     </Label>
                     <Input
@@ -46,10 +46,10 @@ export function PlanCheckoutGstSection({
                         className="h-8 rounded-lg text-xs bg-white uppercase font-mono"
                     />
                     {gstin && !isGstValid && (
-                        <p className="text-[10px] text-amber-600">Please enter a valid 15-character GSTIN (e.g. 27AAAAA0000A1Z5)</p>
+                        <p className="text-tiny text-amber-600">Please enter a valid 15-character GSTIN (e.g. 27AAAAA0000A1Z5)</p>
                     )}
                     {isGstValid && (
-                        <p className="text-[10px] text-emerald-600 font-medium flex items-center gap-1">
+                        <p className="text-tiny text-emerald-600 font-medium flex items-center gap-1">
                             <CheckCircle2 className="h-3 w-3 inline" /> Valid GSTIN. B2B Tax Invoice enabled.
                         </p>
                     )}

--- a/apps/web/src/components/user/profile/dialogs/PlanPurchaseDialog.tsx
+++ b/apps/web/src/components/user/profile/dialogs/PlanPurchaseDialog.tsx
@@ -125,7 +125,7 @@ export function PlanPurchaseDialog({
                                     <p className="font-semibold text-slate-900">{plan.name}</p>
                                     <p className="text-xs text-muted-foreground">{plan.type}</p>
                                 </div>
-                                <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wider ${taxResult.invoiceType === 'TAX_INVOICE' ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-200 text-slate-700'}`}>
+                                <span className={`text-tiny font-bold px-2 py-0.5 rounded-full uppercase tracking-wider ${taxResult.invoiceType === 'TAX_INVOICE' ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-200 text-slate-700'}`}>
                                     {taxResult.invoiceType === 'TAX_INVOICE' ? 'B2B Tax Invoice' : 'Bill of Supply'}
                                 </span>
                             </div>
@@ -169,11 +169,11 @@ export function PlanPurchaseDialog({
 
                                 {taxResult.taxBreakup?.cgstAmount !== undefined && (
                                     <>
-                                        <div className="flex items-center justify-between text-slate-500 text-[11px]">
+                                        <div className="flex items-center justify-between text-slate-500 text-caption">
                                             <span>CGST (9%):</span>
                                             <span>{formatCurrency(taxResult.taxBreakup.cgstAmount)}</span>
                                         </div>
-                                        <div className="flex items-center justify-between text-slate-500 text-[11px]">
+                                        <div className="flex items-center justify-between text-slate-500 text-caption">
                                             <span>SGST (9%):</span>
                                             <span>{formatCurrency(taxResult.taxBreakup.sgstAmount!)}</span>
                                         </div>
@@ -181,7 +181,7 @@ export function PlanPurchaseDialog({
                                 )}
 
                                 {taxResult.taxBreakup?.igstAmount !== undefined && (
-                                    <div className="flex items-center justify-between text-slate-500 text-[11px]">
+                                    <div className="flex items-center justify-between text-slate-500 text-caption">
                                         <span>IGST (18%):</span>
                                         <span>{formatCurrency(taxResult.taxBreakup.igstAmount)}</span>
                                     </div>

--- a/apps/web/src/components/user/profile/tabs/PlansTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/PlansTab.tsx
@@ -208,7 +208,7 @@ export const PlansTab: React.FC<PlansTabProps> = ({
                   >
                     <span>{catType}</span>
                     <span
-                      className={`px-1.5 py-0.5 rounded-full text-[10px] font-extrabold ${
+                      className={`px-1.5 py-0.5 rounded-full text-tiny font-extrabold ${
                         isSelected
                           ? 'bg-white/20 text-white'
                           : 'bg-slate-100 text-slate-600'

--- a/apps/web/src/components/user/profile/tabs/SavedAdsTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/SavedAdsTab.tsx
@@ -112,7 +112,7 @@ export function SavedAdsTab({ navigateTo }: SavedAdsTabProps) {
                     className="object-cover group-hover:scale-105 transition-transform duration-300"
                   />
                   {ad.category && (
-                    <span className="absolute bottom-1 left-1 bg-slate-900/80 backdrop-blur-xs text-white text-[9px] font-semibold px-1.5 py-0.2 rounded">
+                    <span className="absolute bottom-1 left-1 bg-slate-900/80 backdrop-blur-xs text-white text-tiny font-semibold px-1.5 py-0.2 rounded">
                       {ad.category}
                     </span>
                   )}

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -172,7 +172,7 @@ const FieldMessage = React.forwardRef<
       ref={ref}
       id={formMessageId}
       role="alert"
-      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      className={cn("text-caption font-medium text-destructive", className)}
       {...props}
     >
       {body}


### PR DESCRIPTION
## Summary
Remediates all 20 active typography violations across the web, admin, and mobile apps by converting arbitrary pixel/rem font size utilities (`text-[10px]`, `text-[11px]`, `text-[0.8rem]`) to canonical SSOT design tokens (`text-tiny`, `text-caption`, `text-small`).

Part of #436

## Phase 4 Remediation Breakdown
- **Web App**:
  - `apps/web/src/components/chat/ConversationHeader.tsx`: Converted `text-[11px]` to `text-tiny`.
  - `apps/web/src/components/user/profile/cards/DynamicPlanCard.tsx`: Converted `text-[10px]` to `text-tiny`.
  - `apps/web/src/components/user/profile/dialogs/InvoicePreviewDialog.tsx`: Converted `text-[10px]` to `text-tiny`.
  - `apps/web/src/components/user/profile/dialogs/PlanCheckoutGstSection.tsx`: Converted `text-[11px]` and `text-[10px]` to `text-caption` / `text-tiny`.
  - `apps/web/src/components/user/profile/dialogs/PlanPurchaseDialog.tsx`: Converted `text-[10px]` and `text-[11px]` to `text-tiny` / `text-caption`.
  - `apps/web/src/components/user/profile/tabs/PlansTab.tsx`: Converted `text-[10px]` to `text-tiny`.
  - `apps/web/src/components/user/profile/tabs/SavedAdsTab.tsx`: Converted `text-[9px]` to `text-tiny`.
- **Admin App**:
  - `apps/admin/src/app/(protected)/(system)/users/page.tsx`: Converted `text-[10px]` to `text-tiny`.
- **Mobile App**:
  - `apps/mobile/src/features/chat/presentation/components/MobileChatMessageReceipt.tsx`: Cleaned redundant `text-[10px]` from `AppText variant="tiny"`.
- **Shared UI**:
  - `packages/ui/src/forms/Form.tsx`: Converted `text-[0.8rem]` to `text-caption`.

## Verification
- `npm run guard:typography-ssot`: Passed (0 violations)
- `npm run type-check`: Passed (0 errors across 9 workspaces)
- Pre-push `repo:gate`: Passed (100% green)