### PR TITLE
refactor(core): enforce strict typing in catalog search and category orchestrator

### DIFF
--- a/core/src/domains/catalog/application/requests/entity.ts
+++ b/core/src/domains/catalog/application/requests/entity.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose';
 import { CATALOG_APPROVAL_STATUS } from '@esparex/contracts';
 import { CATALOG_STATUS } from '@esparex/contracts';
 import { scoreModeratorTrust } from '../services/CatalogSearchGovernanceService';
@@ -56,9 +57,9 @@ export const applyMarketplaceTrustMetadata = (entity: Record<string, unknown>, m
 };
 
 export const ensureEntityActiveAndTrusted = async (
-    entity: { categoryIds?: unknown[]; save: (...args: any[]) => Promise<any>; approvalStatus?: string; isActive?: boolean; status?: string; rejectionReason?: string | null; needsReview?: boolean },
+    entity: { categoryIds?: unknown[]; save: (options?: { session?: ClientSession | null }) => Promise<unknown>; approvalStatus?: string; isActive?: boolean; status?: string; rejectionReason?: string | null; needsReview?: boolean },
     request: { requestCount?: number; categoryId: unknown },
-    session: unknown,
+    session: ClientSession | null | undefined,
     trustParams: { createdCanonicalEntity?: boolean; duplicateResolution?: boolean }
 ): Promise<void> => {
     let needsSave = ensureCatalogActivationFlags(entity);

--- a/core/src/domains/catalog/application/requests/resolvers.ts
+++ b/core/src/domains/catalog/application/requests/resolvers.ts
@@ -27,8 +27,8 @@ export const resolveOrCreateBrand = async (request: ICatalogRequest, session: Cl
             marketplaceTrust: buildApprovalTrustMetadata({ requestCount: request.requestCount, createdCanonicalEntity: true }),
         }], { session });
         return { entityId: created[0]._id as Types.ObjectId, createdCanonicalEntity: true };
-    } catch (error: any) {
-        if (error.code !== 11000) throw error;
+    } catch (error: unknown) {
+        if ((error as { code?: number }).code !== 11000) throw error;
         existingBrand = await Brand.findOne({ canonicalName: requestCanonicalName, ...NON_DELETED_QUERY, approvalStatus: { $in: [CATALOG_APPROVAL_STATUS.APPROVED, CATALOG_APPROVAL_STATUS.PENDING] } }).session(session);
         if (!existingBrand) throw error;
         await ensureEntityActiveAndTrusted(existingBrand, request, session, { createdCanonicalEntity: false });
@@ -56,8 +56,8 @@ export const resolveOrCreateModel = async (request: ICatalogRequest, session: Cl
             marketplaceTrust: buildApprovalTrustMetadata({ requestCount: request.requestCount, createdCanonicalEntity: true }),
         }], { session });
         return { entityId: created[0]._id as Types.ObjectId, createdCanonicalEntity: true };
-    } catch (error: any) {
-        if (error.code !== 11000) throw error;
+    } catch (error: unknown) {
+        if ((error as { code?: number }).code !== 11000) throw error;
         existingModel = await CatalogModel.findOne({ brandId: request.parentBrandId, canonicalName: requestCanonicalName, ...NON_DELETED_QUERY, approvalStatus: { $in: [CATALOG_APPROVAL_STATUS.APPROVED, CATALOG_APPROVAL_STATUS.PENDING] } }).session(session);
         if (!existingModel) throw error;
         await ensureEntityActiveAndTrusted(existingModel, request, session, { createdCanonicalEntity: false });

--- a/core/src/domains/catalog/application/search/search.ts
+++ b/core/src/domains/catalog/application/search/search.ts
@@ -1,4 +1,3 @@
-import type { Model } from 'mongoose';
 import logger from '../../../../utils/logger';
 import { escapeRegExp } from '../../../../utils/stringUtils';
 import type { AtlasCatalogSearchResult, SeoCrawlDecision } from './types';
@@ -52,8 +51,15 @@ export function buildRegexSearchClauses(search: string, searchFields: string[]):
     return clauses;
 }
 
+import type { PipelineStage } from 'mongoose';
+
 export async function tryAtlasCatalogSearch(params: {
-    model: Model<any>;
+    model: {
+        aggregate: (pipeline: PipelineStage[]) => {
+            option: (opts: Record<string, unknown>) => Promise<Array<{ _id: unknown; score?: number }>>;
+        };
+        modelName?: string;
+    };
     query: Record<string, unknown>;
     search: string;
     searchFields: string[];
@@ -78,8 +84,8 @@ export async function tryAtlasCatalogSearch(params: {
             },
         }))).slice(0, MAX_ATLAS_SHOULD_CLAUSES);
 
-        const filterClauses: Record<string, any>[] = [];
-        const mustNotClauses: Record<string, any>[] = [];
+        const filterClauses: Record<string, unknown>[] = [];
+        const mustNotClauses: Record<string, unknown>[] = [];
         const MAPPED_ATLAS_FIELDS = new Set(['isActive', 'isDeleted', 'approvalStatus', 'categoryIds', 'brandId', 'parentModelId', 'variantOfModelId', 'type']);
 
         for (const [key, rawVal] of Object.entries(params.query)) {
@@ -92,23 +98,23 @@ export async function tryAtlasCatalogSearch(params: {
                 const keys = Object.keys(rawVal);
                 if (keys.length === 1) {
                     const op = keys[0];
-                    const opVal = (rawVal as Record<string, any>)[op];
+                    const opVal = (rawVal as Record<string, unknown>)[op];
                     if (op === '$ne') {
                         mustNotClauses.push({ equals: { path: targetPath, value: typeof opVal === 'object' && opVal ? String(opVal) : opVal } });
                     } else if (op === '$in' && Array.isArray(opVal)) {
-                        filterClauses.push({ in: { path: targetPath, value: opVal.map((v: any) => typeof v === 'object' && v ? String(v) : v) } });
+                        filterClauses.push({ in: { path: targetPath, value: opVal.map((v) => typeof v === 'object' && v ? String(v) : v) } });
                     } else if (op === '$nin' && Array.isArray(opVal)) {
-                        mustNotClauses.push({ in: { path: targetPath, value: opVal.map((v: any) => typeof v === 'object' && v ? String(v) : v) } });
+                        mustNotClauses.push({ in: { path: targetPath, value: opVal.map((v) => typeof v === 'object' && v ? String(v) : v) } });
                     }
                 }
             } else if (Array.isArray(rawVal)) {
-                filterClauses.push({ in: { path: targetPath, value: rawVal.map((v: any) => typeof v === 'object' && v ? String(v) : v) } });
+                filterClauses.push({ in: { path: targetPath, value: rawVal.map((v) => typeof v === 'object' && v ? String(v) : v) } });
             } else {
                 filterClauses.push({ equals: { path: targetPath, value: typeof rawVal === 'object' && rawVal ? String(rawVal) : rawVal } });
             }
         }
 
-        const compound: Record<string, any> = { should, minimumShouldMatch: 1 };
+        const compound: Record<string, unknown> = { should, minimumShouldMatch: 1 };
         if (filterClauses.length > 0) compound.filter = filterClauses;
         if (mustNotClauses.length > 0) compound.mustNot = mustNotClauses;
 

--- a/core/src/domains/catalog/application/services/CatalogCategoryService.ts
+++ b/core/src/domains/catalog/application/services/CatalogCategoryService.ts
@@ -28,7 +28,7 @@ const ACTIVE_CATEGORY_QUERY = {
 };
 
 const CACHE_TTL_MS = 60 * 1000;
-let activeCategoryCache: { at: number; categories: any[] } | null = null;
+let activeCategoryCache: { at: number; categories: Array<{ _id: unknown; slug?: string; name?: string }> } | null = null;
 
 const getActiveCategories = async () => {
     const now = Date.now();
@@ -53,7 +53,7 @@ export const clearCategoryCanonicalCache = () => {
 export const resolveEquivalentActiveCategoryIds = async (categoryId: string): Promise<string[]> => {
     if (!mongoose.Types.ObjectId.isValid(categoryId)) return [];
 
-    const sourceCategory = await Category.findById(categoryId).select('_id slug name').lean<any>();
+    const sourceCategory = await Category.findById(categoryId).select('_id slug name').lean<{ _id: unknown; slug?: string; name?: string }>();
     if (!sourceCategory) return [];
 
     const sourceKeys = CatalogFacade.category.normalize.categoryKeys(sourceCategory.slug, sourceCategory.name);
@@ -176,8 +176,8 @@ export const resolveCategoryWithSubcategoryIds = async (
 const CATALOG_COUNT_MAX_TIME_MS = 1500;
 const CATALOG_COUNT_ESTIMATE_MAX_TIME_MS = 1000;
 
-async function countCatalogCollectionSafely(
-    model: MongooseModel<any>,
+async function countCatalogCollectionSafely<T>(
+    model: MongooseModel<T>,
     filter: Record<string, unknown>,
     hint?: Record<string, 1 | -1>
 ): Promise<number> {

--- a/core/src/domains/catalog/application/services/CatalogOrchestrator.ts
+++ b/core/src/domains/catalog/application/services/CatalogOrchestrator.ts
@@ -54,7 +54,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Invalidate catalog caches, optionally scoped by category or brand
      */
-    async invalidateCatalogCache(opts?: { categoryIds?: any[], brandIds?: any[] }) {
+    async invalidateCatalogCache(opts?: { categoryIds?: Array<string | { toString(): string }>, brandIds?: Array<string | { toString(): string }> }) {
         const cleanOpts = opts ? {
             categoryIds: opts.categoryIds ? opts.categoryIds.map(id => String(id)) : undefined,
             brandIds: opts.brandIds ? opts.brandIds.map(id => String(id)) : undefined
@@ -197,7 +197,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Create Category with cache invalidation
      */
-    async createCategory(data: any): Promise<CategoryResult> {
+    async createCategory(data: Parameters<CategoryRepositoryPort['create']>[0]): Promise<CategoryResult> {
         const result = await this.categoryRepository.create(data);
         await this.invalidateCatalogCache({ categoryIds: [result.id] });
         return result as CategoryResult;
@@ -206,7 +206,7 @@ export class CatalogOrchestratorImpl {
     /**
      * Update Category with cache invalidation
      */
-    async updateCategory(id: string, data: any): Promise<CategoryResult | null> {
+    async updateCategory(id: string, data: Parameters<CategoryRepositoryPort['update']>[1]): Promise<CategoryResult | null> {
         const result = await this.categoryRepository.update(id, data);
         if (result) await this.invalidateCatalogCache({ categoryIds: [id] });
         return result as CategoryResult;
@@ -311,7 +311,7 @@ function getServiceInstance(): CatalogOrchestratorImpl {
 export class CatalogOrchestrator {
     private static get instance() { return getServiceInstance(); }
 
-    static async invalidateCatalogCache(opts?: { categoryIds?: any[], brandIds?: any[] }) {
+    static async invalidateCatalogCache(opts?: { categoryIds?: Array<string | { toString(): string }>, brandIds?: Array<string | { toString(): string }> }) {
         return this.instance.invalidateCatalogCache(opts);
     }
     static async cascadeCategoryDelete(categoryId: string, session?: TransactionContext) {
@@ -320,10 +320,10 @@ export class CatalogOrchestrator {
     static async cascadeBrandDelete(brandId: string, session?: TransactionContext) {
         return this.instance.cascadeBrandDelete(brandId, session);
     }
-    static async createCategory(data: any): Promise<CategoryResult> {
+    static async createCategory(data: Parameters<CategoryRepositoryPort['create']>[0]): Promise<CategoryResult> {
         return this.instance.createCategory(data);
     }
-    static async updateCategory(id: string, data: any): Promise<CategoryResult | null> {
+    static async updateCategory(id: string, data: Parameters<CategoryRepositoryPort['update']>[1]): Promise<CategoryResult | null> {
         return this.instance.updateCategory(id, data);
     }
     static async resolveCategoryIdsFromBrand(brandId: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
Enforces strict typing across the Catalog domain application services by replacing loose `any` casts with strongly typed structures in Atlas search compound queries and filter clauses, typing `createCategory` and `updateCategory` with `CategoryRepositoryPort` parameters, typing the active category in-memory cache, and removing unused mongoose imports.

### Key Changes
1. **Atlas Catalog Search Compound Query Typing**:
   - [`core/src/domains/catalog/application/search/search.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/catalog/application/search/search.ts): Replaced `Record<string, any>` with strongly typed `Record<string, unknown>` and typed mapping functions across compound filter/mustNot clauses; removed unused `import type { Model }`.
2. **Category Repository Orchestrator Typing**:
   - [`core/src/domains/catalog/application/services/CatalogOrchestrator.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/catalog/application/services/CatalogOrchestrator.ts): Replaced `data: any` with `Parameters<CategoryRepositoryPort['create']>[0]` and `Parameters<CategoryRepositoryPort['update']>[1]`, and typed cache invalidation identifier arrays.
3. **Category Service In-Memory Cache & Counters**:
   - [`core/src/domains/catalog/application/services/CatalogCategoryService.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/catalog/application/services/CatalogCategoryService.ts): Strongly typed `activeCategoryCache` entries and generic mongoose models in `countCatalogCollectionSafely<T>`.
4. **Catalog Entity Requests & Resolvers**:
   - [`core/src/domains/catalog/application/requests/entity.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/catalog/application/requests/entity.ts) & [`resolvers.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/catalog/application/requests/resolvers.ts): Strongly typed entity metadata and query resolvers.

### Scope Verification
- Strictly **5 files** (+32 / −25 lines) in `core/src/domains/catalog/`.
- Zero UI redesigns, zero mobile modifications, zero API contract changes.
- 100% backwards-compatible runtime behavior.

### Verification
- `npm run type-check -w @esparex/core` (0 errors)
- `npm run build -w @esparex/core` (0 errors)
- `npm run build -w @esparex/backend-api` (0 errors)
- `npm run lint:ci` (Passed: 0 new/critical violations)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.