### PR TITLE
refactor(web): standardize typography and semantic tokens in account and profile module

### DIFF
--- a/apps/web/src/components/user/AccountHeader.tsx
+++ b/apps/web/src/components/user/AccountHeader.tsx
@@ -57,7 +57,7 @@ export function AccountHeader({
             </Button>
           )}
           {/* ui-guard-ignore: multiple-h1 Responsive sibling — mobile-only h1, hidden md:block counterpart below */}
-          <h1 className="account-page-title text-sm font-semibold text-slate-800 truncate">
+          <h1 className="account-page-title truncate">
             {mobileTitle}
           </h1>
         </div>

--- a/apps/web/src/components/user/profile/AccountDesktopSidebar.tsx
+++ b/apps/web/src/components/user/profile/AccountDesktopSidebar.tsx
@@ -49,8 +49,8 @@ export function AccountDesktopSidebar({
       <div className="mt-3 p-3.5 rounded-xl border border-slate-200/80 bg-white shadow-xs">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-2xs font-bold text-slate-500 uppercase tracking-wider">Current Plan</p>
-            <p className="text-sm font-bold text-slate-900 flex items-center gap-1.5 mt-0.5">
+            <p className="text-tiny font-bold text-muted-foreground uppercase tracking-wider">Current Plan</p>
+            <p className="text-body font-bold text-foreground flex items-center gap-1.5 mt-0.5">
               <Crown className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
               <span>{user?.plan || "Free"}</span>
             </p>
@@ -60,7 +60,7 @@ export function AccountDesktopSidebar({
               type="button"
               onClick={() => onTabChange("plans")}
               size="sm"
-              className="h-8 px-3 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold shadow-xs"
+              className="h-8 px-3 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-caption font-semibold shadow-xs"
             >
               Upgrade
             </Button>

--- a/apps/web/src/components/user/profile/cards/ActivePromotionsCard.tsx
+++ b/apps/web/src/components/user/profile/cards/ActivePromotionsCard.tsx
@@ -38,7 +38,7 @@ export const ActivePromotionsCard: React.FC<ActivePromotionsCardProps> = ({ prom
     <Card className="rounded-2xl border border-slate-200/80 bg-white shadow-xs">
       <CardContent className="p-3.5 sm:p-5 space-y-3">
         <div className="flex items-center justify-between">
-          <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider flex items-center gap-1.5">
+          <h4 className="text-caption font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
             <Zap className="w-4 h-4 text-amber-500 shrink-0" />
             <span>Boosted Ads ({uniquePromotions.length})</span>
           </h4>
@@ -52,15 +52,15 @@ export const ActivePromotionsCard: React.FC<ActivePromotionsCardProps> = ({ prom
             return (
               <div
                 key={promo.promotionId}
-                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3 rounded-xl bg-slate-50/80 border border-slate-200/70 text-xs"
+                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3 rounded-xl bg-slate-50/80 border border-slate-200/70 text-caption"
               >
                 <div>
-                  <div className="font-bold text-slate-900">{promo.entityTitle || 'Boosted Listing'}</div>
+                  <div className="font-bold text-foreground">{promo.entityTitle || 'Boosted Listing'}</div>
                   <div className="flex flex-wrap items-center gap-2 mt-1">
-                    <span className="px-2 py-0.5 rounded text-2xs font-bold bg-amber-50 text-amber-700 border border-amber-200 uppercase tracking-wide">
+                    <span className="px-2 py-0.5 rounded text-tiny font-bold bg-amber-50 text-amber-700 border border-amber-200 uppercase tracking-wide">
                       {promo.type.replace('_', ' ')} BOOST
                     </span>
-                    <span className="text-2xs text-slate-500">
+                    <span className="text-tiny text-muted-foreground">
                       Applied {new Date(promo.startsAt).toLocaleDateString()} • Valid until {new Date(promo.endsAt).toLocaleDateString()}
                     </span>
                   </div>
@@ -68,9 +68,9 @@ export const ActivePromotionsCard: React.FC<ActivePromotionsCardProps> = ({ prom
 
                 <div className="self-start sm:self-auto text-right">
                   <span
-                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-2xs font-semibold ${
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-tiny font-semibold ${
                       isExpired
-                        ? 'bg-slate-100 text-slate-600'
+                        ? 'bg-slate-100 text-muted-foreground'
                         : 'bg-emerald-50 text-emerald-700 border border-emerald-200'
                     }`}
                   >

--- a/apps/web/src/components/user/profile/cards/ActiveSubscriptionCard.tsx
+++ b/apps/web/src/components/user/profile/cards/ActiveSubscriptionCard.tsx
@@ -22,19 +22,19 @@ export const ActiveSubscriptionCard: React.FC<ActiveSubscriptionCardProps> = ({
       <div className="bg-white rounded-2xl p-5 border border-slate-200/80 shadow-xs relative overflow-hidden">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-2xs font-bold bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
+            <div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-tiny font-bold bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
               <Crown className="w-3 h-3 text-blue-600 shrink-0" />
               <span>FREE PLAN</span>
             </div>
-            <h3 className="text-base font-bold text-slate-900 tracking-tight">Free Starter Plan</h3>
-            <p className="text-xs text-slate-500 max-w-lg">
+            <h3 className="text-body-lg font-bold text-foreground tracking-tight">Free Starter Plan</h3>
+            <p className="text-caption text-muted-foreground max-w-lg">
               Monthly plan with free ad postings. Upgrade to unlock extra posting power, spotlight boosts, and instant buyer alerts.
             </p>
           </div>
           {onBrowsePlans && (
             <button
               onClick={onBrowsePlans}
-              className="inline-flex items-center justify-center h-9 px-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold transition-colors shadow-xs whitespace-nowrap self-start sm:self-auto cursor-pointer"
+              className="inline-flex items-center justify-center h-9 px-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-caption font-semibold transition-colors shadow-xs whitespace-nowrap self-start sm:self-auto cursor-pointer"
             >
               Upgrade Plan
             </button>
@@ -51,12 +51,12 @@ export const ActiveSubscriptionCard: React.FC<ActiveSubscriptionCardProps> = ({
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-2xs font-bold bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
+            <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-tiny font-bold bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
               <Crown className="w-3 h-3 text-blue-600 shrink-0" />
               <span>{subscription.category || 'Standard'}</span>
             </span>
             <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-full text-2xs font-semibold ${
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-tiny font-semibold ${
                 isExpired ? 'bg-red-50 text-red-700 border border-red-200' : 'bg-emerald-50 text-emerald-700 border border-emerald-200'
               }`}
             >
@@ -64,11 +64,11 @@ export const ActiveSubscriptionCard: React.FC<ActiveSubscriptionCardProps> = ({
             </span>
           </div>
 
-          <h3 className="text-base font-bold text-slate-900 tracking-tight">
+          <h3 className="text-body-lg font-bold text-foreground tracking-tight">
             {formatPlanName(subscription.planName)}
           </h3>
 
-          <p className="text-xs text-slate-500">
+          <p className="text-caption text-muted-foreground">
             {isExpired ? 'Plan has expired. Renew to continue posting.' : '30-Day Plan Validity • Resets on 1st of every month'}
           </p>
         </div>
@@ -76,7 +76,7 @@ export const ActiveSubscriptionCard: React.FC<ActiveSubscriptionCardProps> = ({
         {onBrowsePlans && (
           <button
             onClick={onBrowsePlans}
-            className="inline-flex items-center justify-center h-9 px-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold transition-colors shadow-xs whitespace-nowrap self-start sm:self-auto cursor-pointer"
+            className="inline-flex items-center justify-center h-9 px-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-caption font-semibold transition-colors shadow-xs whitespace-nowrap self-start sm:self-auto cursor-pointer"
           >
             Upgrade Plan
           </button>

--- a/apps/web/src/components/user/profile/cards/WalletOverviewCard.tsx
+++ b/apps/web/src/components/user/profile/cards/WalletOverviewCard.tsx
@@ -11,7 +11,7 @@ export const WalletOverviewCard: React.FC<WalletOverviewCardProps> = ({ wallet }
   return (
     <Card className="rounded-2xl border border-slate-200/80 bg-white shadow-xs">
       <CardContent className="p-3.5 sm:p-5 space-y-3.5 sm:space-y-4">
-        <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+        <h4 className="text-caption font-bold text-muted-foreground uppercase tracking-wider">
           Ad Credits & Allowances
         </h4>
 
@@ -23,15 +23,15 @@ export const WalletOverviewCard: React.FC<WalletOverviewCardProps> = ({ wallet }
                 <div className="p-1.5 rounded-lg bg-blue-50 text-blue-600 border border-blue-100">
                   <Package className="w-4 h-4 shrink-0" />
                 </div>
-                <span className="text-xs font-bold text-slate-900">Ad Postings</span>
+                <span className="text-small font-bold text-foreground">Ad Postings</span>
               </div>
-              <span className="text-2xs font-semibold px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-200">
+              <span className="text-tiny font-semibold px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-200">
                 {wallet.monthlyFreeAdsRemaining + wallet.paidAdCredits} Available
               </span>
             </div>
-            <div className="flex items-baseline justify-between text-2xs text-slate-500 pt-2 border-t border-slate-200/60">
-              <span>Free Monthly: <strong className="text-slate-800">{wallet.monthlyFreeAdsRemaining}</strong> / {wallet.monthlyFreeAdsTotal}</span>
-              <span>Extra Paid: <strong className="text-slate-800">{wallet.paidAdCredits}</strong></span>
+            <div className="flex items-baseline justify-between text-tiny text-muted-foreground pt-2 border-t border-slate-200/60">
+              <span>Free Monthly: <strong className="text-foreground">{wallet.monthlyFreeAdsRemaining}</strong> / {wallet.monthlyFreeAdsTotal}</span>
+              <span>Extra Paid: <strong className="text-foreground">{wallet.paidAdCredits}</strong></span>
             </div>
           </div>
 
@@ -42,13 +42,13 @@ export const WalletOverviewCard: React.FC<WalletOverviewCardProps> = ({ wallet }
                 <div className="p-1.5 rounded-lg bg-emerald-50 text-emerald-600 border border-emerald-100">
                   <Bell className="w-4 h-4 shrink-0" />
                 </div>
-                <span className="text-xs font-bold text-slate-900">Smart Alerts</span>
+                <span className="text-small font-bold text-foreground">Smart Alerts</span>
               </div>
-              <span className="text-2xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200">
+              <span className="text-tiny font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200">
                 {wallet.smartAlertSlots ?? 0} Active
               </span>
             </div>
-            <div className="text-2xs text-slate-500 pt-2 border-t border-slate-200/60">
+            <div className="text-tiny text-muted-foreground pt-2 border-t border-slate-200/60">
               Instant match notifications for buyer requests
             </div>
           </div>
@@ -60,15 +60,15 @@ export const WalletOverviewCard: React.FC<WalletOverviewCardProps> = ({ wallet }
                 <div className="p-1.5 rounded-lg bg-amber-50 text-amber-600 border border-amber-100">
                   <Zap className="w-4 h-4 shrink-0" />
                 </div>
-                <span className="text-xs font-bold text-slate-900">Listing Boosts</span>
+                <span className="text-small font-bold text-foreground">Listing Boosts</span>
               </div>
-              <span className="text-2xs font-semibold px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+              <span className="text-tiny font-semibold px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
                 {wallet.spotlightCredits + wallet.topAdCredits} Credits
               </span>
             </div>
-            <div className="flex items-baseline justify-between text-2xs text-slate-500 pt-2 border-t border-slate-200/60">
-              <span>Spotlight: <strong className="text-slate-800">{wallet.spotlightCredits}</strong></span>
-              <span>Top Ad: <strong className="text-slate-800">{wallet.topAdCredits}</strong></span>
+            <div className="flex items-baseline justify-between text-tiny text-muted-foreground pt-2 border-t border-slate-200/60">
+              <span>Spotlight: <strong className="text-foreground">{wallet.spotlightCredits}</strong></span>
+              <span>Top Ad: <strong className="text-foreground">{wallet.topAdCredits}</strong></span>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/user/profile/tabs/PersonalProfileEmailSection.tsx
+++ b/apps/web/src/components/user/profile/tabs/PersonalProfileEmailSection.tsx
@@ -16,8 +16,8 @@ export function PersonalProfileEmailSection({
     return (
         <div className="flex flex-col gap-1.5">
             <div className="flex items-center justify-between">
-                <Label htmlFor="profile-email" className="text-xs font-semibold text-slate-700">
-                    Notification & Invoice Email <span className="text-slate-400 font-normal">(Optional)</span>
+                <Label htmlFor="profile-email" className="text-caption font-semibold text-foreground-secondary">
+                    Notification & Invoice Email <span className="text-muted-foreground font-normal">(Optional)</span>
                 </Label>
             </div>
             <Input
@@ -25,12 +25,12 @@ export function PersonalProfileEmailSection({
                 type="email"
                 placeholder="name@company.com"
                 {...register("email")}
-                className={`h-10 sm:h-10.5 rounded-xl bg-white border-slate-200 px-3.5 text-xs sm:text-sm font-medium ${emailError ? "border-red-500" : ""}`}
+                className={`h-10 sm:h-10.5 rounded-xl bg-white border-slate-200 px-3.5 text-caption sm:text-body font-medium ${emailError ? "border-red-500" : ""}`}
                 aria-invalid={!!emailError}
                 aria-describedby={emailError ? "profile-email-error" : "profile-email-helper"}
                 autoComplete="email"
             />
-            <p id="profile-email-helper" className="text-tiny text-slate-500">
+            <p id="profile-email-helper" className="text-tiny text-muted-foreground">
                 Used strictly to send PDF invoices and ad status updates.
             </p>
             <FormError id="profile-email-error" message={emailError} />

--- a/apps/web/src/components/user/profile/tabs/PersonalProfileGstSection.tsx
+++ b/apps/web/src/components/user/profile/tabs/PersonalProfileGstSection.tsx
@@ -16,8 +16,8 @@ export function PersonalProfileGstSection({
     return (
         <div className="flex flex-col gap-1.5">
             <div className="flex items-center justify-between">
-                <Label htmlFor="profile-gstin" className="text-xs font-semibold text-slate-700">
-                    GSTIN Number <span className="text-slate-400 font-normal">(Optional)</span>
+                <Label htmlFor="profile-gstin" className="text-caption font-semibold text-foreground-secondary">
+                    GSTIN Number <span className="text-muted-foreground font-normal">(Optional)</span>
                 </Label>
             </div>
             <Input
@@ -26,11 +26,11 @@ export function PersonalProfileGstSection({
                 placeholder="e.g. 27AAAAA0000A1Z5"
                 maxLength={15}
                 {...register("gstin")}
-                className={`h-10 sm:h-10.5 rounded-xl bg-white border-slate-200 px-3.5 text-xs sm:text-sm font-medium uppercase ${gstinError ? "border-red-500" : ""}`}
+                className={`h-10 sm:h-10.5 rounded-xl bg-white border-slate-200 px-3.5 text-caption sm:text-body font-medium uppercase ${gstinError ? "border-red-500" : ""}`}
                 aria-invalid={!!gstinError}
                 aria-describedby={gstinError ? "profile-gstin-error" : "profile-gstin-helper"}
             />
-            <p id="profile-gstin-helper" className="text-tiny text-slate-500">
+            <p id="profile-gstin-helper" className="text-tiny text-muted-foreground">
                 Enter your 15-character GSTIN to claim 18% Input Tax Credit (ITC) on B2B invoices.
             </p>
             <FormError id="profile-gstin-error" message={gstinError} />

--- a/apps/web/src/components/user/profile/tabs/PersonalTab.tsx
+++ b/apps/web/src/components/user/profile/tabs/PersonalTab.tsx
@@ -176,8 +176,8 @@ export function PersonalTab({ user, onUpdateUser }: PersonalTabProps) {
                                 </div>
                             </div>
                             <div className="flex-1 min-w-0">
-                                <h4 className="text-xs sm:text-sm font-bold text-slate-900 tracking-tight">Profile photo</h4>
-                                <p className="text-tiny text-slate-500">
+                                <h4 className="text-small sm:text-body font-bold text-foreground tracking-tight">Profile photo</h4>
+                                <p className="text-tiny text-muted-foreground">
                                     JPG, PNG, WEBP. Max 5MB. Click to upload or change.
                                 </p>
                                 <FormError message={photoError} />
@@ -188,14 +188,14 @@ export function PersonalTab({ user, onUpdateUser }: PersonalTabProps) {
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5 sm:gap-4">
                             {/* Column 1: Full Name */}
                             <div className="space-y-1">
-                                <Label htmlFor="profile-name" className="text-xs font-semibold text-slate-700">
+                                <Label htmlFor="profile-name" className="text-caption font-semibold text-foreground-secondary">
                                     Full name <span className="text-red-500">*</span>
                                 </Label>
                                 <Input
                                     id="profile-name"
                                     type="text"
                                     placeholder="Enter your full name"
-                                    className="h-9 text-xs sm:text-sm rounded-xl border-slate-200 bg-white px-3.5 focus-visible:ring-2 focus-visible:ring-blue-500"
+                                    className="h-9 text-caption sm:text-body rounded-xl border-slate-200 bg-white px-3.5 focus-visible:ring-2 focus-visible:ring-blue-500"
                                     {...form.register("name")}
                                 />
                                 <FormError message={nameError} />
@@ -203,7 +203,7 @@ export function PersonalTab({ user, onUpdateUser }: PersonalTabProps) {
 
                             {/* Column 2: Mobile Number (Read-only verified) */}
                             <div className="space-y-1">
-                                <Label htmlFor="profile-mobile" className="text-xs font-semibold text-slate-700">
+                                <Label htmlFor="profile-mobile" className="text-caption font-semibold text-foreground-secondary">
                                     Mobile number
                                 </Label>
                                 <div className="relative">
@@ -214,7 +214,7 @@ export function PersonalTab({ user, onUpdateUser }: PersonalTabProps) {
                                         value={formattedMobile}
                                         readOnly
                                         disabled
-                                        className="h-9 text-xs sm:text-sm pl-8.5 pr-3.5 rounded-xl border-slate-200 bg-slate-50 text-slate-800 font-medium cursor-not-allowed"
+                                        className="h-9 text-caption sm:text-body pl-8.5 pr-3.5 rounded-xl border-slate-200 bg-slate-50 text-foreground font-medium cursor-not-allowed"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
Standardizes typography scale classes and semantic design tokens across the User Account and Profile module components, eliminating arbitrary typography styling and ensuring clean dark-mode support and layout consistency.

Part of #436

## Phase 5A Scope & Standardizations
- **AccountHeader (`apps/web/src/components/user/AccountHeader.tsx`)**:
  - Replaced hardcoded text color overrides with canonical `account-page-title` and semantic tokens.
- **AccountDesktopSidebar (`apps/web/src/components/user/profile/AccountDesktopSidebar.tsx`)**:
  - Converted legacy `text-2xs` and hardcoded slate colors to `text-tiny` and `text-muted-foreground`.
  - Mapped headings and button labels to canonical tokens (`text-body`, `text-caption`).
- **PersonalTab & Form Sections (`PersonalTab.tsx`, `PersonalProfileEmailSection.tsx`, `PersonalProfileGstSection.tsx`)**:
  - Standardized section titles, form labels (`text-caption`, `text-foreground-secondary`), inputs, and helper messages (`text-tiny`, `text-muted-foreground`).
- **Wallet & Promotions Cards (`WalletOverviewCard.tsx`, `ActivePromotionsCard.tsx`, `ActiveSubscriptionCard.tsx`)**:
  - Standardized badge chips (`text-tiny`), section titles (`text-caption font-bold uppercase`), body descriptions, and stat metrics.

## Verification
- `npm run guard:typography-ssot`: Passed (0 violations)
- `npm run type-check`: Passed (0 errors across 9 workspaces)
- Pre-push `repo:gate`: Passed (100% green test suites)