### PR TITLE
refactor(core): enforce strict typing in ad creation, validation, and sentry

### DIFF
--- a/core/src/adapters/outbound/database/admin/MongoAdminDashboardRepositoryAdapter.ts
+++ b/core/src/adapters/outbound/database/admin/MongoAdminDashboardRepositoryAdapter.ts
@@ -23,6 +23,7 @@ import {
     type DashboardCardAdStatsFacet,
     type RevenueTotalAggItem,
 } from '../../../../domains/admin';
+import type { Model } from 'mongoose';
 import Category from '../../../../models/Category';
 import Brand from '../../../../models/Brand';
 import SparePart from '../../../../models/SparePart';
@@ -169,7 +170,7 @@ export class MongoAdminDashboardRepositoryAdapter implements AdminDashboardRepos
     public async getCatalogEntityCounts(): Promise<Record<string, number>> {
         const nonDeletedFilter = { isDeleted: { $ne: true } };
 
-        const countCollection = async (model: any, name: string): Promise<number> => {
+        const countCollection = async <T>(model: Model<T>, name: string): Promise<number> => {
             try {
                 return await model.countDocuments(nonDeletedFilter).hint({ isDeleted: 1 }).exec();
             } catch (error) {

--- a/core/src/config/sentry.ts
+++ b/core/src/config/sentry.ts
@@ -11,7 +11,8 @@ import * as Sentry from '@sentry/node';
 import { env, isProduction, isDevelopment } from './env';
 import logger from '../utils/logger';
 
-let nodeProfilingIntegration: any = null;
+type SentryIntegration = Parameters<typeof Sentry.addIntegration>[0];
+let nodeProfilingIntegration: (() => SentryIntegration) | null = null;
 try {
     nodeProfilingIntegration = require('@sentry/profiling-node').nodeProfilingIntegration;
 } catch (error) {

--- a/core/src/domains/listings/application/ad/AdCreationService.ts
+++ b/core/src/domains/listings/application/ad/AdCreationService.ts
@@ -93,7 +93,7 @@ const normalizeObjectId = (value: unknown): mongoose.Types.ObjectId | undefined 
     return new mongoose.Types.ObjectId(value);
 };
 
-const extractBusinessLocationId = (business: any): mongoose.Types.ObjectId | undefined => {
+const extractBusinessLocationId = (business: { locationId?: unknown; location?: unknown }): mongoose.Types.ObjectId | undefined => {
     const rawBusinessLocationId =
         business.locationId
         || (typeof business.location === 'object' && business.location
@@ -308,7 +308,7 @@ export class AdCreationService {
                     );
                 }
 
-                payload.serviceTypeIds = resolvedServiceTypes.serviceTypeIds.map((id: any) => id.toString());
+                payload.serviceTypeIds = resolvedServiceTypes.serviceTypeIds.map((id) => String(id));
             }
         }
 
@@ -430,7 +430,7 @@ export class AdCreationService {
         // --- Compute Lightweight Listing Quality Score ---
         if (listingType === LISTING_TYPE.SERVICE) {
             const { calculateServiceQuality } = await import('../../../../utils/serviceQuality');
-            let merged: any = { ...payload };
+            let merged: Record<string, unknown> = { ...payload };
             if (partial && adId) {
                 const existing = await getListingRepository().findById(adId);
                 if (existing) {

--- a/core/src/domains/listings/application/ad/AdValidationService.ts
+++ b/core/src/domains/listings/application/ad/AdValidationService.ts
@@ -9,7 +9,8 @@ import { BusinessErrorCode } from '@esparex/contracts';
 import { 
     DuplicatePayload, 
     DuplicateLookupResult, 
-    CrossUserDuplicateRisk, 
+    CrossUserDuplicateRisk,
+    SelfDuplicateQuery, 
     buildDuplicateFingerprint,
     findExistingSelfDuplicate,
     assessCrossUserDuplicateRisk,
@@ -85,6 +86,7 @@ export {
     type DuplicatePayload,
     type DuplicateLookupResult,
     type CrossUserDuplicateRisk,
+    type SelfDuplicateQuery,
     type DuplicateAwareError,
     buildDuplicateFingerprint,
     findExistingSelfDuplicate,

--- a/core/src/domains/listings/application/ad/ad/AdDetailService.ts
+++ b/core/src/domains/listings/application/ad/ad/AdDetailService.ts
@@ -73,8 +73,6 @@ export const getAnyAdById = async (
     void _requesterId;
     if (!mongoose.Types.ObjectId.isValid(adId)) return null;
 
-    const id = new mongoose.Types.ObjectId(adId);
-
     try {
         const ad = await getListingRepository().findOne({ ids: [adId], isDeleted: { $in: [true, false] } });
         if (!ad) return null;

--- a/core/src/domains/listings/application/ad/ad/AdUpdateService.ts
+++ b/core/src/domains/listings/application/ad/ad/AdUpdateService.ts
@@ -180,7 +180,7 @@ export const updateAdLogic = async (
                              );
                         }
                     }
-                } catch (err: any) {
+                } catch (err: unknown) {
                     logger.error('Failed to dispatch price drop notifications', { error: err, adId });
                 }
             })();

--- a/core/src/domains/listings/application/aggregation/adAggregation/metadata.ts
+++ b/core/src/domains/listings/application/aggregation/adAggregation/metadata.ts
@@ -28,7 +28,7 @@ async function fetchMetadataWithCache<T>(
     const cachedResults = await getMultiCache<T>(cacheKeys);
     const results: T[] = [];
     const missingIds: string[] = [];
-    cachedResults.forEach((val: any, index: any) => {
+    cachedResults.forEach((val, index) => {
         if (val) results.push(val);
         else { const id = idArray[index]; if (id) missingIds.push(id); }
     });


### PR DESCRIPTION
## Summary
Enforces strict typing across core domain services in listing ad creation, validation, update notifications, and sentry integration by eliminating loose `any` casts.

### Key Changes
1. **Ad Creation & Quality Score**:
   - [`AdCreationService.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/listings/application/ad/AdCreationService.ts): Replaced `business: any` with typed `{ locationId?: unknown; location?: unknown }`, mapped serviceTypeIds cleanly without `any`, and typed merged quality payload with `Record<string, unknown>`.
2. **Ad Update & Price Notifications**:
   - [`AdUpdateService.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/listings/application/ad/ad/AdUpdateService.ts): Replaced `catch (err: any)` with `catch (err: unknown)`.
3. **Ad Detail Service**:
   - [`AdDetailService.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/listings/application/ad/ad/AdDetailService.ts): Removed unused `const id = new mongoose.Types.ObjectId(adId)` variable.
4. **Metadata Caching**:
   - [`metadata.ts`](file:///Users/admin/Desktop/Esparex/core/src/domains/listings/application/aggregation/adAggregation/metadata.ts): Eliminated `any` parameters in `cachedResults.forEach`.
5. **Sentry Integration**:
   - [`sentry.ts`](file:///Users/admin/Desktop/Esparex/core/src/config/sentry.ts): Strongly typed `nodeProfilingIntegration` using `Parameters<typeof Sentry.addIntegration>[0]` instead of `any`.
6. **Admin Mongo Dashboard Counts**:
   - [`MongoAdminDashboardRepositoryAdapter.ts`](file:///Users/admin/Desktop/Esparex/core/src/adapters/outbound/database/admin/MongoAdminDashboardRepositoryAdapter.ts): Replaced `model: any` with generic `Model<T>`.

### Scope Verification
- Strictly **7 files** (+12 / −10 lines) in `core/`.
- Zero UI redesigns, zero mobile modifications, zero API contract changes.
- 100% backwards-compatible runtime behavior.

### Verification
- `npm run type-check -w @esparex/core` (0 errors)
- `npm run build -w @esparex/core` (0 errors)
- `npm run build -w @esparex/backend-api` (0 errors)
- `npm run lint:ci` (Passed: 0 new/critical violations)
- `npm run guard:platform-governance` (All 16 governance guards passed cleanly)
- Pre-push fast suite passed cleanly.