### PR TITLE
refactor(admin): enforce strict types on settings tabs and filter toolbar

### DIFF
--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 const port = Number(process.env.ADMIN_FRONTEND_PORT || 3001);
 const baseURL = process.env.ADMIN_FRONTEND_BASE_URL || `http://127.0.0.1:${port}`;
 const isCI = !!process.env.CI;
-const useProdServerInCI = isCI && process.env.PLAYWRIGHT_CI_SERVER_MODE === "prod";
+
 
 export default defineConfig({
   testDir: "./tests",

--- a/apps/admin/src/app/(protected)/(system)/settings/page.tsx
+++ b/apps/admin/src/app/(protected)/(system)/settings/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 
 import Link from "next/link";
-import { Tv } from "lucide-react";
+import { Tv, type LucideIcon } from "lucide-react";
 import { PlatformSettings } from "./components/PlatformSettings";
 import { ModerationSettings } from "./components/ModerationSettings";
 import { PaymentSettings } from "./components/PaymentSettings";
@@ -43,7 +43,7 @@ type SettingsTab =
   | "display-ads"
   | "monetization";
 
-const SETTINGS_TABS: Array<{ key: SettingsTab; label: string; icon: any }> = [
+const SETTINGS_TABS: Array<{ key: SettingsTab; label: string; icon: LucideIcon }> = [
   { key: "platform", label: "Platform", icon: Globe },
   { key: "listing", label: "Listing Rules", icon: ListChecks },
   { key: "moderation", label: "Moderation", icon: Cpu },

--- a/apps/admin/src/app/(protected)/ads/components/AdsFilterToolbarExtras.tsx
+++ b/apps/admin/src/app/(protected)/ads/components/AdsFilterToolbarExtras.tsx
@@ -11,7 +11,7 @@ const SORT_OPTIONS: Array<{ label: string; value: ModerationFilters["sort"] }> =
 
 type AdsFilterToolbarExtrasProps = {
     filters: ModerationFilters;
-    updateFilter: (key: keyof ModerationFilters, value: any) => void;
+    updateFilter: (key: keyof ModerationFilters, value: ModerationFilters[keyof ModerationFilters]) => void;
     clearFilters: () => void;
 };
 

--- a/apps/admin/src/hooks/useAdminLocations.ts
+++ b/apps/admin/src/hooks/useAdminLocations.ts
@@ -35,7 +35,7 @@ type MutableLocationPayload = Partial<Location> & {
 const DEFAULT_LIMIT = 20;
 
 function stripLocationFormHelpers(data: MutableLocationPayload): Partial<Location> {
-    const { selectedStateId: _s, parentId: _p, ...clean } = data;
+    const { selectedStateId: _selectedStateId, parentId: _parentId, ...clean } = data;
     return clean;
 }
 


### PR DESCRIPTION
## Summary
Enforces strict typing and removes dead code across `apps/admin/` by typing settings navigation tabs with `LucideIcon`, typing `updateFilter` parameters in the Ads filter toolbar, removing an unused Playwright CI server variable, and normalizing location mutation payload helpers.

### Key Changes
1. **Admin Settings & Navigation Tabs**:
   - [`apps/admin/src/app/(protected)/(system)/settings/page.tsx`](file:///Users/admin/Desktop/Esparex/apps/admin/src/app/(protected)/(system)/settings/page.tsx): Replaced `icon: any` with `icon: LucideIcon` in `SETTINGS_TABS`.
2. **Ads Filter Toolbar**:
   - [`apps/admin/src/app/(protected)/ads/components/AdsFilterToolbarExtras.tsx`](file:///Users/admin/Desktop/Esparex/apps/admin/src/app/(protected)/ads/components/AdsFilterToolbarExtras.tsx): Replaced `value: any` in `updateFilter` prop with strongly typed `ModerationFilters[keyof ModerationFilters]`.
3. **Location Hook Form Helpers**:
   - [`apps/admin/src/hooks/useAdminLocations.ts`](file:///Users/admin/Desktop/Esparex/apps/admin/src/hooks/useAdminLocations.ts): Renamed unused helper variables from `_s, _p` to canonical `_selectedStateId, _parentId`.
4. **Playwright Config**:
   - [`apps/admin/playwright.config.ts`](file:///Users/admin/Desktop/Esparex/apps/admin/playwright.config.ts): Removed unused `useProdServerInCI` declaration.

### Scope Verification
- Strictly **4 files** (+5 / −5 lines) in `apps/admin/`.
- Zero UI redesigns, zero mobile modifications, zero API contract changes.
- 100% backwards-compatible runtime behavior.

### Verification
- `npm run type-check -w @esparex/apps-admin` (0 errors)
- `npm run build -w @esparex/apps-admin` (Production build passed cleanly, all static/dynamic routes generated)
- `npm run lint:ci` (Passed: 0 new/critical violations)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.