### PR TITLE
fix(validation): harden chat attachment mime allowlists and eliminate business name false-positives

### DIFF
--- a/apps/web/src/__tests__/business-registration.schema.spec.ts
+++ b/apps/web/src/__tests__/business-registration.schema.spec.ts
@@ -60,9 +60,48 @@ describe("businessRegistrationSchema", () => {
         );
     });
 
+    it("accepts valid business names containing common English words (Select, Drop, Script, Insert, Exec)", () => {
+        const names = [
+            "Select Auto Spares & Garage",
+            "Drop Shipping & Delivery Hub",
+            "Script Solutions Pvt Ltd",
+            "Insert Tooling & Repair",
+            "Executive Auto Spares",
+        ];
+
+        for (const name of names) {
+            const result = businessRegistrationSchema.safeParse({
+                ...validRegistrationPayload,
+                name,
+            });
+            expect(result.success).toBe(true);
+        }
+    });
+
+    it("rejects malicious script payloads and excessive symbol spam in business names", () => {
+        const invalidNames = [
+            "<script>alert('xss')</script>",
+            "$$$$$$ Auto Repair $$$$$$",
+            "<iframe>hack</iframe>",
+            "javascript:void(0)",
+        ];
+
+        for (const name of invalidNames) {
+            const result = businessRegistrationSchema.safeParse({
+                ...validRegistrationPayload,
+                name,
+            });
+            expect(result.success).toBe(false);
+            expect(result.error?.flatten().fieldErrors.name).toContain(
+                "Business name contains invalid characters",
+            );
+        }
+    });
+
     it("accepts the payload without a canonical locationId", () => {
         const result = businessRegistrationSchema.safeParse(validRegistrationPayload);
 
         expect(result.success).toBe(true);
     });
 });
+

--- a/apps/web/src/schemas/business.schema.shared.ts
+++ b/apps/web/src/schemas/business.schema.shared.ts
@@ -61,10 +61,20 @@ export const validateBusinessImageSelection = (file: File): string | null =>
 export const validateBusinessDocumentSelection = (file: File): string | null =>
     validateBusinessUploadSelection(file, BUSINESS_DOCUMENT_MIME_TYPES, "document");
 
-export const sanitizedBusinessText = (text: string) => {
-    const excessiveSpecialChars = /[!@#$%^&*()_+=[\]{};:'"<>,.?/\\|`~]{3,}/.test(text);
-    const suspiciousPatterns = /xss|sql|script|select|drop|insert|exec/i.test(text);
-    return !excessiveSpecialChars && !suspiciousPatterns;
+export const sanitizedBusinessText = (text: string): boolean => {
+    if (!text || typeof text !== "string") return false;
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return false;
+
+    // Disallow excessive consecutive special punctuation (e.g. $$$$, ???? except standard formatting)
+    const excessiveRepeatedSpecialChars = /[!@#$%^&*+=[\]{};:"<>/\\|`~]{4,}/.test(trimmed);
+    if (excessiveRepeatedSpecialChars) return false;
+
+    // Reject raw script or HTML tag injection payloads
+    const containsHtmlOrScriptTag = /<\s*script\b[^>]*>|<\s*\/\s*script\s*>|<\s*iframe\b[^>]*>|javascript:/i.test(trimmed);
+    if (containsHtmlOrScriptTag) return false;
+
+    return true;
 };
 
 const requiredBusinessFields = {

--- a/backend/api/src/__tests__/validators/chat.validator.spec.ts
+++ b/backend/api/src/__tests__/validators/chat.validator.spec.ts
@@ -1,23 +1,98 @@
-import { adminListQuerySchema } from "@esparex/core/validators/chat.validator";
+import {
+    adminListQuerySchema,
+    sendMessageSchema,
+    chatUploadUrlSchema,
+    ALLOWED_CHAT_MIME_TYPES,
+} from "@esparex/core/validators/chat.validator";
 
-describe("adminListQuerySchema", () => {
-    it("accepts canonical admin chat filters", () => {
-        const parsed = adminListQuerySchema.parse({
-            filter: "reported",
-            q: "conv-123",
-            page: "3",
-            limit: "15",
+describe("chat.validator", () => {
+    const validConversationId = "507f1f77bcf86cd799439011";
+
+    describe("adminListQuerySchema", () => {
+        it("accepts canonical admin chat filters", () => {
+            const parsed = adminListQuerySchema.parse({
+                filter: "reported",
+                q: "conv-123",
+                page: "3",
+                limit: "15",
+            });
+
+            expect(parsed.filter).toBe("reported");
+            expect(parsed.q).toBe("conv-123");
+            expect(parsed.page).toBe(3);
+            expect(parsed.limit).toBe(15);
         });
 
-        expect(parsed.filter).toBe("reported");
-        expect(parsed.q).toBe("conv-123");
-        expect(parsed.page).toBe(3);
-        expect(parsed.limit).toBe(15);
+        it("rejects the legacy search alias", () => {
+            expect(() => adminListQuerySchema.parse({
+                search: "conv-123",
+            })).toThrow(/search|q/i);
+        });
     });
 
-    it("rejects the legacy search alias", () => {
-        expect(() => adminListQuerySchema.parse({
-            search: "conv-123",
-        })).toThrow(/search|q/i);
+    describe("sendMessageSchema MIME-type enforcement (VAL-02)", () => {
+        it("accepts all canonical allowed chat MIME types", () => {
+            for (const mimeType of ALLOWED_CHAT_MIME_TYPES) {
+                const result = sendMessageSchema.safeParse({
+                    conversationId: validConversationId,
+                    text: "Here is an attachment",
+                    attachments: [
+                        {
+                            url: "https://example.com/file.jpg",
+                            mimeType,
+                            size: 1024 * 1024,
+                            name: "test-file",
+                        },
+                    ],
+                });
+                expect(result.success).toBe(true);
+            }
+        });
+
+        it("rejects unauthorized or executable MIME types", () => {
+            const dangerousTypes = [
+                "application/x-msdownload",
+                "text/html",
+                "application/javascript",
+                "image/svg+xml",
+                "application/octet-stream",
+                "",
+            ];
+
+            for (const mimeType of dangerousTypes) {
+                const result = sendMessageSchema.safeParse({
+                    conversationId: validConversationId,
+                    text: "Dangerous payload",
+                    attachments: [
+                        {
+                            url: "https://example.com/payload",
+                            mimeType,
+                            size: 1024,
+                        },
+                    ],
+                });
+                expect(result.success).toBe(false);
+            }
+        });
+    });
+
+    describe("chatUploadUrlSchema MIME validation", () => {
+        it("accepts valid media content types", () => {
+            const result = chatUploadUrlSchema.safeParse({
+                conversationId: validConversationId,
+                contentType: "image/jpeg; charset=utf-8",
+                filename: "photo.jpg",
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects unsupported content types", () => {
+            const result = chatUploadUrlSchema.safeParse({
+                conversationId: validConversationId,
+                contentType: "application/x-sh",
+            });
+            expect(result.success).toBe(false);
+        });
     });
 });
+

--- a/backend/api/src/controllers/chat/chatController.ts
+++ b/backend/api/src/controllers/chat/chatController.ts
@@ -15,10 +15,11 @@ import {
   conversationListQuerySchema,
   messagesQuerySchema,
   chatUploadUrlSchema,
+  type AllowedChatMimeType,
 } from '@esparex/core/validators/chat.validator';
 import { generatePresignedUploadUrl } from '@esparex/core/utils/s3';
 
-const MIME_TO_EXT: Record<string, string> = {
+const MIME_TO_EXT: Record<AllowedChatMimeType, string> = {
   'image/jpeg': 'jpg',
   'image/png': 'png',
   'image/webp': 'webp',

--- a/backend/api/src/controllers/chat/chatController.ts
+++ b/backend/api/src/controllers/chat/chatController.ts
@@ -286,7 +286,7 @@ export const getChatUploadUrl = async (req: Request, res: Response): Promise<voi
     await getConversationForUser(conversationId, userId);
 
     const normalizedMime = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
-    const ext = MIME_TO_EXT[normalizedMime];
+    const ext = normalizedMime in MIME_TO_EXT ? MIME_TO_EXT[normalizedMime as AllowedChatMimeType] : undefined;
     if (!ext) {
       sendErrorResponse(req, res, 400, 'Unsupported attachment type');
       return;

--- a/core/src/validators/chat.validator.ts
+++ b/core/src/validators/chat.validator.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { Types } from 'mongoose';
-import { CHAT_REPORT_REASON_VALUES } from '@esparex/contracts';
+import {
+  CHAT_REPORT_REASON_VALUES,
+  ALLOWED_CHAT_MIME_TYPES,
+  type AllowedChatMimeType,
+} from '@esparex/contracts';
+
+export { ALLOWED_CHAT_MIME_TYPES, type AllowedChatMimeType };
 
 /* -------------------------------------------------------------------------- */
 /* Helpers                                                                     */
@@ -33,7 +39,9 @@ export const sendMessageSchema = z.object({
     .array(
       z.object({
         url: z.string().url('Attachment URL must be valid'),
-        mimeType: z.string().min(1),
+        mimeType: z.enum(ALLOWED_CHAT_MIME_TYPES, {
+          errorMap: () => ({ message: 'Unsupported attachment MIME type' }),
+        }),
         size: z.number().positive().max(8 * 1024 * 1024, 'Attachment too large (max 8 MB)'),
         name: z.string().trim().max(160).optional(),
       })
@@ -82,7 +90,16 @@ export const messagesQuerySchema = z
 
 export const chatUploadUrlSchema = z.object({
   conversationId: objectId(),
-  contentType: z.string().min(1, 'contentType is required'),
+  contentType: z
+    .string()
+    .min(1, 'contentType is required')
+    .refine(
+      (val) => {
+        const normalized = val.split(';')[0]?.trim().toLowerCase();
+        return ALLOWED_CHAT_MIME_TYPES.includes(normalized as AllowedChatMimeType);
+      },
+      { message: 'Unsupported attachment content type' }
+    ),
   filename: z.string().trim().max(160).optional(),
 });
 

--- a/packages/contracts/src/v1/chat/enums/chatStatus.ts
+++ b/packages/contracts/src/v1/chat/enums/chatStatus.ts
@@ -58,3 +58,19 @@ export const CHAT_REPORT_REASON = {
 
 export type ChatReportReasonValue = (typeof CHAT_REPORT_REASON)[keyof typeof CHAT_REPORT_REASON];
 export const CHAT_REPORT_REASON_VALUES = Object.values(CHAT_REPORT_REASON) as [ChatReportReasonValue, ...ChatReportReasonValue[]];
+
+/* -------------------------------------------------------------------------- */
+/* Chat Attachment MIME Types (SSOT)                                          */
+/* -------------------------------------------------------------------------- */
+
+export const ALLOWED_CHAT_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'video/mp4',
+  'application/pdf',
+] as const;
+
+export type AllowedChatMimeType = (typeof ALLOWED_CHAT_MIME_TYPES)[number];


### PR DESCRIPTION
## Summary of Changes

This PR hardens content-safety validation and eliminates false-positive rejections identified in the validation SSOT audit:

1. **Chat Attachment MIME-Type Security Allowlist (`VAL-02`)**:
   - Defined canonical `ALLOWED_CHAT_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif', 'video/mp4', 'application/pdf'] as const` in `@esparex/contracts`.
   - Enforced `z.enum(ALLOWED_CHAT_MIME_TYPES)` on `sendMessageSchema` attachments and presigned upload request `chatUploadUrlSchema` in `@esparex/core/validators/chat.validator.ts`.
   - Strongly typed `MIME_TO_EXT: Record<AllowedChatMimeType, string>` with safe lookup in `backend/api/src/controllers/chat/chatController.ts`.
   - Added unit tests in `backend/api/src/__tests__/validators/chat.validator.spec.ts` verifying rejection of executable/unauthorized MIME types (`.exe`, `.html`, `.js`, `.sh`, `.svg`).

2. **Business Registration Name False-Positive Elimination (`VAL-03`)**:
   - Replaced crude `/xss|sql|script|select|drop|insert|exec/i` keyword blacklist in `apps/web/src/schemas/business.schema.shared.ts` with clean character hygiene (rejects script/HTML tags and `$$$$$` symbol spam).
   - Eliminated false-positive rejection of valid business names containing ordinary English words (e.g., *"Select Auto Spares"*, *"Drop Shipping Point"*, *"Script Solutions"*, *"Executive Auto Parts"*).
   - Added unit tests in `apps/web/src/__tests__/business-registration.schema.spec.ts`.

---

## Repository Impact Statement

```text
Repository Impact Statement
---------------------------
Problem: Chat allowed unvalidated MIME strings and web business schema blocked words like "Select" or "Drop".
Existing SSOT: @esparex/contracts/src/v1/chat/enums/chatStatus.ts, core/src/validators/chat.validator.ts, apps/web/src/schemas/business.schema.shared.ts
New Files: 0
Existing Files Modified: 5
Duplicate Risk: None
Reason: Hardened existing schemas and validator SSOT.
