### PR TITLE
refactor(web): standardize typography in marketplace cards and search headers

### DIFF
--- a/apps/web/src/components/search/SearchResultsHeader.tsx
+++ b/apps/web/src/components/search/SearchResultsHeader.tsx
@@ -59,7 +59,7 @@ const SortDropdownTrigger = React.forwardRef<HTMLButtonElement, SortDropdownTrig
             {...props}
         >
             <SortAsc className="size-4 text-foreground-subtle" />
-            <span className="hidden sm:inline font-normal text-slate-700 text-xs sm:text-sm">{SORT_LABELS[sort]}</span>
+            <span className="hidden sm:inline font-normal text-foreground-secondary text-caption sm:text-body">{SORT_LABELS[sort]}</span>
             <ChevronDown className={cn("size-3.5 text-foreground-subtle transition-transform", open && "rotate-180")} />
         </button>
     );
@@ -86,7 +86,7 @@ function SortDropdownMenu({
                     onSelect={() => onSelect(key)}
                     aria-selected={sort === key}
                     className={cn(
-                        "min-h-[44px] cursor-pointer rounded-lg px-3 py-2.5 text-sm",
+                        "min-h-[44px] cursor-pointer rounded-lg px-3 py-2.5 text-body",
                         sort === key
                             ? "bg-slate-900 text-white font-medium focus:bg-slate-900 focus:text-white"
                             : "text-foreground-tertiary focus:bg-slate-50 focus:text-foreground-secondary"
@@ -147,7 +147,7 @@ export function SearchResultsHeader({
                 <div className="flex items-center gap-2.5 md:gap-3 min-w-0 flex-1">
                     {filterNode && <div className="shrink-0 lg:hidden">{filterNode}</div>}
                     {categoryName && (
-                        <h2 className="hidden sm:block text-h4 font-bold text-slate-900 tracking-tight leading-none truncate">
+                        <h2 className="hidden sm:block text-h4 font-bold text-foreground tracking-tight leading-none truncate">
                             {categoryName}
                         </h2>
                     )}

--- a/apps/web/src/components/user/ad-card/AdCardDashboard.tsx
+++ b/apps/web/src/components/user/ad-card/AdCardDashboard.tsx
@@ -67,7 +67,7 @@ export const AdCardDashboard = memo(function AdCardDashboard({
         </AdCardCover>
 
         <CardContent className="p-2.5 md:p-4 space-y-1 md:space-y-2">
-          <Badge variant="secondary" className="mb-1 text-xs font-normal">
+          <Badge variant="secondary" className="mb-1 text-tiny font-normal">
             {categoryLabel}
           </Badge>
 

--- a/apps/web/src/components/user/ad-card/AdCardList.tsx
+++ b/apps/web/src/components/user/ad-card/AdCardList.tsx
@@ -145,7 +145,7 @@ export const AdCardList = memo(function AdCardList({
                 </div>
 
                 <div className="mt-2.5 flex min-w-0 items-center justify-between gap-2">
-                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-normal text-foreground-tertiary uppercase tracking-wide">
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-tiny font-normal text-foreground-tertiary uppercase tracking-wide">
                     {categoryLabel}
                   </span>
                   {conditionBadge}

--- a/apps/web/src/components/user/ad-card/primitives/AdCardMeta.tsx
+++ b/apps/web/src/components/user/ad-card/primitives/AdCardMeta.tsx
@@ -69,7 +69,7 @@ export const AdCardMeta = memo(function AdCardMeta({
         <span
           className={cn(
             "font-normal sm:font-bold tracking-tight text-emerald-700 dark:text-emerald-400",
-            isList ? "text-sm sm:text-lg" : isDashboard ? "text-sm sm:text-base" : "text-sm sm:text-base"
+            isList ? "text-body sm:text-h4" : isDashboard ? "text-body sm:text-body-lg" : "text-body sm:text-body-lg"
           )}
           aria-label={`Price: ${priceDisplay}`}
         >
@@ -80,8 +80,8 @@ export const AdCardMeta = memo(function AdCardMeta({
       {/* Title — De-congested with relaxed line-height and clean font weight */}
       <div className="min-h-[2rem] sm:min-h-[2.5rem] flex items-start my-0.5">
         <h3 className={cn(
-          "font-normal sm:font-semibold line-clamp-2 leading-relaxed text-slate-800 tracking-normal",
-          isList ? "text-xs sm:text-sm" : "text-xs sm:text-sm"
+          "font-normal sm:font-semibold line-clamp-2 leading-relaxed text-foreground tracking-normal",
+          isList ? "text-caption sm:text-body" : "text-caption sm:text-body"
         )}>
           {sanitizeListingTitle(ad.title, ad)}
         </h3>


### PR DESCRIPTION
## Summary
Standardizes typography scales and semantic design tokens across Marketplace Ad Cards, Card Meta info, and Search Results header controls.

Part of #436

## Phase 5C Scope & Standardizations
- **AdCardList (`AdCardList.tsx`)**:
  - Standardized category chip badge to `text-tiny font-normal uppercase tracking-wide`.
- **AdCardMeta (`AdCardMeta.tsx`)**:
  - Aligned prices to canonical typography tokens (`text-body sm:text-h4` for list, `text-body sm:text-body-lg` for cards).
  - Aligned ad titles to `text-caption sm:text-body font-normal sm:font-semibold text-foreground`.
- **AdCardDashboard (`AdCardDashboard.tsx`)**:
  - Converted category badge font size to canonical `text-tiny`.
- **SearchResultsHeader (`SearchResultsHeader.tsx`)**:
  - Aligned sort trigger labels, dropdown item typography (`text-body`), and category headings to `text-h4 font-bold text-foreground`.

## Verification
- `npm run guard:typography-ssot`: Passed (0 violations)
- `npm run type-check`: Passed (0 errors across 9 workspaces)
- Pre-push `repo:gate`: Passed (100% green test suites)