### PR TITLE
fix(web): correct broken routes to canonical /account/ads and /contact

### DIFF
--- a/apps/web/src/__tests__/route-integrity.spec.ts
+++ b/apps/web/src/__tests__/route-integrity.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("Frontend Route Integrity (FIND-001 & FIND-002)", () => {
+    const webSrcDir = path.resolve(__dirname, "..");
+
+    it("verifies useListingSubmission uses canonical /account/ads route instead of /my-account/listings", () => {
+        const filePath = path.join(webSrcDir, "hooks/listings/useListingSubmission.ts");
+        const content = fs.readFileSync(filePath, "utf8");
+
+        expect(content).not.toContain("/my-account/listings");
+        expect(content).toContain('window.location.href = "/account/ads"');
+    });
+
+    it("verifies BusinessApplicationStatus uses canonical /contact route instead of /support", () => {
+        const filePath = path.join(webSrcDir, "components/user/profile/BusinessApplicationStatus.tsx");
+        const content = fs.readFileSync(filePath, "utf8");
+
+        expect(content).not.toContain("'/support'");
+        expect(content).not.toContain('"/support"');
+        expect(content).toContain("window.location.href = '/contact'");
+    });
+});

--- a/apps/web/src/components/user/profile/BusinessApplicationStatus.tsx
+++ b/apps/web/src/components/user/profile/BusinessApplicationStatus.tsx
@@ -239,7 +239,7 @@ export function BusinessApplicationStatus({
                 businessName={businessLabel}
                 actions={
                     <Button
-                        onClick={() => window.location.href = '/support'}
+                        onClick={() => window.location.href = '/contact'}
                         className="w-full bg-orange-600 hover:bg-orange-700 text-white"
                     >
                         Contact Support

--- a/apps/web/src/hooks/listings/useListingSubmission.ts
+++ b/apps/web/src/hooks/listings/useListingSubmission.ts
@@ -246,7 +246,7 @@ export function useListingSubmission<T extends ListingSubmissionValues, R = unkn
                             label: "View My Listings",
                             action: () => {
                                 if (typeof window !== "undefined") {
-                                    window.location.href = "/my-account/listings";
+                                    window.location.href = "/account/ads";
                                 }
                             }
                         },


### PR DESCRIPTION
## Summary of Changes

### Problem
Forensic audit runtime verification identified two HTTP 404 broken routes in user frontend action handlers:
1. **FIND-001**: `useListingSubmission.ts` navigated to `/my-account/listings` on duplicate ad warning action (returns 404).
2. **FIND-002**: `BusinessApplicationStatus.tsx` navigated to `/support` on suspended business contact action (returns 404).

### Solution
- Updated `apps/web/src/hooks/listings/useListingSubmission.ts` to route to canonical `/account/ads`.
- Updated `apps/web/src/components/user/profile/BusinessApplicationStatus.tsx` to route to canonical `/contact`.
- Added unit test suite `apps/web/src/__tests__/route-integrity.spec.ts` to prevent future route regressions.

### Verification Matrix
- ✅ Pre-commit staged quality guard passed.
- ✅ Pre-push authoritative `npm run pr:gate` passed (types, tests, lint-ci, repo-gate).
- ✅ Unit tests in `route-integrity.spec.ts` pass 100% green.