### PR TITLE
chore(ci): configure dependabot non-breaking semver grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,20 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      dependencies:
+      non-breaking:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### Summary of Changes
- Configured `.github/dependabot.yml` to group `minor` and `patch` updates for `npm` and `github-actions`.
- Prevents uncoordinated bundling of breaking major version updates into giant monolithic PRs.

### Verification
- [x] `npm run repo:gate` — 100% PASS (18/18 checks)