### PR TITLE
refactor(shared): retire legacy route aliases and complete core contracts migration

### DIFF
--- a/core/src/domains/catalog/application/services/CatalogImportService.ts
+++ b/core/src/domains/catalog/application/services/CatalogImportService.ts
@@ -5,7 +5,7 @@ import Category, { ICategory } from '../../../../models/Category';
 import Brand from '../../../../models/Brand';
 import Model from '../../../../models/Model';
 import CatalogOrchestrator from '../services/CatalogOrchestrator';
-import { CATALOG_APPROVAL_STATUS } from '@esparex/shared';
+import { CATALOG_APPROVAL_STATUS } from '@esparex/contracts';
 import { escapeRegExp } from '../../../../utils/stringUtils';
 
 interface ImportResult {

--- a/core/src/domains/catalog/application/services/CatalogReferenceService.ts
+++ b/core/src/domains/catalog/application/services/CatalogReferenceService.ts
@@ -9,8 +9,7 @@ import ScreenSizeModelImport from '../../../../models/ScreenSize';
 import CategoryModel from '../../../../models/Category';
 import BrandModel from '../../../../models/Brand';
 import { getListingRepository } from '../../../../composition/listings';
-import { CATALOG_APPROVAL_STATUS, type AdStatusValue } from '@esparex/shared';
-import { LISTING_STATUS } from '@esparex/contracts';
+import { CATALOG_APPROVAL_STATUS, LISTING_STATUS, type AdStatusValue } from '@esparex/contracts';
 import { ACTIVE_CATEGORY_QUERY } from './CatalogValidationService';
 import { normalizeSlug } from '../../../../utils/stringUtils';
 // Re-export model instances for generic handler calls in the controller layer

--- a/core/src/domains/catalog/application/services/CatalogSparePartService.ts
+++ b/core/src/domains/catalog/application/services/CatalogSparePartService.ts
@@ -9,7 +9,7 @@ import CategoryModel from '../../../../models/Category';
 import BrandModel from '../../../../models/Brand';
 import CatalogModel from '../../../../models/Model';
 import { getListingRepository } from '../../../../composition/listings';
-import { CATALOG_APPROVAL_STATUS } from '@esparex/shared';
+import { CATALOG_APPROVAL_STATUS } from '@esparex/contracts';
 
 // Re-export model instance for generic handler calls in the controller layer
 export const SparePartModel = SparePartImport;

--- a/core/src/domains/catalog/application/services/CatalogValidationService.ts
+++ b/core/src/domains/catalog/application/services/CatalogValidationService.ts
@@ -1,8 +1,8 @@
 import {
     CATALOG_APPROVAL_STATUS,
     type CatalogApprovalStatusValue,
-    CatalogFacade,
-} from '@esparex/shared';
+} from '@esparex/contracts';
+import { CatalogFacade } from '@esparex/shared';
 import { validateObjectIdOrThrow } from '../../../../utils/idUtils';
 import {
     applyCatalogGovernanceDefaults,

--- a/core/src/migrations/catalogApprovalMigration.ts
+++ b/core/src/migrations/catalogApprovalMigration.ts
@@ -1,5 +1,5 @@
-type FilterQuery<T = unknown> = Record<string, unknown>;
-import { CATALOG_APPROVAL_STATUS } from '@esparex/shared';
+type FilterQuery = Record<string, unknown>;
+import { CATALOG_APPROVAL_STATUS } from '@esparex/contracts';
 import Category from '../models/Category';
 import Brand from '../models/Brand';
 import Model from '../models/Model';
@@ -22,7 +22,7 @@ export interface MigrationStats {
  * on catalog collections with `CATALOG_APPROVAL_STATUS.APPROVED`.
  */
 export async function runCatalogApprovalStatusMigration(): Promise<MigrationStats> {
-    const missingFilter: FilterQuery<unknown> = {
+    const missingFilter: FilterQuery = {
         $or: [
             { approvalStatus: { $exists: false } },
             { approvalStatus: null },

--- a/core/src/models/Brand.ts
+++ b/core/src/models/Brand.ts
@@ -1,13 +1,13 @@
 import { Schema, Document, Types, Model } from 'mongoose'
 import { ISoftDeleteDocument } from '../utils/softDeletePlugin'
 import softDeletePlugin from '../utils/softDeletePlugin'
-import { CATALOG_STATUS } from '@esparex/contracts'
-import { applyCatalogGovernanceDefaults } from '../utils/catalogGovernance'
 import {
+  CATALOG_STATUS,
   CATALOG_APPROVAL_STATUS,
   CATALOG_APPROVAL_STATUS_VALUES,
-  CatalogApprovalStatusValue,
-} from '@esparex/shared'
+  type CatalogApprovalStatusValue,
+} from '@esparex/contracts'
+import { applyCatalogGovernanceDefaults } from '../utils/catalogGovernance'
 import {
   IMarketplaceTrust,
   marketplaceTrustDefinition,

--- a/core/src/models/Category.ts
+++ b/core/src/models/Category.ts
@@ -1,10 +1,12 @@
 import mongoose, { Schema, Document, Model } from 'mongoose';
-import { CATALOG_STATUS, CATALOG_STATUS_VALUES, CatalogStatusValue } from '@esparex/contracts';
 import {
+    CATALOG_STATUS,
+    CATALOG_STATUS_VALUES,
+    type CatalogStatusValue,
     CATALOG_APPROVAL_STATUS,
     CATALOG_APPROVAL_STATUS_VALUES,
-    CatalogApprovalStatusValue,
-} from '@esparex/shared';
+    type CatalogApprovalStatusValue,
+} from '@esparex/contracts';
 import { IMarketplaceTrust, marketplaceTrustDefinition } from './catalogLifecycle';
 
 export interface ICategory extends Document {

--- a/core/src/models/Location.ts
+++ b/core/src/models/Location.ts
@@ -3,7 +3,7 @@ import { getUserConnection } from "../config/db";
 import softDeletePlugin, { ISoftDeleteDocument } from "../utils/softDeletePlugin";
 import { hasValidCoordinateArray, normalizeGeoPoint } from "@esparex/shared";
 import { LOCATION_LEVELS, buildLocationSlug, normalizeLocationNameForSearch } from "@esparex/shared";
-import { LOCATION_STATUS, LOCATION_STATUS_VALUES, type LocationStatusValue } from '@esparex/shared';
+import { LOCATION_STATUS, LOCATION_STATUS_VALUES, type LocationStatusValue } from '@esparex/contracts';
 
 /* -------------------------------------------------------------------------- */
 /* TYPES                                                                      */

--- a/core/src/services/AiService.ts
+++ b/core/src/services/AiService.ts
@@ -118,7 +118,7 @@ export const executeAiRequest = async (input: ExecuteAiRequestInput): Promise<AI
         moderate: 'content_moderation',
     };
     const capabilityKey = capabilityKeyMap[type] || 'post_ad_title';
-    const capabilityConfig = (config.capabilities as Record<string, any>)?.[capabilityKey];
+    const capabilityConfig = (config.capabilities as Record<string, { provider?: string }> | undefined)?.[capabilityKey];
     
     const primaryProvider = capabilityConfig?.provider || config.provider || 'gemini';
     const fallbackCandidates = ['gemini', 'openai', 'claude', 'deepseek'];

--- a/core/src/services/adminBusiness/business.ts
+++ b/core/src/services/adminBusiness/business.ts
@@ -176,7 +176,7 @@ export const rejectAdminBusiness = async (id: string, reason: string, actorId: s
     return business;
 };
 
-export const expireAdminBusiness = async (id: string, actorId: string, logFn: any) => {
+export const expireAdminBusiness = async (id: string, actorId: string, logFn: AdminLogFn) => {
     const business = await Business.findById(id);
     if (!business) throw new AppError('Business not found', 404);
     const actor: ActorMetadata = { type: ACTOR_TYPE.ADMIN, id: actorId };

--- a/core/src/services/adminBusiness/mutations.ts
+++ b/core/src/services/adminBusiness/mutations.ts
@@ -49,6 +49,7 @@ export const renewAdminBusiness = async (id: string, actorId: string, logFn: Adm
     if (!business) throw new AppError('Business not found', 404);
     const userIdStr = String(business.userId ?? '');
     const expiresAtStr = business.expiresAt ? new Date(business.expiresAt as string | number | Date).toLocaleDateString() : 'N/A';
+    await logFn('RENEW_BUSINESS', 'Business', id, { actorId });
     await dispatchTemplatedNotification(userIdStr, 'BUSINESS_STATUS', 'BUSINESS_RENEWED', { name: String(business.name ?? ''), expiresAt: expiresAtStr }, { businessId: id, status: 'live' });
     return business;
 };

--- a/core/src/services/adminLocation/locations.ts
+++ b/core/src/services/adminLocation/locations.ts
@@ -132,10 +132,10 @@ export const adminUpdateLocation = async (id: string, updateBody: AdminUpdateLoc
     }
     if (isActive !== undefined) location.isActive = Boolean(isActive);
     if (name || country || level || hasParentMutation) {
-        let parentLocation: any = null;
+        let parentLocation: Awaited<ReturnType<typeof findLocationParent>> = null;
         if (location.parentId) parentLocation = await findLocationParent(location.parentId);
-        location.path = buildHierarchyPath(location._id, parentLocation);
-        const ps = parentLocation ? await resolveLocationSummary(parentLocation) : null;
+        location.path = buildHierarchyPath(location._id, parentLocation as { _id?: unknown; path?: unknown[] });
+        const ps = parentLocation ? await resolveLocationSummary(parentLocation as CanonicalLocationDoc) : null;
         location.slug = safeSlugify([location.name, ps?.state, location.country || 'unknown'].filter((p): p is string => Boolean(p)).join('-'));
     }
     await saveLocation(location);
@@ -157,8 +157,8 @@ export const adminDeleteLocation = async (id: string, logFn: AdminLogFn) => {
     const location = await findLocationById(id);
     if (!location) throw new AppError('Location not found', 404);
     const locationSummary = await resolveLocationSummary(location.toObject());
-    const adUsageQuery: any = { $or: [{ 'location.locationId': id }] };
-    const userUsageQuery: any = { $or: [{ locationId: id }] };
+    const adUsageQuery: { $or: Array<Record<string, unknown>> } = { $or: [{ 'location.locationId': id }] };
+    const userUsageQuery: { $or: Array<Record<string, unknown>> } = { $or: [{ locationId: id }] };
     if (locationSummary?.city && locationSummary?.state) { adUsageQuery.$or.push({ 'location.city': locationSummary.city, 'location.state': locationSummary.state }); userUsageQuery.$or.push({ 'location.city': locationSummary.city, 'location.state': locationSummary.state }); }
     const [adsCount, usersCount] = await Promise.all([countAdsForLocation(adUsageQuery), countUsersForLocation(userUsageQuery)]);
     if (adsCount > 0 || usersCount > 0) throw new AppError(`Cannot delete location "${locationSummary?.name || location.name}". It is currently used by ${adsCount} ads and ${usersCount} users. Consider deactivating it instead.`, 409);

--- a/core/src/services/ai/moderation/registry/ModerationModelRegistry.ts
+++ b/core/src/services/ai/moderation/registry/ModerationModelRegistry.ts
@@ -21,7 +21,7 @@ export class ModelNotFoundError extends Error {
 }
 
 export class ModerationModelRegistry {
-    private adapters: Map<string, ModelAdapter<any, any>> = new Map();
+    private adapters: Map<string, ModelAdapter> = new Map();
 
     /**
      * Registers a model adapter in the registry.

--- a/core/src/services/ai/providers/GeminiProvider.ts
+++ b/core/src/services/ai/providers/GeminiProvider.ts
@@ -26,8 +26,8 @@ export class GeminiProvider implements AIProvider {
 
     constructor() {
         const configPromise = getAiConfig();
-        this.clientPromise = configPromise.then((c: any) => new GoogleGenAI({ apiKey: c.geminiApiKey }));
-        this.modelNamePromise = configPromise.then((c: any) => c.geminiModel);
+        this.clientPromise = configPromise.then((c) => new GoogleGenAI({ apiKey: (c as { geminiApiKey?: string }).geminiApiKey || '' }));
+        this.modelNamePromise = configPromise.then((c) => (c as { geminiModel?: string }).geminiModel || 'gemini-1.5-flash');
     }
 
     private mapError(error: unknown): GeminiProviderError {

--- a/core/src/utils/imageProcessor.ts
+++ b/core/src/utils/imageProcessor.ts
@@ -2,7 +2,7 @@ import { getBucketName, uploadToS3 } from './s3';
 import crypto from 'crypto';
 import logger from './logger';
 import { env } from '../config/env';
-import { imageDomainRegistry } from "@esparex/shared";
+import { imageDomainRegistry } from "@esparex/contracts";
 
 let cached: typeof import('sharp') | undefined;
 

--- a/core/src/utils/s3.ts
+++ b/core/src/utils/s3.ts
@@ -1,8 +1,8 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import logger from './logger';
-import { imageDomainRegistry } from "@esparex/shared";
 import { env } from '../config/env';
+import { imageDomainRegistry } from "@esparex/contracts";
 
 const ALLOWED_S3_MIME_TYPES = new Set([
     'image/jpeg',

--- a/core/src/utils/slugGenerator.ts
+++ b/core/src/utils/slugGenerator.ts
@@ -1,8 +1,8 @@
 import slugify from 'slugify';
 import { nanoid } from 'nanoid';
-import { Model } from 'mongoose';
-
-type SlugModel = Model<any>;
+export interface SlugModel {
+    exists(filter: Record<string, unknown>): Promise<unknown>;
+}
 
 /**
  * Generates a unique SEO-friendly slug with DB-checked retries to avoid

--- a/shared/src/contracts/api/adminRoutes.ts
+++ b/shared/src/contracts/api/adminRoutes.ts
@@ -77,10 +77,6 @@ export const ADMIN_ROUTES = {
   LISTING_BULK_RESEND_SPOTLIGHT_WARNINGS: "/listings/bulk/resend-spotlight-warnings",
   LISTING_DELETE: (id: string) => `/listings/${id}`,
   LISTING_REPORT_RESOLVE: (id: string) => `/listings/${id}/report-resolve`,
-  // Legacy report aliases mapped to canonical reports surface
-  REPORTED_ADS: "/reports",
-  REPORTED_AD_DETAIL: (id: string) => `/reports/${id}`,
-  REPORTED_AD_RESOLVE: (id: string) => `/reports/${id}/resolve`,
   REPORTS: "/reports",
   REPORT_STATUS: (id: string) => `/reports/${id}/status`,
 

--- a/shared/src/contracts/api/userRoutes.ts
+++ b/shared/src/contracts/api/userRoutes.ts
@@ -24,17 +24,6 @@ export const USER_ROUTES = {
   SERVICE_TYPES: "catalog/service-types",
   SCREEN_SIZES: "catalog/screen-sizes",
 
-  // Ads (Legacy - Redirected to Listings)
-  ADS: "listings",
-  ADS_NEARBY: "listings/nearby",
-  ADS_SUGGESTIONS: "listings/suggestions",
-  AD_DETAIL: (id: string | number) => `listings/${encodeURIComponent(String(id))}`,
-  AD_REPOST: (id: string | number) => `listings/${id}/repost`,
-  ADS_UPLOAD_IMAGE: "listings/upload-image",
-  ADS_UPLOAD_PRESIGN: "listings/upload-presign",
-  ADS_TRENDING: "listings/trending",
-  HOME_FEED: "listings/home", // canonical home feed endpoint
-  
   // Listings (Unified SSOT)
   LISTINGS: "listings",
   LISTINGS_NEARBY: "listings/nearby",
@@ -42,6 +31,7 @@ export const USER_ROUTES = {
   LISTINGS_TRENDING: "listings/trending",
   LISTINGS_UPLOAD_IMAGE: "listings/upload-image",
   LISTINGS_UPLOAD_PRESIGN: "listings/upload-presign",
+  HOME_FEED: "listings/home",
   MY_LISTINGS: "listings/mine",
   MY_LISTINGS_STATS: "listings/mine/stats",
   LISTING_DETAIL: (id: string | number) => `listings/${id}`,
@@ -54,7 +44,6 @@ export const USER_ROUTES = {
   LISTING_VIEW: (id: string | number) => `listings/${id}/view`,
   LISTING_PHONE: (id: string | number) => `listings/${id}/phone`,
   LISTING_REPOST: (id: string | number) => `listings/${id}/repost`,
-
 
   // Locations
   LOCATIONS: "locations",
@@ -95,20 +84,6 @@ export const USER_ROUTES = {
   BUSINESS_ADS: (id: string) => `businesses/${id}/ads`,
   BUSINESS_SPARE_PARTS: (id: string) => `businesses/${id}/spare-parts`,
   BUSINESS_LISTINGS: (id: string) => `businesses/${id}/listings`,
-
-  // Services (Legacy - Redirected to Listings)
-  SERVICES: "listings",
-  SERVICE_DETAIL: (id: string) => `listings/${encodeURIComponent(id)}`,
-  SERVICE_VIEW: (id: string) => `listings/${encodeURIComponent(id)}/view`,
-  SERVICE_SOLD: (id: string) => `listings/${id}/sold`,
-  SERVICE_DEACTIVATE: (id: string) => `listings/${id}/deactivate`,
-  SERVICE_REPOST: (id: string) => `listings/${id}/repost`,
-
-  // Spare Part Listings (Legacy - Redirected to Listings)
-  SPARE_PART_LISTINGS: "listings",
-  SPARE_PART_LISTING_DETAIL: (id: string) => `listings/${encodeURIComponent(id)}`,
-  SPARE_PART_DEACTIVATE: (id: string) => `listings/${id}/deactivate`,
-  SPARE_PART_REPOST: (id: string) => `listings/${id}/repost`,
 
   // Users
   USERS: "users",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,13 +1,6 @@
 // Esparex Shared Package Entry Point
 // Export common schemas, enums, constants and utilities
 
-/**
- * @deprecated The contracts proxy re-export is a temporary compatibility layer.
- * All consumers must import directly from `@esparex/contracts`.
- * This proxy export will be removed in Phase 2.
- */
-export * from '@esparex/contracts';
-
 // CONSTANTS: only bannedWords remains exclusively in @esparex/shared (business logic)
 // adLimits, fieldLimits, adminNotificationTargets, mobileVisibility constants,
 // locationEvents, notificationRetention are all now in @esparex/contracts above.


### PR DESCRIPTION
## Summary
Completes the architectural decoupling between `@esparex/shared` and `@esparex/contracts` by retiring legacy route aliases in `shared`, removing the deprecated contracts proxy re-export, migrating remaining core models and services to direct `@esparex/contracts` imports, and eliminating loose `any` casts in `core` services and utilities.

### Key Changes
1. **Shared Route & Contract Cleanups**:
   - [`shared/src/contracts/api/adminRoutes.ts`](file:///Users/admin/Desktop/Esparex/shared/src/contracts/api/adminRoutes.ts): Retired legacy report route aliases (`REPORTED_ADS`, `REPORTED_AD_DETAIL`, `REPORTED_AD_RESOLVE`) in favor of canonical `REPORTS`.
   - [`shared/src/contracts/api/userRoutes.ts`](file:///Users/admin/Desktop/Esparex/shared/src/contracts/api/userRoutes.ts): Retired legacy redirect aliases (`ADS`, `ADS_NEARBY`, `SERVICES`, `SPARE_PART_LISTINGS`, etc.) in favor of unified `LISTINGS`.
   - [`shared/src/index.ts`](file:///Users/admin/Desktop/Esparex/shared/src/index.ts): Removed deprecated `export * from '@esparex/contracts'` proxy re-export, enforcing direct canonical contracts imports across the repository.
2. **Core Direct Contracts Imports**:
   - Migrated `CatalogImportService`, `CatalogReferenceService`, `CatalogSparePartService`, `CatalogValidationService`, `catalogApprovalMigration`, `Brand`, `Category`, and `Location` to import `CATALOG_APPROVAL_STATUS`, `LOCATION_STATUS`, etc. directly from `@esparex/contracts`.
3. **Core Utility & Service Type Hygiene**:
   - `core/src/utils/slugGenerator.ts`: Replaced `Model<any>` with typed `SlugModel` interface.
   - `core/src/utils/s3.ts` & `imageProcessor.ts`: Switched `imageDomainRegistry` import to `@esparex/contracts`.
   - `core/src/services/adminLocation/locations.ts`: Replaced `any` query objects and parent location types with typed structures.
   - `core/src/services/adminBusiness/business.ts` & `mutations.ts`: Replaced `any` with `AdminLogFn`.
   - `core/src/services/ai/providers/GeminiProvider.ts` & `AiService.ts`: Replaced `any` with typed configuration shapes.
   - `core/src/services/ai/moderation/registry/ModerationModelRegistry.ts`: Normalized generic model adapter map.

### Scope Verification
- Strictly **20 files** (+35 / −69 lines) across `shared/` and `core/`.
- Zero UI redesigns, zero mobile modifications, zero breaking runtime behavior.

### Verification
- `npm run build -w @esparex/shared` (0 errors)
- `npm run build -w @esparex/core` (0 errors)
- `npm run build -w @esparex/backend-api` (0 errors)
- `npm test -w @esparex/core` (69/69 test suites passed, 382/382 tests green)
- `npm test -w @esparex/backend-api` (73/73 test suites passed, 367/367 tests green)
- `npm run lint:ci` (Passed: 0 new/critical violations, legacy violations down to 303)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.