### PR TITLE
fix(location): preserve exact browser GPS coordinates and eliminate snapping distortion

### DIFF
--- a/core/src/__tests__/services/LocationService.spec.ts
+++ b/core/src/__tests__/services/LocationService.spec.ts
@@ -134,6 +134,7 @@ describe("locationService regression", () => {
         expect(result?.state).toBe("Andhra Pradesh");
         expect(result?.locationId).toBe("65f0a1b2c3d4e5f607182930");
         expect(result?.name).toBe("Macherla");
+        expect(result?.coordinates?.coordinates).toEqual([79.44, 16.48]);
     });
 
     it("reverseGeocode uses the nearest settlement-level canonical match without tiered area gating", async () => {

--- a/core/src/__tests__/services/ReverseGeocodeService.spec.ts
+++ b/core/src/__tests__/services/ReverseGeocodeService.spec.ts
@@ -27,24 +27,27 @@ describe('ReverseGeocodeService', () => {
         (setCache as jest.Mock).mockResolvedValue(undefined);
     });
 
-    describe('haversineDistance logic and snapping', () => {
-        it('should correctly calculate haversine distance between Mumbai coords and snap', async () => {
-            // Simulated Mumbai coords: 19.0760, 72.8777
-            // Target city coords: 19.0800, 72.8800 (very close)
+    describe('haversineDistance logic and exact GPS coordinate preservation', () => {
+        it('should correctly calculate haversine distance between coords', async () => {
             const lat1 = 19.0760;
             const lon1 = 72.8777;
             const lat2 = 19.0800;
             const lon2 = 72.8800;
 
             const distance = haversineDistance(lat1, lon1, lat2, lon2);
-            expect(distance).toBeLessThan(7.5); // Should be well within 7.5km
+            expect(distance).toBeLessThan(7.5);
         });
 
-        it('should snap coordinates to the nearest settlement if within 7.5km', async () => {
+        it('should preserve exact input GPS coordinates when a settlement is matched (even 6-7 km away)', async () => {
             const inputLat = 19.0760;
             const inputLng = 72.8777;
-            const cityCenterLat = 19.0800;
-            const cityCenterLng = 72.8800;
+            // Settlement located ~6.8km away
+            const cityCenterLat = 19.0200;
+            const cityCenterLng = 72.8500;
+
+            const distance = haversineDistance(inputLat, inputLng, cityCenterLat, cityCenterLng);
+            expect(distance).toBeGreaterThan(6.0);
+            expect(distance).toBeLessThan(7.5);
 
             (AdminBoundary.find as jest.Mock).mockReturnValue({
                 select: jest.fn().mockReturnValue({
@@ -77,21 +80,17 @@ describe('ReverseGeocodeService', () => {
             expect(result).toBeDefined();
             expect(result?.city).toBe('Mumbai');
             
-            // The coordinates should be SNAPPED to the city center, not the input
-            expect(result?.coordinates?.coordinates[0]).toBe(cityCenterLng);
-            expect(result?.coordinates?.coordinates[1]).toBe(cityCenterLat);
-            expect(result?.isSnapped).toBe(true);
+            // The coordinates MUST PRESERVE the input GPS coordinates, NOT city center
+            expect(result?.coordinates?.coordinates[0]).toBe(inputLng);
+            expect(result?.coordinates?.coordinates[1]).toBe(inputLat);
+            expect(result?.isSnapped).toBe(false);
         });
 
-        it('should NOT snap coordinates if distance > 7.5km', async () => {
-            const inputLat = 19.0760;
-            const inputLng = 72.8777;
-            // Place city center 20km away
-            const cityCenterLat = 19.2000;
-            const cityCenterLng = 72.9000;
-
-            const dist = haversineDistance(inputLat, inputLng, cityCenterLat, cityCenterLng);
-            expect(dist).toBeGreaterThan(7.5);
+        it('should accurately preserve reproduced coordinates (lat = 16.4812, lng = 79.4412)', async () => {
+            const inputLat = 16.4812;
+            const inputLng = 79.4412;
+            const settlementLat = 16.5300;
+            const settlementLng = 79.4000;
 
             (AdminBoundary.find as jest.Mock).mockReturnValue({
                 select: jest.fn().mockReturnValue({
@@ -102,11 +101,13 @@ describe('ReverseGeocodeService', () => {
             (Location.findOne as jest.Mock).mockReturnValue({
                 select: jest.fn().mockReturnValue({
                     lean: jest.fn().mockResolvedValue({
-                        _id: 'mock_city_id',
-                        name: 'Far City',
+                        _id: 'mock_macherla_id',
+                        name: 'Macherla',
+                        city: 'Macherla',
+                        state: 'Andhra Pradesh',
                         country: 'India',
                         level: 'city',
-                        coordinates: { type: 'Point', coordinates: [cityCenterLng, cityCenterLat] },
+                        coordinates: { type: 'Point', coordinates: [settlementLng, settlementLat] },
                         isActive: true
                     })
                 })
@@ -121,12 +122,9 @@ describe('ReverseGeocodeService', () => {
             const result = await reverseGeocode(inputLat, inputLng);
 
             expect(result).toBeDefined();
-            expect(result?.city).toBe('Far City');
-            
-            // The coordinates should REMAIN the input, NOT snapped
-            expect(result?.coordinates?.coordinates[0]).toBe(inputLng);
-            expect(result?.coordinates?.coordinates[1]).toBe(inputLat);
-            expect(result?.isSnapped).toBeUndefined();
+            expect(result?.name).toBe('Macherla');
+            expect(result?.coordinates?.coordinates).toEqual([79.4412, 16.4812]);
+            expect(result?.isSnapped).toBe(false);
         });
     });
 });

--- a/core/src/services/location/ReverseGeocodeService.ts
+++ b/core/src/services/location/ReverseGeocodeService.ts
@@ -26,7 +26,6 @@ import type {
 } from './_shared/locationServiceBase';
 export { normalizeGeoPoint, normalizeCoordinates } from './_shared/locationServiceBase';
 
-const SNAP_THRESHOLD_KM = 7.5; // Confidence radius for snapping to city center
 const resolveBoundaryMatch = async (lat: number, lng: number): Promise<NormalizedLocationResponse | null> => {
     const point = { type: 'Point', coordinates: [lng, lat] as [number, number] };
     const boundaries = await adminBoundaryRepository.findBoundaries({
@@ -76,26 +75,20 @@ const resolveBoundaryMatch = async (lat: number, lng: number): Promise<Normalize
         const cityCoords = (nearestCity.coordinates as GeoJSONPoint)?.coordinates;
         if (cityCoords) {
             const distance = haversineDistance(lat, lng, cityCoords[1], cityCoords[0]);
-            if (distance <= SNAP_THRESHOLD_KM) {
-                logger.info('Snapping coordinates to nearest city center.', { 
-                    city: nearestCity.name, 
-                    distance: distance.toFixed(2),
-                    from: { lat, lng },
-                    to: { lat: cityCoords[1], lng: cityCoords[0] }
-                });
-                // Update local coordinates to match canonical city center
-                lat = cityCoords[1];
-                lng = cityCoords[0];
-            }
+            logger.info('Reverse geocode matched nearest settlement in boundary.', { 
+                city: nearestCity.name, 
+                distanceKm: Number(distance.toFixed(2)),
+                inputCoordinates: { lat, lng },
+                settlementCoordinates: { lat: cityCoords[1], lng: cityCoords[0] }
+            });
         }
 
         const [mappedCity] = await mapLocationDocsToResponses([nearestCity]);
         if (mappedCity) {
-            const isSnapped = lat === cityCoords?.[1] && lng === cityCoords?.[0];
             return {
                 ...mappedCity,
                 coordinates: { type: 'Point', coordinates: [lng, lat] },
-                isSnapped: isSnapped
+                isSnapped: false
             } as NormalizedLocationResponse;
         }
     }
@@ -105,7 +98,8 @@ const resolveBoundaryMatch = async (lat: number, lng: number): Promise<Normalize
     if (mappedState) {
         return {
             ...mappedState,
-            coordinates: { type: 'Point', coordinates: [lng, lat] }
+            coordinates: { type: 'Point', coordinates: [lng, lat] },
+            isSnapped: false
         };
     }
     return null;
@@ -180,18 +174,10 @@ export const reverseGeocode = async (
 
     const finalResponse = {
         ...response,
-        coordinates: { type: 'Point', coordinates: [lng, lat] as [number, number] }
+        coordinates: { type: 'Point', coordinates: [lng, lat] as [number, number] },
+        isSnapped: false
     } as NormalizedLocationResponse;
 
-    const candidateCoords = (nearest.coordinates as GeoJSONPoint)?.coordinates;
-    if (candidateCoords) {
-        const distance = haversineDistance(lat, lng, candidateCoords[1], candidateCoords[0]);
-        if (distance <= SNAP_THRESHOLD_KM && finalResponse.coordinates) {
-            finalResponse.coordinates.coordinates = [candidateCoords[0], candidateCoords[1]];
-            finalResponse.isSnapped = true;
-        }
-    }
-
     await setCache(cacheKey, finalResponse, CACHE_TTLS.REVERSE_GEOCODE);
-    return finalResponse as NormalizedLocationResponse;
+    return finalResponse;
 };


### PR DESCRIPTION
## Summary
Resolves the issue where detected user locations were shifting by ~7 km away to neighboring city centers.

### Root Cause
In `core/src/services/location/ReverseGeocodeService.ts`, `SNAP_THRESHOLD_KM = 7.5` was actively overwriting the user's valid browser GPS coordinates with the coordinates of the nearest database settlement if within 7.5 km. This caused proximity searches, feed ranking, and UI location display to shift up to 7.5 km away from the user's actual device position.

### Solution
1. **Preserve Exact Coordinates**: Removed destructive coordinate mutation/snapping in `ReverseGeocodeService.ts`. User GPS coordinates are maintained as the immutable source of truth (`coordinates: { type: 'Point', coordinates: [lng, lat] }`).
2. **Metadata Enrichment**: Nearest settlement documents are used exclusively for administrative hierarchy and display metadata (`name`, `city`, `state`, `level`, `display`).
3. **Comprehensive Tests**: Updated `ReverseGeocodeService.spec.ts` and `LocationService.spec.ts` to verify that exact coordinates (including `lat: 16.4812, lng: 79.4412`) are preserved alongside resolved settlement metadata.

### Verification
- `npm test -w @esparex/core` (69/69 test suites pass, 382/382 tests green)
- `npm run type-check` (0 TypeScript errors across all 9 packages)
- `npm run lint:ci` (0 new violations)
- `npm run build` (Production build succeeded cleanly)