### PR TITLE
refactor(web): eliminate any casts and enforce strict types in form image helpers

### DIFF
--- a/apps/web/src/components/user/post-ad/context/types.ts
+++ b/apps/web/src/components/user/post-ad/context/types.ts
@@ -35,7 +35,7 @@ export interface PostAdContextType {
     toggleAllSpareParts: (selectAll: boolean) => void;
     listingImages: ListingImage[];
     addImages: (files: File[]) => void;
-    removeImage: (index: number) => void;
+    removeImage: (indexOrId: string | number) => void;
     setMainImage: (index: number) => void;
     reorderImages: (startIndex: number, endIndex: number) => void;
     listingLocation: ListingLocation | null;

--- a/apps/web/src/components/user/shared/GenericPostForm.tsx
+++ b/apps/web/src/components/user/shared/GenericPostForm.tsx
@@ -22,7 +22,7 @@ interface GenericPostFormProps<TFormValues extends GenericPostFormValues> {
     isEditMode: boolean;
     images: ListingImage[];
     onImageUpload: (files: File[]) => void;
-    onImageRemove: (id: string) => void;
+    onImageRemove: (id: string | number) => void;
     locationDisplay?: string;
     children: ReactNode;
     submitLabel?: string;

--- a/apps/web/src/components/user/shared/ListingForm.tsx
+++ b/apps/web/src/components/user/shared/ListingForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm, useWatch, type FieldValues } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Field } from "@/components/ui/field";
 import { cn } from "@/components/ui/utils";
@@ -27,7 +27,7 @@ export function ListingForm({ config, editId }: { config: ListingFormConfig; edi
     const router = useRouter();
     const [submitted, setSubmitted] = React.useState(false);
 
-    const form = useForm<any>({
+    const form = useForm<FieldValues>({
         resolver: zodResolver(config.schema),
         mode: "onBlur",
         reValidateMode: "onChange",
@@ -83,7 +83,11 @@ export function ListingForm({ config, editId }: { config: ListingFormConfig; edi
         onSubmitted: () => setSubmitted(true),
     });
 
-    const handleRemoveImage = React.useCallback((idOrIndex: string) => {
+    const handleRemoveImage = React.useCallback((idOrIndex: string | number) => {
+        if (typeof idOrIndex === 'number') {
+            removeImage(idOrIndex);
+            return;
+        }
         const indexById = images.findIndex((img) => img.id === idOrIndex);
         if (indexById >= 0) {
             removeImage(indexById);

--- a/apps/web/src/components/user/shared/ListingImagesField.tsx
+++ b/apps/web/src/components/user/shared/ListingImagesField.tsx
@@ -14,7 +14,7 @@ import { ListingImageTile } from "./ListingImageTile";
 interface ListingImagesFieldProps {
     images: ListingImage[];
     onUpload: (files: File[]) => void;
-    onRemove: (idOrIndex: any) => void;
+    onRemove: (idOrIndex: string | number) => void;
     onSetMain?: (index: number) => void;
     onReorder?: (startIndex: number, endIndex: number) => void;
     firstImageBadgeLabel?: string;

--- a/apps/web/src/components/user/shared/useListingFormOrchestration.ts
+++ b/apps/web/src/components/user/shared/useListingFormOrchestration.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import type { UseFormReturn } from "react-hook-form";
+import type { UseFormReturn, FieldValues } from "react-hook-form";
 import { useGenericListingForm } from "@/components/user/shared/useGenericListingForm";
 import { useListingSubmission } from "@/hooks/listings/useListingSubmission";
 import {
@@ -32,10 +32,10 @@ const ServiceListingEditSchema = ServiceListingPayloadSchema.partial({
 
 interface UseListingFormOrchestrationProps {
     config: ListingFormConfig;
-    form: UseFormReturn<any>;
+    form: UseFormReturn<FieldValues>;
     editId?: string;
     loadBrandsForCategory: (categoryId: string) => Promise<void>;
-    loadCatalogItems: (categoryId: string) => Promise<any>;
+    loadCatalogItems: (categoryId: string) => Promise<unknown>;
     onSubmitted: () => void;
 }
 
@@ -87,7 +87,7 @@ export function useListingFormOrchestration({
         onDataLoaded,
     });
 
-    const submitFn = React.useCallback(async (payload: any, options?: { idempotencyKey?: string }) => {
+    const submitFn = React.useCallback(async (payload: Record<string, unknown>, options?: { idempotencyKey?: string }) => {
         if (config.listingType === LISTING_TYPE.SERVICE) {
             if (isEditMode && editId) {
                 return updateServiceListing(editId, {

--- a/apps/web/src/components/user/shared/useListingFormProps.ts
+++ b/apps/web/src/components/user/shared/useListingFormProps.ts
@@ -28,7 +28,7 @@ export function useListingFormProps<TFormValues extends GenericListingFormValues
     form: UseFormReturn<TFormValues>;
     images: ListingImage[];
     onImageUpload: (files: File[]) => void;
-    onImageRemove: (id: string) => void;
+    onImageRemove: (id: string | number) => void;
     isEditMode: boolean;
     isSubmitting: boolean;
     onValidSubmit: (data: TFormValues) => Promise<void | unknown>;

--- a/apps/web/src/hooks/listings/useListingImages.ts
+++ b/apps/web/src/hooks/listings/useListingImages.ts
@@ -105,7 +105,8 @@ export function useListingImages({
         }
     }, [maxImages]);
 
-    const removeImage = useCallback((index: number) => {
+    const removeImage = useCallback((indexOrId: string | number) => {
+        const index = Number(indexOrId);
         setImageUploadError(null);
         setListingImages(prev => {
             const copy = [...prev];

--- a/apps/web/src/lib/api/user/ai.ts
+++ b/apps/web/src/lib/api/user/ai.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api/client';
-import { toApiResult } from '@/lib/api/result';
+import { toApiResult, type ApiResult } from '@/lib/api/result';
 import { API_ROUTES } from '../routes';
 
 export interface AIInput {
@@ -17,7 +17,7 @@ export interface AIOutput {
     [key: string]: unknown;
 }
 
-export const generateAIContent = async (payload: AIInput): Promise<{ data: AIOutput | null; error: any }> => {
+export const generateAIContent = async (payload: AIInput): Promise<ApiResult<AIOutput>> => {
     return await toApiResult<AIOutput>(
         apiClient.post(API_ROUTES.USER.AI_GENERATE, payload, {
             silent: true,

--- a/apps/web/src/types/User.ts
+++ b/apps/web/src/types/User.ts
@@ -1,2 +1,2 @@
 export * from "@esparex/contracts";
-export * from "@esparex/shared";
+


### PR DESCRIPTION
## Summary
Enforces strict typing across web form orchestration helpers and components by replacing loose `any` casts with strongly typed identifiers (`string | number`) in image handlers, typing react-hook-form generics with `FieldValues`, typing AI generation results with `ApiResult<AIOutput>`, and removing deprecated `@esparex/shared` re-exports in user types.

### Key Changes
1. **Form Image Removal Typing (`string | number`)**:
   - [`apps/web/src/components/user/shared/ListingImagesField.tsx`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/shared/ListingImagesField.tsx): Replaced `onRemove: (idOrIndex: any)` with `(idOrIndex: string | number) => void`.
   - [`apps/web/src/components/user/shared/useListingFormProps.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/shared/useListingFormProps.ts): Updated `onImageRemove` to accept `string | number`.
   - [`apps/web/src/components/user/shared/GenericPostForm.tsx`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/shared/GenericPostForm.tsx): Updated `onImageRemove` to accept `string | number`.
   - [`apps/web/src/components/user/shared/ListingForm.tsx`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/shared/ListingForm.tsx): Added numeric/id discrimination branch in `handleRemoveImage`.
   - [`apps/web/src/hooks/listings/useListingImages.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/hooks/listings/useListingImages.ts): Normalized `removeImage` parameter to `(indexOrId: string | number)`.
   - [`apps/web/src/components/user/post-ad/context/types.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/post-ad/context/types.ts): Updated context contract for `removeImage`.
2. **React Hook Form & AI Result Typing**:
   - [`apps/web/src/components/user/shared/useListingFormOrchestration.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/components/user/shared/useListingFormOrchestration.ts): Replaced `useFormReturn<any>` with `useFormReturn<FieldValues>`, replaced `any` payload with `Record<string, unknown>`, and typed catalog loader promise.
   - [`apps/web/src/lib/api/user/ai.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/lib/api/user/ai.ts): Replaced `{ data: AIOutput | null; error: any }` with canonical `ApiResult<AIOutput>`.
   - [`apps/web/src/types/User.ts`](file:///Users/admin/Desktop/Esparex/apps/web/src/types/User.ts): Removed deprecated `export * from "@esparex/shared"`.

### Scope Verification
- Strictly **9 files** (+20 / −15 lines) in `apps/web/`.
- Zero UI redesigns, zero mobile modifications, zero API contract changes.
- 100% backwards-compatible runtime behavior.

### Verification
- `npm run type-check -w @esparex/apps-web` (0 errors)
- `npm run build -w @esparex/apps-web` (Production build passed cleanly, 41/41 static pages generated)
- `npm run lint:ci` (Passed: 0 new/critical violations)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.