### PR TITLE
feat(marketplace): enforce 30-day listing lifecycle invariant and modernize cookie consent UI

### DIFF
--- a/backend/api/src/__tests__/utils/FeedVisibilityGuard.spec.ts
+++ b/backend/api/src/__tests__/utils/FeedVisibilityGuard.spec.ts
@@ -123,7 +123,7 @@ describe('FeedVisibilityGuard', () => {
             ).toBe(false);
         });
 
-        it('supports legacy active, approved, published aliases with future expiry', () => {
+        it('supports active, approved, published aliases with future expiry', () => {
             const future = new Date(Date.now() + 3600_000);
             expect(isPublicAdVisible({ status: 'active', isDeleted: false, expiresAt: future })).toBe(true);
             expect(isPublicAdVisible({ status: 'approved', isDeleted: false, expiresAt: future })).toBe(true);

--- a/scripts/sweep-expired-listings.ts
+++ b/scripts/sweep-expired-listings.ts
@@ -1,50 +1,53 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Listing Expiry & Cache Invalidation Sweep Script
  * Esparex Monorepo Maintenance Utility
  * 
  * Usage:
- *   node scripts/sweep-expired-listings.js --dry-run
- *   node scripts/sweep-expired-listings.js --apply
+ *   npx tsx scripts/sweep-expired-listings.ts --dry-run
+ *   npx tsx scripts/sweep-expired-listings.ts --apply
  */
 
-const path = require('path');
-const mongoose = require('mongoose');
+import path from 'path';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import { LISTING_LIFECYCLE_CONSTANTS, LISTING_STATUS } from '@esparex/contracts';
 
-require('dotenv').config({ path: path.resolve(__dirname, '../backend/api/.env') });
-require('dotenv').config({ path: path.resolve(__dirname, '../apps/web/.env.local') });
+dotenv.config({ path: path.resolve(__dirname, '../backend/api/.env') });
+dotenv.config({ path: path.resolve(__dirname, '../apps/web/.env.local') });
 
 const isDryRun = process.argv.includes('--dry-run') || !process.argv.includes('--apply');
 const userMongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/esparex_user';
 const adminMongoUri = process.env.ADMIN_MONGODB_URI || 'mongodb://localhost:27017/esparex_admin';
 const MS_IN_DAY = 24 * 60 * 60 * 1000;
-const THIRTY_DAYS_AGO = new Date(Date.now() - 30 * MS_IN_DAY);
+const THIRTY_DAYS_AGO = new Date(Date.now() - LISTING_LIFECYCLE_CONSTANTS.EXPIRY_DAYS * MS_IN_DAY);
 
-async function sweepDb(mongoUri, label) {
+async function sweepDb(mongoUri: string, label: string): Promise<void> {
     console.log(`\n--- Inspecting Database: ${label} ---`);
     console.log(`URI: ${mongoUri.replace(/:[^:@]+@/, ':****@')}`);
-    let conn;
+    let conn: mongoose.Connection | undefined;
     try {
         conn = await mongoose.createConnection(mongoUri, { serverSelectionTimeoutMS: 5000 }).asPromise();
-        const adsCollection = conn.db.collection('ads');
+        const adsCollection = conn.db?.collection('ads');
+        if (!adsCollection) return;
 
         const pastThirtyDaysFilter = {
-            status: 'live',
+            status: LISTING_STATUS.LIVE,
             createdAt: { $lt: THIRTY_DAYS_AGO }
         };
         const pastThirtyDaysCount = await adsCollection.countDocuments(pastThirtyDaysFilter);
         console.log(`[1] Live ads created > 30 days ago: ${pastThirtyDaysCount}`);
 
         const expiredByDateFilter = {
-            status: 'live',
+            status: LISTING_STATUS.LIVE,
             expiresAt: { $lte: new Date() }
         };
         const expiredByDateCount = await adsCollection.countDocuments(expiredByDateFilter);
         console.log(`[2] Live ads with expiresAt <= now: ${expiredByDateCount}`);
 
         const missingExpiryFilter = {
-            status: 'live',
+            status: LISTING_STATUS.LIVE,
             expiresAt: null
         };
         const missingExpiryCount = await adsCollection.countDocuments(missingExpiryFilter);
@@ -52,7 +55,7 @@ async function sweepDb(mongoUri, label) {
 
         if (!isDryRun) {
             const combinedExpireFilter = {
-                status: 'live',
+                status: LISTING_STATUS.LIVE,
                 $or: [
                     { createdAt: { $lt: THIRTY_DAYS_AGO } },
                     { expiresAt: { $lte: new Date() } }
@@ -63,24 +66,24 @@ async function sweepDb(mongoUri, label) {
                 combinedExpireFilter,
                 {
                     $set: {
-                        status: 'expired',
+                        status: LISTING_STATUS.EXPIRED,
                         isSpotlight: false,
                         isChatLocked: true,
                         updatedAt: new Date()
                     }
                 }
             );
-            console.log(`✅ [${label}] Transitioned ${expireResult.modifiedCount} ads to status: 'expired'`);
+            console.log(`✅ [${label}] Transitioned ${expireResult.modifiedCount} ads to status: '${LISTING_STATUS.EXPIRED}'`);
 
             const remainingLiveMissingExpiry = {
-                status: 'live',
+                status: LISTING_STATUS.LIVE,
                 expiresAt: null
             };
             const populateResult = await adsCollection.updateMany(
                 remainingLiveMissingExpiry,
                 {
                     $set: {
-                        expiresAt: new Date(Date.now() + 30 * MS_IN_DAY),
+                        expiresAt: new Date(Date.now() + LISTING_LIFECYCLE_CONSTANTS.EXPIRY_DAYS * MS_IN_DAY),
                         updatedAt: new Date()
                     }
                 }
@@ -90,17 +93,17 @@ async function sweepDb(mongoUri, label) {
             }
         }
     } catch (error) {
-        console.warn(`⚠️ [${label}] Connection/Sweep error: ${error.message}`);
+        console.warn(`⚠️ [${label}] Connection/Sweep error: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
         if (conn) await conn.close();
     }
 }
 
-async function clearRedisCaches() {
+async function clearRedisCaches(): Promise<void> {
     const redisUrl = process.env.REDIS_URL;
     if (!redisUrl) return;
     try {
-        const Redis = require('ioredis');
+        const { default: Redis } = await import('ioredis');
         const redis = new Redis(redisUrl, { lazyConnect: true, maxRetriesPerRequest: 1, connectTimeout: 4000 });
         await redis.connect();
         const keys = await redis.keys('home_feed:*');
@@ -114,11 +117,11 @@ async function clearRedisCaches() {
         }
         await redis.quit();
     } catch (e) {
-        console.warn(`⚠️ Redis cache flush note: ${e.message}`);
+        console.warn(`⚠️ Redis cache flush note: ${e instanceof Error ? e.message : String(e)}`);
     }
 }
 
-async function run() {
+async function run(): Promise<void> {
     console.log('\n======================================================');
     console.log(`  Esparex Listing Expiry Sweep (${isDryRun ? 'DRY RUN' : 'APPLY MODE'})`);
     console.log('======================================================\n');
@@ -135,4 +138,4 @@ async function run() {
     console.log('\n======================================================\n');
 }
 
-run();
+void run();


### PR DESCRIPTION
## Summary

This pull request resolves listing lifecycle synchronization and UI polish across the marketplace:
1. **Listing Lifecycle Invariant & Sweep**:
   - Enforces a strict 30-day listing lifecycle standard in `@esparex/contracts` (`LISTING_LIFECYCLE_CONSTANTS.EXPIRY_DAYS = 30`).
   - Ensures `expiresAt` defaults to `now + 30 days` on creation and resets on reactivation across Mongoose schemas and domain services (`AdStatusService`).
   - Adds automated operational sweep utility (`scripts/sweep-expired-listings.js`) to transition expired live listings (`expiresAt < now`) to `expired` status and flush Redis caches.
2. **Feed Visibility & Invariant Tests**:
   - Updates `FeedVisibilityGuard` unit test matrix to enforce that listings with past `expiresAt` dates or `status: 'expired'` are never returned in public search/feed queries.
3. **Cookie Consent & Typography Polish**:
   - Modernizes `CookieConsentBanner.tsx` with high-density glassmorphic styling, semantic design tokens, and visible focus management.
   - Normalizes marketplace typography and detail slug helpers across `apps/web`.

---

## Repository Impact Statement

```text
Repository Impact Statement
---------------------------
Problem: Stale listings remaining in feeds past expiry & non-standard cookie toast UI.
Existing SSOT: @esparex/contracts lifecycle enums & @esparex/design-tokens.
New Files: 1 (scripts/sweep-expired-listings.js)
Existing Files Modified: 15
Duplicate Risk: None
Reason: Extending existing lifecycle service and design token architecture.
