### PR TITLE
fix(maintenance): fix expiry sweep script constant and add unit tests for ListingExpiryService

### DIFF
--- a/core/src/__tests__/services/ListingExpiryService.spec.ts
+++ b/core/src/__tests__/services/ListingExpiryService.spec.ts
@@ -1,0 +1,103 @@
+import { ListingExpiryService } from '../../services/lifecycle/ListingExpiryService';
+import { LISTING_STATUS, ACTOR_TYPE } from '@esparex/contracts';
+import { mutateStatusesBulk } from '../../services/lifecycle/StatusMutationService';
+import { lifecycleEvents } from '../../events';
+
+jest.mock('../../composition/listings', () => {
+    const mockRepo = {
+        find: jest.fn(),
+        updateMany: jest.fn(),
+    };
+    const mockCache = {
+        invalidateAdFeedCaches: jest.fn(),
+    };
+    return {
+        getListingRepository: () => mockRepo,
+        getListingsCache: () => mockCache,
+    };
+});
+
+jest.mock('../../services/lifecycle/StatusMutationService', () => ({
+    mutateStatusesBulk: jest.fn(),
+}));
+
+jest.mock('../../events', () => ({
+    lifecycleEvents: {
+        dispatch: jest.fn(),
+    },
+}));
+
+describe('ListingExpiryService', () => {
+    let mockRepo: any;
+    let mockCache: any;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        const { getListingRepository, getListingsCache } = await import('../../composition/listings');
+        mockRepo = getListingRepository();
+        mockCache = getListingsCache();
+    });
+
+    it('returns zero counts when no listings are expired', async () => {
+        mockRepo.find.mockResolvedValue([]);
+
+        const result = await ListingExpiryService.runSweep(new Date());
+
+        expect(result).toEqual({
+            expiredCount: 0,
+            touchedCount: 0,
+            listingIds: [],
+        });
+        expect(mockRepo.updateMany).not.toHaveBeenCalled();
+        expect(mutateStatusesBulk).not.toHaveBeenCalled();
+        expect(lifecycleEvents.dispatch).not.toHaveBeenCalled();
+        expect(mockCache.invalidateAdFeedCaches).not.toHaveBeenCalled();
+    });
+
+    it('successfully transitions expired listings, clears spotlight, locks chat, dispatches events, and invalidates caches', async () => {
+        const now = new Date('2026-08-31T12:00:00Z');
+        const mockExpiring = [
+            { id: 'ad-1', title: 'Ad 1', expiresAt: new Date('2026-08-30T12:00:00Z') },
+            { id: 'ad-2', title: 'Ad 2', expiresAt: new Date('2026-08-25T12:00:00Z') },
+        ];
+
+        mockRepo.find.mockResolvedValue(mockExpiring);
+        mockRepo.updateMany.mockResolvedValue({ modifiedCount: 2 });
+        (mutateStatusesBulk as jest.Mock).mockResolvedValue(2);
+
+        const result = await ListingExpiryService.runSweep(now);
+
+        expect(mockRepo.find).toHaveBeenCalledWith({
+            status: LISTING_STATUS.LIVE,
+            expiresAt: { $lte: now },
+            isDeleted: false,
+        });
+
+        expect(mockRepo.updateMany).toHaveBeenCalledWith(
+            { ids: ['ad-1', 'ad-2'] },
+            { isSpotlight: false, isChatLocked: true }
+        );
+
+        expect(mutateStatusesBulk).toHaveBeenCalledWith(
+            'ad',
+            ['ad-1', 'ad-2'],
+            LISTING_STATUS.EXPIRED,
+            { type: ACTOR_TYPE.SYSTEM, id: 'listing_expiry_cron' },
+            'Automated expiry'
+        );
+
+        expect(lifecycleEvents.dispatch).toHaveBeenCalledWith('listing.expired.bulk', {
+            count: 2,
+            listingIds: ['ad-1', 'ad-2'],
+            source: 'ListingExpiryService',
+        });
+
+        expect(mockCache.invalidateAdFeedCaches).toHaveBeenCalled();
+
+        expect(result).toEqual({
+            expiredCount: 2,
+            touchedCount: 2,
+            listingIds: ['ad-1', 'ad-2'],
+        });
+    });
+});

--- a/scripts/sweep-expired-listings.ts
+++ b/scripts/sweep-expired-listings.ts
@@ -12,7 +12,7 @@
 import path from 'path';
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
-import { LISTING_LIFECYCLE_CONSTANTS, LISTING_STATUS } from '@esparex/contracts';
+import { LISTING_STATUS } from '@esparex/contracts';
 
 dotenv.config({ path: path.resolve(__dirname, '../backend/api/.env') });
 dotenv.config({ path: path.resolve(__dirname, '../apps/web/.env.local') });
@@ -21,7 +21,8 @@ const isDryRun = process.argv.includes('--dry-run') || !process.argv.includes('-
 const userMongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/esparex_user';
 const adminMongoUri = process.env.ADMIN_MONGODB_URI || 'mongodb://localhost:27017/esparex_admin';
 const MS_IN_DAY = 24 * 60 * 60 * 1000;
-const THIRTY_DAYS_AGO = new Date(Date.now() - LISTING_LIFECYCLE_CONSTANTS.EXPIRY_DAYS * MS_IN_DAY);
+const EXPIRY_DAYS = 30;
+const THIRTY_DAYS_AGO = new Date(Date.now() - EXPIRY_DAYS * MS_IN_DAY);
 
 async function sweepDb(mongoUri: string, label: string): Promise<void> {
     console.log(`\n--- Inspecting Database: ${label} ---`);
@@ -38,6 +39,10 @@ async function sweepDb(mongoUri: string, label: string): Promise<void> {
         };
         const pastThirtyDaysCount = await adsCollection.countDocuments(pastThirtyDaysFilter);
         console.log(`[1] Live ads created > 30 days ago: ${pastThirtyDaysCount}`);
+        if (pastThirtyDaysCount > 0) {
+            const oldAds = await adsCollection.find(pastThirtyDaysFilter, { projection: { title: 1, listingType: 1, createdAt: 1, approvedAt: 1, expiresAt: 1, status: 1 } }).toArray();
+            console.log('    Details:', JSON.stringify(oldAds, null, 2));
+        }
 
         const expiredByDateFilter = {
             status: LISTING_STATUS.LIVE,


### PR DESCRIPTION
## Summary

This PR addresses maintenance tooling and test coverage for the listing expiry lifecycle:
- **Maintenance Script**: Fixed undefined `LISTING_LIFECYCLE_CONSTANTS.EXPIRY_DAYS` constant in `scripts/sweep-expired-listings.ts` and enhanced dry-run diagnostics to output detailed listing metadata.
- **Unit Testing**: Added dedicated test suite `core/src/__tests__/services/ListingExpiryService.spec.ts` testing automated status transitions, spotlight removal, chat lock, event dispatching, and cache invalidation.

## Verification
- Monorepo Type Check: `npm run type-check` passed cleanly (0 errors).
- Core Unit Tests: `npm test -w @esparex/core` passed (69/69 suites, 379/379 tests).
- Pre-push quality, hygiene, and secret guards passed.