### PR TITLE
refactor(web): standardize typography in global footer and mobile navigation

### DIFF
--- a/apps/web/src/components/common/Footer.tsx
+++ b/apps/web/src/components/common/Footer.tsx
@@ -63,8 +63,8 @@ export function Footer({ theme = "light", onNavigate, className, currentYear }: 
     const renderLink = (label: string, href: string, pageKey: string, compact = false) => {
         const baseClassName = cn(
             compact
-                ? "inline-flex items-center text-xs md:text-sm transition-colors"
-                : "inline-flex min-h-10 items-center text-left text-xs md:text-sm transition-colors md:min-h-0",
+                ? "inline-flex items-center text-caption md:text-body transition-colors"
+                : "inline-flex min-h-10 items-center text-left text-caption md:text-body transition-colors md:min-h-0",
             isDark ? "hover:text-primary text-foreground-subtle" : "hover:text-green-600 text-foreground-tertiary"
         );
 
@@ -111,7 +111,7 @@ export function Footer({ theme = "light", onNavigate, className, currentYear }: 
         >
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 {/* Mobile Single-Line Footer Links */}
-                <div className="flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1 text-xs text-foreground-tertiary md:hidden mb-3">
+                <div className="flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1 text-caption text-foreground-tertiary md:hidden mb-3">
                     {FOOTER_LINK_SECTIONS.flatMap((section) => section.links).map((link, idx, arr) => (
                         <div key={link.label} className="inline-flex items-center gap-2.5">
                             {renderLink(link.label, link.href, link.pageKey, true)}
@@ -133,7 +133,7 @@ export function Footer({ theme = "light", onNavigate, className, currentYear }: 
                             key={section.title}
                             className="col-span-1 text-left"
                         >
-                            <h3 className={cn("mb-4 font-bold uppercase tracking-wider text-xs", isDark ? "text-foreground-subtle" : "text-foreground")}>
+                            <h3 className={cn("mb-4 font-bold uppercase tracking-wider text-caption", isDark ? "text-foreground-subtle" : "text-foreground")}>
                                 {section.title}
                             </h3>
                             <ul className="space-y-2">
@@ -151,13 +151,13 @@ export function Footer({ theme = "light", onNavigate, className, currentYear }: 
                 <div className={cn("flex flex-col items-start justify-between gap-2.5 pt-3 md:flex-row md:items-center md:gap-4 md:pt-4 border-t", isDark ? "border-slate-900" : "border-slate-200")}>
                     <div className="flex flex-col items-start gap-2 md:flex-row md:items-center md:gap-4">
                         <Badge className={cn(
-                            "border px-2.5 py-0.5 text-tiny md:text-xs",
+                            "border px-2.5 py-0.5 text-tiny md:text-caption",
                             isDark ? "bg-slate-900 text-primary border-slate-800" : "bg-green-50 text-green-700 border-green-100"
                         )}>
                             <CheckCircle className="h-3 w-3 mr-1.5" />
                             Verified Safe Marketplace
                         </Badge>
-                        <span className="text-tiny md:text-xs font-normal text-muted-foreground">
+                        <span className="text-tiny md:text-caption font-normal text-muted-foreground">
                             © {currentYear} Esparex Platform. Built for the future of tech repair.
                         </span>
                     </div>

--- a/apps/web/src/components/mobile/MobileBottomNav.tsx
+++ b/apps/web/src/components/mobile/MobileBottomNav.tsx
@@ -81,7 +81,7 @@ export function MobileBottomNav({ enabled = true }: MobileBottomNavProps) {
                             )}
                         >
                             <Icon className="h-4.5 w-4.5 shrink-0" />
-                            <span className="max-w-full truncate text-2xs font-normal leading-tight">
+                            <span className="max-w-full truncate text-tiny font-normal leading-tight">
                                 {item.label}
                             </span>
                         </Link>
@@ -120,7 +120,7 @@ export function MobileBottomNav({ enabled = true }: MobileBottomNavProps) {
                     </div>
                     <span
                         className={cn(
-                            "text-2xs font-normal leading-tight",
+                            "text-tiny font-normal leading-tight",
                             isBackendUp ? "text-link" : "text-muted-foreground"
                         )}
                     >

--- a/apps/web/src/components/mobile/MobileNavDrawer.tsx
+++ b/apps/web/src/components/mobile/MobileNavDrawer.tsx
@@ -103,7 +103,7 @@ export function MobileNavDrawer({
 
           {/* Nav Items */}
           <div className="flex-1 overflow-y-auto px-3 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))] space-y-0.5">
-            <p className="px-3 text-2xs font-bold text-foreground-subtle uppercase tracking-widest mb-2">
+            <p className="px-3 text-tiny font-bold text-foreground-subtle uppercase tracking-widest mb-2">
               {isLoggedIn ? "Account" : "Navigation"}
             </p>
             {visibleDrawerItems.map((item) => {


### PR DESCRIPTION
## Summary
Standardizes typography scales and design token usage across global layout components including the Mobile Bottom Navigation, Mobile Nav Drawer, and Footer links/badges.

Part of #436

## Phase 5D Scope & Standardizations
- **MobileBottomNav (`MobileBottomNav.tsx`)**:
  - Replaced legacy `text-2xs` labels with canonical `text-tiny font-normal leading-tight`.
- **MobileNavDrawer (`MobileNavDrawer.tsx`)**:
  - Replaced legacy `text-2xs` section headers with `text-tiny font-bold text-foreground-subtle uppercase tracking-widest`.
- **Footer (`Footer.tsx`)**:
  - Aligned mobile and desktop footer links to `text-caption md:text-body`.
  - Aligned section headings to `text-caption font-bold uppercase`.
  - Aligned verified badge and copyright text to `text-tiny md:text-caption`.

## Verification
- `npm run guard:typography-ssot`: Passed (0 violations)
- `npm run type-check`: Passed (0 errors across 9 workspaces)
- Pre-push `repo:gate`: Passed (100% green test suites)