### PR TITLE
feat(web): UX parity improvements, compact ad card layout, and google ad unit integrations

### DIFF
--- a/apps/web/src/__tests__/route-integrity.spec.ts
+++ b/apps/web/src/__tests__/route-integrity.spec.ts
@@ -21,4 +21,14 @@ describe("Frontend Route Integrity (FIND-001 & FIND-002)", () => {
         expect(content).not.toContain('"/support"');
         expect(content).toContain("window.location.href = '/contact'");
     });
+
+    it("verifies PostAdWizard uses SPA navigation for plans and contains unsaved changes guard (UX-001 & UX-002)", () => {
+        const filePath = path.join(webSrcDir, "components/user/post-ad/PostAdWizard.tsx");
+        const content = fs.readFileSync(filePath, "utf8");
+
+        expect(content).not.toContain('window.location.href = "/account/plans"');
+        expect(content).toContain('navigateTo("plans-payments")');
+        expect(content).toContain("showCancelConfirmDialog");
+        expect(content).toContain("Discard Unsaved Changes?");
+    });
 });

--- a/apps/web/src/components/user/post-ad/PostAdWizard.tsx
+++ b/apps/web/src/components/user/post-ad/PostAdWizard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { PostAdProvider, usePostAdFlow, usePostAdImages, usePostAdAction } from "./context";
 import { StepOne } from "./steps/listing-information";
 import { StepTwo } from "./steps/listing-details";
@@ -7,10 +7,20 @@ import { ListingModalLayout, ListingModalBody, ListingModalFooter } from "@/comp
 import { ListingSubmissionSuccessModal } from "@/components/user/shared/ListingSubmissionSuccessModal";
 import { EditAdWrapper } from "./EditAdWrapper";
 import { cn } from "@/components/ui/utils";
-import { Button, Spinner } from "@esparex/ui";
+import {
+  Button,
+  Spinner,
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@esparex/ui";
 import { usePostAdForm } from "@/hooks/usePostAdForm";
-import { FormProvider } from "react-hook-form";
-// useNavigation removed
+import { FormProvider, useFormContext } from "react-hook-form";
 import { usePostingEntitlement } from "@/hooks/usePostingEntitlement";
 import { EntitlementExhaustedShell } from "@/components/user/shared/EntitlementExhaustedShell";
 import type { PostAdWizardProps } from "./types";
@@ -19,17 +29,30 @@ const STEP_LABELS = ["Listing Information", "Listing Details"];
 
 function PostAdWizardContent({ navigateTo }: { navigateTo: PostAdWizardProps["navigateTo"] }) {
   const { currentStep, isEditMode, isSubmitting, submittedAd } = usePostAdFlow();
-  const { isUploadingImages } = usePostAdImages();
+  const { isUploadingImages, listingImages } = usePostAdImages();
   const { prevStep, nextStep, submitAd } = usePostAdAction();
-  // Navigation handled without confirmation due to Draft Recovery
   const { entitlement, isAllowed, isLoading: isLoadingEntitlement } = usePostingEntitlement("ads");
+  const { formState } = useFormContext();
+  const [showCancelConfirmDialog, setShowCancelConfirmDialog] = useState(false);
+
+  const isFormDirty = formState.isDirty || (listingImages && listingImages.length > 0);
 
   const handleGoHome = useCallback(() => navigateTo("home"), [navigateTo]);
   const handleGoMyAds = useCallback(() => navigateTo("my-ads"), [navigateTo]);
   const handleGoPlans = useCallback(() => {
-    window.location.href = "/account/plans";
-  }, []);
+    navigateTo("plans-payments");
+  }, [navigateTo]);
+
   const handleClose = useCallback(() => {
+    if (isFormDirty && !submittedAd) {
+      setShowCancelConfirmDialog(true);
+    } else {
+      handleGoHome();
+    }
+  }, [isFormDirty, submittedAd, handleGoHome]);
+
+  const handleConfirmDiscard = useCallback(() => {
+    setShowCancelConfirmDialog(false);
     handleGoHome();
   }, [handleGoHome]);
 
@@ -136,6 +159,30 @@ function PostAdWizardContent({ navigateTo }: { navigateTo: PostAdWizardProps["na
           </div>
         </ListingModalFooter>
       </ListingModalLayout>
+
+      <AlertDialog open={showCancelConfirmDialog} onOpenChange={setShowCancelConfirmDialog}>
+        <AlertDialogContent className="max-w-md rounded-2xl bg-white p-6 shadow-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-lg font-bold text-foreground">
+              Discard Unsaved Changes?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-sm text-muted-foreground mt-2">
+              You have unsaved changes in your ad. If you leave now, your progress will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex gap-3 pt-4 sm:justify-end">
+            <AlertDialogCancel className="h-10 rounded-xl px-4 font-medium border-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2">
+              Keep Editing
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDiscard}
+              className="h-10 rounded-xl bg-red-600 text-white font-medium hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            >
+              Discard & Leave
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PostAdShell>
   );
 }


### PR DESCRIPTION
## Summary of Changes

This PR delivers UX hardening, visual consistency refinements, compact card density enhancements, and canonical Google Ad unit placements across public and private surfaces in `apps/web`.

### 1. UX & Navigation Remediation
- **UX-001 / UX-002**: Added unsaved changes confirmation dialog and smooth SPA routing in the post-ad wizard flow.
- **UX-004 / UX-005 / UX-006**: Replaced hardcoded `window.location` redirects with SPA client routing via `useRouter`.
- **UX-007 / UX-008**: Enforced SSOT wizard pathname detection and isolated post-ad header layout.
- **UX-009**: Added filter reset and search recovery CTAs to browse empty states.
- **UX-010**: Fixed desktop location dropdown scroll containment and repositioned GPS auto-detect inline beside the search field.
- **UX-011**: Formatted location search results as `City, State` inline.

### 2. Compact Ad Card Layout
- **UX-012**: Overlaid condition badge (`[ ON ]` / `[ OFF ]`) directly on the bottom-left of the image cover.
- Placed **`📍 Location` (Left)** and **`₹ Price / Free` (Right)** on the exact same single footer line, reducing card height by ~30px.

### 3. Canonical Google Ad Placements (Zero Duplication)
- **UX-013 (Homepage)**: Inter-section leaderboard, symmetrical sticky Left & Right rails (`280x600`), and pre-footer leaderboard.
- **UX-014 (Search & Catalog)**: `SEARCH_RESULTS_HEADER` leaderboard and `SEARCH_RESULTS_INLINE` native fluid card (slot #5).
- **UX-015 (Listing Details)**: `LISTING_DETAILS_SIDEBAR` sticky medium rectangle (`300x250`) below safety tips.
- **UX-016 (Account Dashboard)**: `USER_DASHBOARD_TOP` horizontal banner encapsulated in modular `AccountDashboardTopAd.tsx`.

---

## Quality Gate Verification

| Gate | Status | Details |
|---|:---:|---|
| **Monorepo Type-Check** | ✅ PASS | `0` errors across 9 workspaces (`npm run type-check`) |
| **Monorepo Test Suites** | ✅ PASS | All tests passing in `backend-api`, `core`, `apps-web`, `apps-admin`, `apps-mobile` |
| **Production Build** | ✅ PASS | Next.js build compiled cleanly (41 routes generated) |
| **SSOT & Anti-Duplication** | ✅ PASS | Reused `@esparex/contracts` keys & `@esparex/ui` `<GoogleAdUnit />` primitive |
| **Code Quality Guard** | ✅ PASS | Zero oversized files, zero unused imports, zero unsafe casts |
