### PR TITLE
refactor(mobile): eliminate redundant try catch logging in listing service

### DIFF
--- a/apps/mobile/src/features/listings/application/ApiListingRepository.ts
+++ b/apps/mobile/src/features/listings/application/ApiListingRepository.ts
@@ -4,7 +4,7 @@ import { CreatedListing } from '../domain/CreatedListing';
 import { ListingMapper } from '../infrastructure/mappers/ListingMapper';
 import { CreatedListingMapper } from '../infrastructure/mappers/CreatedListingMapper';
 import { apiClient } from '../../../infrastructure/api/apiClient';
-import type { Ad } from '@esparex/contracts/src/v1/listings/schema/ad.schema';
+import type { Ad } from '@esparex/contracts';
 import { ListingQueryParams, CreateListingRequest, Category } from '@esparex/contracts';
 import { API_ROUTES } from '@esparex/shared';
 

--- a/apps/mobile/src/features/listings/application/ListingService.ts
+++ b/apps/mobile/src/features/listings/application/ListingService.ts
@@ -6,74 +6,34 @@ export class ListingService {
   constructor(private readonly repository: IListingRepository) {}
 
   public async getMarketplaceFeed(params?: ListingQueryParams): Promise<readonly Listing[]> {
-    try {
-      return await this.repository.getListings(params);
-    } catch (error) {
-      console.error('ListingService.getMarketplaceFeed failed:', error);
-      throw error;
-    }
+    return this.repository.getListings(params);
   }
 
   public async getListingDetails(id: string): Promise<Listing> {
-    try {
-      return await this.repository.getListingById(id);
-    } catch (error) {
-      console.error(`ListingService.getListingDetails failed for ID ${id}:`, error);
-      throw error;
-    }
+    return this.repository.getListingById(id);
   }
 
   public async getMyListings(params?: ListingQueryParams): Promise<readonly Listing[]> {
-    try {
-      return await this.repository.getMyListings(params);
-    } catch (error) {
-      console.error('ListingService.getMyListings failed:', error);
-      throw error;
-    }
+    return this.repository.getMyListings(params);
   }
 
   public async getSavedListings(): Promise<readonly Listing[]> {
-    try {
-      return await this.repository.getSavedListings();
-    } catch (error) {
-      console.error('ListingService.getSavedListings failed:', error);
-      throw error;
-    }
+    return this.repository.getSavedListings();
   }
 
   public async toggleSaveListing(adId: string, isSaved: boolean): Promise<void> {
-    try {
-      return await this.repository.toggleSaveListing(adId, isSaved);
-    } catch (error) {
-      console.error(`ListingService.toggleSaveListing failed for ID ${adId}:`, error);
-      throw error;
-    }
+    return this.repository.toggleSaveListing(adId, isSaved);
   }
 
   public async updateListing(id: string, request: Partial<CreateListingRequest>): Promise<Listing> {
-    try {
-      return await this.repository.update(id, request);
-    } catch (error) {
-      console.error(`ListingService.updateListing failed for ID ${id}:`, error);
-      throw error;
-    }
+    return this.repository.update(id, request);
   }
 
   public async getCategories(): Promise<readonly Category[]> {
-    try {
-      return await this.repository.getCategories();
-    } catch (error) {
-      console.error('ListingService.getCategories failed:', error);
-      throw error;
-    }
+    return this.repository.getCategories();
   }
 
   public async reportListing(adId: string, reason: string, description?: string): Promise<void> {
-    try {
-      return await this.repository.reportListing(adId, reason, description);
-    } catch (error) {
-      console.error(`ListingService.reportListing failed for ID ${adId}:`, error);
-      throw error;
-    }
+    return this.repository.reportListing(adId, reason, description);
   }
 }


### PR DESCRIPTION
## Summary
Cleans up `apps/mobile/src/features/listings/application/` by removing redundant `try/catch (console.error; throw)` boilerplate wrappers across all 8 `ListingService` methods and standardizing `@esparex/contracts` package imports.

### Key Changes
1. **Listing Service Error Flow**:
   - [`apps/mobile/src/features/listings/application/ListingService.ts`](file:///Users/admin/Desktop/Esparex/apps/mobile/src/features/listings/application/ListingService.ts): Removed 40 lines of duplicate try-catch wrapper boilerplate from `getMarketplaceFeed`, `getListingDetails`, `getMyListings`, `getSavedListings`, `toggleSaveListing`, `updateListing`, `getCategories`, and `reportListing`. Domain exceptions now propagate directly to presentation hooks without console spam.
2. **Contracts Package Import Normalization**:
   - [`apps/mobile/src/features/listings/application/ApiListingRepository.ts`](file:///Users/admin/Desktop/Esparex/apps/mobile/src/features/listings/application/ApiListingRepository.ts): Replaced deep path import `@esparex/contracts/src/v1/listings/schema/ad.schema` with canonical root `@esparex/contracts`.

### Scope Verification
- Strictly **2 files** (+9 / −49 lines) in `apps/mobile/`.
- Zero UI redesigns, zero web modifications, zero API contract changes.
- 100% backwards-compatible runtime behavior.

### Verification
- `npm run type-check -w @esparex/apps-mobile` (0 errors)
- `npm test -w @esparex/apps-mobile` (58/58 test suites passed, 210/210 tests green)
- `npm run lint:ci` (Passed: 0 new/critical violations)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.