### PR TITLE
refactor(web): standardize typography in post-ad wizard and submission modals

### DIFF
--- a/apps/web/src/components/user/post-ad/steps/listing-details/DescriptionSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-details/DescriptionSection.tsx
@@ -19,7 +19,7 @@ export function DescriptionSection() {
                 render={({ field }) => (
                     <div className="flex flex-col gap-1.5">
                         <div className="flex items-center justify-between gap-2 mb-1">
-                            <FieldLabel required className="text-xs sm:text-sm font-semibold leading-snug text-foreground-secondary">
+                            <FieldLabel required className="text-caption sm:text-body font-semibold leading-snug text-foreground-secondary">
                                 Describe your product
                             </FieldLabel>
                             {isAiAvailable && (
@@ -29,7 +29,7 @@ export function DescriptionSection() {
                                     size="sm"
                                     onClick={() => generateDescription('description')}
                                     disabled={isGeneratingAI !== null}
-                                    className="h-7 sm:h-8 px-2.5 sm:px-3 text-xs bg-primary/10 text-primary hover:bg-primary/20 rounded-lg font-medium shrink-0"
+                                    className="h-7 sm:h-8 px-2.5 sm:px-3 text-caption bg-primary/10 text-primary hover:bg-primary/20 rounded-lg font-medium shrink-0"
                                 >
                                     {isGeneratingAI === 'description' ? <Loader2 className="w-3 h-3 animate-spin" /> : "AI Enhance"}
                                 </Button>
@@ -41,7 +41,7 @@ export function DescriptionSection() {
                                 rows={3}
                                 placeholder="Describe the condition, issues, and what's included..."
                                 maxLength={MAX_AD_DESCRIPTION_CHARS}
-                                className="min-h-[88px] text-sm font-normal border-slate-200 rounded-xl shadow-2xs focus-visible:ring-2 focus-visible:ring-blue-600/20 focus-visible:border-blue-600 py-2.5 px-3 placeholder:text-xs sm:placeholder:text-sm leading-relaxed"
+                                className="min-h-[88px] text-body font-normal border-slate-200 rounded-xl shadow-2xs focus-visible:ring-2 focus-visible:ring-blue-600/20 focus-visible:border-blue-600 py-2.5 px-3 placeholder:text-caption sm:placeholder:text-body leading-relaxed"
                             />
                         </FieldControl>
                         <div className="flex justify-between items-start mt-1">

--- a/apps/web/src/components/user/post-ad/steps/listing-details/LocationSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-details/LocationSection.tsx
@@ -139,22 +139,22 @@ export function LocationSection() {
     return (
         <section className="space-y-3" aria-labelledby="location-heading">
             <h2 id="location-heading" className="sr-only">Location</h2>
-            <Field label="Where are you located?" labelClassName="text-xs sm:text-sm font-semibold text-foreground-secondary" required error={locationError as string}>
+            <Field label="Where are you located?" labelClassName="text-caption sm:text-body font-semibold text-foreground-secondary" required error={locationError as string}>
                 <div className="space-y-2">
                     <LocationSelector
                         variant="inline"
                         mode="postAd"
                         onLocationSelect={handleSelectLocation}
                         currentDisplay={locationVal?.display}
-                        className="h-11 font-normal text-sm rounded-xl border border-slate-200"
+                        className="h-11 font-normal text-body rounded-xl border border-slate-200"
                         disabled={isLocationLocked}
                     />
                     {isLocationLocked ? (
-                        <p className="text-xs text-amber-600 text-center font-normal">
+                        <p className="text-caption text-amber-600 text-center font-normal">
                             Location cannot be changed once an ad is live or under review.
                         </p>
                     ) : (
-                        <p className="text-xs text-foreground-subtle text-center font-normal">Use GPS auto-detect or search manually for your city.</p>
+                        <p className="text-caption text-foreground-subtle text-center font-normal">Use GPS auto-detect or search manually for your city.</p>
                     )}
                 </div>
             </Field>

--- a/apps/web/src/components/user/post-ad/steps/listing-details/TitleSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-details/TitleSection.tsx
@@ -19,7 +19,7 @@ export function TitleSection() {
                 render={({ field }) => (
                     <div className="flex flex-col gap-1.5">
                         <div className="flex items-center justify-between gap-2 mb-1">
-                            <FieldLabel required className="text-xs sm:text-sm font-semibold leading-snug text-foreground-secondary">
+                            <FieldLabel required className="text-caption sm:text-body font-semibold leading-snug text-foreground-secondary">
                                 Choose a catchy title
                             </FieldLabel>
                             {isAiAvailable && (
@@ -29,7 +29,7 @@ export function TitleSection() {
                                     size="sm"
                                     onClick={() => generateDescription('title')}
                                     disabled={isGeneratingAI !== null}
-                                    className="h-7 sm:h-8 px-2.5 sm:px-3 text-xs bg-primary/10 text-primary hover:bg-primary/20 rounded-lg font-medium shrink-0"
+                                    className="h-7 sm:h-8 px-2.5 sm:px-3 text-caption bg-primary/10 text-primary hover:bg-primary/20 rounded-lg font-medium shrink-0"
                                 >
                                     {isGeneratingAI === 'title' ? <Loader2 className="w-3 h-3 animate-spin" /> : "AI Suggest"}
                                 </Button>
@@ -40,7 +40,7 @@ export function TitleSection() {
                                 {...field}
                                 placeholder="e.g. iPhone 13 Pro - Screen issue"
                                 maxLength={MAX_AD_TITLE_CHARS}
-                                className="h-11 text-sm font-normal sm:font-medium border-slate-200 rounded-xl shadow-2xs focus-visible:ring-2 focus-visible:ring-blue-600/20 focus-visible:border-blue-600 placeholder:text-xs sm:placeholder:text-sm"
+                                className="h-11 text-body font-normal sm:font-medium border-slate-200 rounded-xl shadow-2xs focus-visible:ring-2 focus-visible:ring-blue-600/20 focus-visible:border-blue-600 placeholder:text-caption sm:placeholder:text-body"
                             />
                         </FieldControl>
                         <div className="flex justify-between items-start mt-1">

--- a/apps/web/src/components/user/post-ad/steps/listing-information/BrandSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-information/BrandSection.tsx
@@ -36,7 +36,7 @@ export function BrandSection() {
                 name="brand"
                 render={() => (
                     <div className="flex flex-col gap-1.5">
-                        <FieldLabel required className="text-xs sm:text-sm font-semibold text-foreground-secondary">Brand</FieldLabel>
+                        <FieldLabel required className="text-caption sm:text-body font-semibold text-foreground-secondary">Brand</FieldLabel>
                         <FieldControl animateOnError>
                             <BrandSearchSelect 
                                 brands={availableBrands} 
@@ -58,13 +58,13 @@ export function BrandSection() {
             />
             {brandsError && (
                 <div className="p-3 bg-red-50 border border-red-200 rounded-xl mt-2">
-                    <p className="text-xs text-red-700 text-center mb-2">{brandsError}</p>
+                    <p className="text-caption text-red-700 text-center mb-2">{brandsError}</p>
                     <Button 
                         type="button" 
                         variant="outline" 
                         size="sm" 
                         onClick={() => loadBrandsForCategory(categoryId)} 
-                        className="w-full text-xs font-semibold text-red-600 border-red-200 hover:bg-red-50"
+                        className="w-full text-caption font-semibold text-red-600 border-red-200 hover:bg-red-50"
                     >
                         Try Again
                     </Button>

--- a/apps/web/src/components/user/post-ad/steps/listing-information/SpecificationSection.tsx
+++ b/apps/web/src/components/user/post-ad/steps/listing-information/SpecificationSection.tsx
@@ -45,7 +45,7 @@ export function SpecificationSection() {
             {dynamicAttributeFilters.length > 0 ? (
                 <fieldset disabled={isEditMode} className={cn("space-y-2.5 rounded-2xl border border-slate-100 bg-slate-50/40 p-2.5 border-0 m-0", isEditMode && "opacity-60 cursor-not-allowed")}>
                     <div>
-                        <p className="text-2xs sm:text-xs font-bold uppercase tracking-wider text-foreground-tertiary">Category Details</p>
+                        <p className="text-tiny sm:text-caption font-bold uppercase tracking-wider text-foreground-tertiary">Category Details</p>
                     </div>
                     <div className="space-y-2.5">
                         {dynamicAttributeFilters.map((f) => renderAttributeField(
@@ -60,7 +60,7 @@ export function SpecificationSection() {
 
             {requiresScreenSize && (
                 <fieldset disabled={isEditMode} className="w-full border-0 p-0 m-0">
-                    <Field label="Screen Size" labelClassName="text-xs sm:text-sm font-semibold text-foreground-secondary" error={screenSizeError as string} className={cn(isEditMode && "opacity-60 cursor-not-allowed")}>
+                    <Field label="Screen Size" labelClassName="text-caption sm:text-body font-semibold text-foreground-secondary" error={screenSizeError as string} className={cn(isEditMode && "opacity-60 cursor-not-allowed")}>
                         <div className="flex flex-wrap gap-2 mt-1">
                             {availableSizes.map((size) => {
                                 const isSelected = screenSize === size;
@@ -72,7 +72,7 @@ export function SpecificationSection() {
                                         onClick={() => onScreenSizeChange(size)}
                                         aria-pressed={isSelected}
                                         className={cn(
-                                            "h-8 sm:h-9 px-3 sm:px-4 rounded-xl border text-xs sm:text-sm font-medium transition-all duration-200 cursor-pointer select-none",
+                                            "h-8 sm:h-9 px-3 sm:px-4 rounded-xl border text-caption sm:text-body font-medium transition-all duration-200 cursor-pointer select-none",
                                             isSelected
                                                 ? "bg-blue-600 border-blue-600 text-white font-semibold shadow-sm shadow-blue-500/20"
                                                 : "bg-slate-50/80 border-slate-200/90 text-slate-700 hover:bg-slate-100 hover:border-slate-300",

--- a/apps/web/src/components/user/shared/ListingPriceField.tsx
+++ b/apps/web/src/components/user/shared/ListingPriceField.tsx
@@ -41,7 +41,7 @@ export function ListingPriceField<
         <Stack gap="sm" className={className}>
           <div className="flex justify-between items-center">
             {label && (
-              <FieldLabel required={required} className="text-xs sm:text-sm font-semibold text-foreground-secondary">
+              <FieldLabel required={required} className="text-caption sm:text-body font-semibold text-foreground-secondary">
                 {label}
               </FieldLabel>
             )}
@@ -51,7 +51,7 @@ export function ListingPriceField<
             <div className="flex flex-row gap-3">
               <div className="relative flex-1 min-w-0">
                 {showCurrencySymbol && (
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground font-semibold text-sm pointer-events-none">₹</span>
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground font-semibold text-body pointer-events-none">₹</span>
                 )}
                 <Input
                   {...field}
@@ -61,7 +61,7 @@ export function ListingPriceField<
                   disabled={disabled || isFree}
                   placeholder={placeholder}
                   className={cn(
-                    "h-11 text-sm font-normal sm:font-medium rounded-xl shadow-sm focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:border-primary transition-all placeholder:text-xs sm:placeholder:text-sm",
+                    "h-11 text-body font-normal sm:font-medium rounded-xl shadow-sm focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:border-primary transition-all placeholder:text-caption sm:placeholder:text-body",
                     showCurrencySymbol && "pl-8",
                     isFree && "bg-muted border-transparent text-muted-foreground"
                   )}
@@ -103,7 +103,7 @@ export function ListingPriceField<
                       </svg>
                     )}
                   </div>
-                  <span className="text-xs font-bold whitespace-nowrap">{isFree ? "Free" : "Make Free"}</span>
+                  <span className="text-caption font-bold whitespace-nowrap">{isFree ? "Free" : "Make Free"}</span>
                 </button>
               )}
             </div>

--- a/apps/web/src/components/user/shared/ListingSubmissionSuccessModal.tsx
+++ b/apps/web/src/components/user/shared/ListingSubmissionSuccessModal.tsx
@@ -34,27 +34,27 @@ export function ListingSubmissionSuccessModal({
                     </div>
 
                     <Stack gap="xs">
-                        <DialogTitle className="text-base sm:text-lg font-bold text-slate-900">
+                        <DialogTitle className="text-body-lg sm:text-h4 font-bold text-foreground">
                             {titleText}
                         </DialogTitle>
-                        <DialogDescription id="submission-success-description" className="text-xs sm:text-sm text-slate-600 leading-relaxed">
+                        <DialogDescription id="submission-success-description" className="text-caption sm:text-body text-foreground-secondary leading-relaxed">
                             Your {entityLabel.toLowerCase()} is pending admin review.<br />
                             It will go live after approval.
                         </DialogDescription>
-                        <p className="text-2xs text-slate-400">Usually reviewed within 24 hours.</p>
+                        <p className="text-tiny text-muted-foreground">Usually reviewed within 24 hours.</p>
                     </Stack>
 
                     <div className="flex flex-col gap-2 pt-1">
                         <Button
                             onClick={onPrimaryAction}
-                            className="w-full h-9 sm:h-10 bg-blue-600 text-white hover:bg-blue-700 font-semibold text-xs sm:text-sm rounded-xl shadow-xs"
+                            className="w-full h-9 sm:h-10 bg-blue-600 text-white hover:bg-blue-700 font-semibold text-caption sm:text-body rounded-xl shadow-xs"
                         >
                             Done
                         </Button>
                         <Button
                             variant="outline"
                             onClick={onSecondaryAction}
-                            className="w-full h-9 sm:h-10 border-slate-200 text-slate-700 hover:bg-slate-50 font-medium text-xs sm:text-sm rounded-xl"
+                            className="w-full h-9 sm:h-10 border-slate-200 text-foreground-secondary hover:bg-muted font-medium text-caption sm:text-body rounded-xl"
                         >
                             {pendingActionLabel}
                         </Button>


### PR DESCRIPTION
## Summary
Standardizes typography font scales and semantic tokens across the Post Ad Wizard, step forms, custom input controls, and listing submission modals.

Part of #436

## Phase 5B Scope & Standardizations
- **ListingSubmissionSuccessModal (`ListingSubmissionSuccessModal.tsx`)**:
  - Migrated dialog title to `text-body-lg sm:text-h4 font-bold text-foreground`.
  - Migrated description to `text-caption sm:text-body text-foreground-secondary`.
  - Replaced legacy `text-2xs` review note with canonical `text-tiny text-muted-foreground`.
- **SpecificationSection (`SpecificationSection.tsx`)**:
  - Standardized section title to `text-tiny sm:text-caption uppercase tracking-wider`.
  - Standardized field labels and screen size chip buttons to `text-caption sm:text-body`.
- **BrandSection (`BrandSection.tsx`)**:
  - Aligned required field labels and error state typography with design tokens.
- **ListingPriceField (`ListingPriceField.tsx`)**:
  - Standardized field labels, currency prefix, input placeholder tokens, and 'Make Free' toggle text.
- **TitleSection & DescriptionSection (`TitleSection.tsx`, `DescriptionSection.tsx`)**:
  - Harmonized field labels, AI suggestion buttons (`text-caption`), inputs, and textareas (`text-body`).
- **LocationSection (`LocationSection.tsx`)**:
  - Standardized location picker helper messages and lock warnings to `text-caption`.

## Verification
- `npm run guard:typography-ssot`: Passed (0 violations)
- `npm run type-check`: Passed (0 errors across 9 workspaces)
- Pre-push `repo:gate`: Passed (100% green test suites)