### PR TITLE
fix(mobile): stabilize useAuth contract and fix screen test auth dependencies

### DIFF
--- a/apps/mobile/src/features/chat/presentation/screens/__tests__/ConversationListScreen.spec.tsx
+++ b/apps/mobile/src/features/chat/presentation/screens/__tests__/ConversationListScreen.spec.tsx
@@ -19,6 +19,10 @@ jest.mock('lucide-react-native', () => {
   );
 });
 
+jest.mock('../../../../../providers/AuthProvider', () => ({
+  useAuth: () => ({ status: 'authenticated' }),
+}));
+
 import { ConversationListScreen } from '../ConversationListScreen';
 import { useConversations } from '../../hooks/useConversations';
 import { IConversationDTO } from '@esparex/contracts';

--- a/apps/mobile/src/features/user/presentation/screens/__tests__/ProfileScreen.spec.tsx
+++ b/apps/mobile/src/features/user/presentation/screens/__tests__/ProfileScreen.spec.tsx
@@ -19,6 +19,10 @@ jest.mock('lucide-react-native', () => {
   );
 });
 
+jest.mock('../../../../../providers/AuthProvider', () => ({
+  useAuth: () => ({ status: 'authenticated' }),
+}));
+
 import { ProfileScreen } from '../ProfileScreen';
 import { useProfile } from '../../hooks/useProfile';
 import { User } from '@esparex/contracts';

--- a/apps/mobile/src/providers/AuthProvider.tsx
+++ b/apps/mobile/src/providers/AuthProvider.tsx
@@ -92,7 +92,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   );
 };
 
-export const useAuth = () => {
+export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);
   if (!context) {
     throw new Error('useAuth must be used within an AuthProvider');


### PR DESCRIPTION
## Root Cause

`ProfileScreen.spec.tsx` and `ConversationListScreen.spec.tsx` had no
`jest.mock` for `AuthProvider`. Because `useAuth` throws when called outside
a Provider (the canonical contract on `develop`), both specs failed before
any rendering occurred. The anonymous-wall guard in each screen fired instead
of the `isError` / authenticated branches the tests intended to exercise —
producing 7 failures across 3 suites.

A secondary gap: `useAuth` was missing its explicit `: AuthContextType` return-
type annotation, leaving the contract implicit and unverifiable by the compiler.

## Changes

### Phase 1 — Stabilize the `useAuth` contract (`AuthProvider.tsx`)

- Added explicit `: AuthContextType` return type to `useAuth`.
- Confirms the canonical contract: `useAuth` throws `'useAuth must be used
  within an AuthProvider'` when called outside its Provider tree.
- No runtime behaviour change — implementation already threw on `develop`.

### Phase 2 — Fix screen test auth dependencies (2 spec files)

- `ProfileScreen.spec.tsx`: added canonical `jest.mock` for `AuthProvider`
  returning `status: 'authenticated'`.
- `ConversationListScreen.spec.tsx`: same mock added.
- Matches the established pattern in `PostAdScreen.spec.tsx`,
  `ListingDetailsScreen.spec.tsx`, and `SettingsScreen.spec.tsx`.
- All existing assertions are unchanged.

## Validation

| Check | Result |
|---|---|
| `AuthProvider.spec.tsx` | 7 / 7 ✅ |
| `ProfileScreen.spec.tsx` | 3 / 3 ✅ — was 1 / 3 |
| `ConversationListScreen.spec.tsx` | 4 / 4 ✅ — was 0 / 4 |
| Full mobile suite | 210 / 210 · 58 / 58 suites ✅ |
| `npm run type-check` | exit 0 ✅ |
| `npm run build` | exit 0 ✅ |
| Architecture guard | ✅ |
| Type Safety Guard (0 `as any` / `@ts-ignore`) | ✅ |
| Lint + Secret scan + Lockfile | ✅ |

## No Business Logic Changed

All changes are confined to one return-type annotation on a hook and two test
files receiving the missing `jest.mock`. No domain logic, API contracts,
production runtime behaviour, or unrelated code was modified.

## Diff summary

