### PR TITLE
refactor(mobile): audit and hygiene cleanup for Home page flow

### DIFF
--- a/apps/mobile/src/features/listings/application/ApiListingRepository.ts
+++ b/apps/mobile/src/features/listings/application/ApiListingRepository.ts
@@ -35,16 +35,19 @@ export class ApiListingRepository implements IListingRepository {
   }
 
   public async getMyListings(params?: ListingQueryParams): Promise<readonly Listing[]> {
-    const response = await apiClient.get<any>('/listings/mine', { params });
+    const response = await apiClient.get<{
+      data?: { items?: Ad[] } | Ad[];
+      items?: Ad[];
+    } | Ad[]>('/listings/mine', { params });
     const resData = response.data;
-    const items = Array.isArray(resData?.data?.items)
-      ? resData.data.items
+    const items = Array.isArray(resData)
+      ? resData
       : Array.isArray(resData?.data)
       ? resData.data
+      : Array.isArray(resData?.data?.items)
+      ? resData.data.items
       : Array.isArray(resData?.items)
       ? resData.items
-      : Array.isArray(resData)
-      ? resData
       : [];
     return items.map(ListingMapper.mapAdToListing);
   }

--- a/apps/mobile/src/features/listings/application/ApiListingRepository.ts
+++ b/apps/mobile/src/features/listings/application/ApiListingRepository.ts
@@ -4,51 +4,27 @@ import { CreatedListing } from '../domain/CreatedListing';
 import { ListingMapper } from '../infrastructure/mappers/ListingMapper';
 import { CreatedListingMapper } from '../infrastructure/mappers/CreatedListingMapper';
 import { apiClient } from '../../../infrastructure/api/apiClient';
-import type { Ad } from '@esparex/contracts';
+import type { Ad, PaginatedResponse } from '@esparex/contracts';
 import { ListingQueryParams, CreateListingRequest, Category } from '@esparex/contracts';
 import { API_ROUTES } from '@esparex/shared';
 
-interface PaginatedResponse<T> {
-  data: T[];
-  meta: {
-    total: number;
-    page: number;
-  };
-}
-
 export class ApiListingRepository implements IListingRepository {
   public async getListings(params?: ListingQueryParams): Promise<readonly Listing[]> {
-    const queryParams: Record<string, any> = { ...params };
+    const queryParams: Record<string, unknown> = { ...params };
     if (queryParams.search && !queryParams.q) {
       queryParams.q = queryParams.search;
     }
     delete queryParams.search;
 
     const response = await apiClient.get<PaginatedResponse<Ad> | Ad[]>('/listings', { params: queryParams });
-    const resData = response.data as {
-      data?: Ad[] | { items?: Ad[]; ads?: Ad[] };
-      items?: Ad[];
-      ads?: Ad[];
-    } | Ad[];
+    const resData = response.data;
 
-    let items: Ad[] = [];
-    if (Array.isArray(resData)) {
-      items = resData;
-    } else if (resData && typeof resData === 'object') {
-      if ('data' in resData && resData.data) {
-        if (Array.isArray(resData.data)) {
-          items = resData.data;
-        } else if ('items' in resData.data && Array.isArray(resData.data.items)) {
-          items = resData.data.items;
-        } else if ('ads' in resData.data && Array.isArray(resData.data.ads)) {
-          items = resData.data.ads;
-        }
-      } else if ('items' in resData && Array.isArray(resData.items)) {
-        items = resData.items;
-      } else if ('ads' in resData && Array.isArray(resData.ads)) {
-        items = resData.ads;
-      }
-    }
+    const items: Ad[] = Array.isArray(resData)
+      ? resData
+      : Array.isArray(resData?.data)
+      ? resData.data
+      : [];
+
     return items.map(ListingMapper.mapAdToListing);
   }
 

--- a/apps/mobile/src/features/listings/infrastructure/__tests__/ApiListingRepositorySavedAds.spec.ts
+++ b/apps/mobile/src/features/listings/infrastructure/__tests__/ApiListingRepositorySavedAds.spec.ts
@@ -60,4 +60,57 @@ describe('ApiListingRepository - Saved Ads', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith('/users/saved-ads', { adId: 'ad-101' });
   });
+
+  describe('getListings', () => {
+    const mockAds = [
+      {
+        id: 'ad-201',
+        title: 'MacBook Air M2',
+        price: 85000,
+        category: 'Laptops',
+        images: ['https://example.com/macbook.jpg'],
+        createdAt: '2026-08-02T10:00:00Z',
+      },
+    ];
+
+    it('fetches and maps listings from canonical PaginatedResponse shape', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockAds,
+          pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+        },
+      });
+
+      const listings = await repository.getListings({ page: 1 });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/listings', { params: { page: 1 } });
+      expect(listings.length).toBe(1);
+      expect(listings[0].id).toBe('ad-201');
+      expect(listings[0].title).toBe('MacBook Air M2');
+    });
+
+    it('handles direct array response gracefully', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValueOnce({
+        data: mockAds,
+      });
+
+      const listings = await repository.getListings();
+
+      expect(listings.length).toBe(1);
+      expect(listings[0].id).toBe('ad-201');
+    });
+
+    it('translates search param to q for backend query', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValueOnce({
+        data: { success: true, data: mockAds },
+      });
+
+      await repository.getListings({ search: 'MacBook' });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/listings', {
+        params: { q: 'MacBook' },
+      });
+    });
+  });
 });

--- a/apps/mobile/src/features/listings/presentation/screens/MarketplaceScreen.tsx
+++ b/apps/mobile/src/features/listings/presentation/screens/MarketplaceScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
-import { FlatList, RefreshControl, View, Image, TouchableOpacity } from 'react-native';
+import { FlatList, RefreshControl, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Screen, Container, AppText, AppIcon } from '@esparex/mobile-ui';
+import { Screen, Container } from '@esparex/mobile-ui';
 import { base } from '@esparex/design-tokens';
 import { ListingQueryParams, LocationMeta } from '@esparex/contracts';
 import { useListings } from '../hooks/useListings';


### PR DESCRIPTION
## Summary
Comprehensive audit and dead-code removal across the Home page flow (`MarketplaceScreen`), including supporting repositories and DTO types.

## Changes
- **`MarketplaceScreen.tsx`**: Removed 4 unused imports (`Image`, `TouchableOpacity`, `AppText`, `AppIcon`).
- **`ApiListingRepository.ts`**:
  - Replaced redundant local `PaginatedResponse` interface with canonical import from `@esparex/contracts`.
  - Streamlined `getListings()` response parsing to canonical `{ data: Ad[], pagination }` format with array fallback, removing obsolete legacy branches (`{items}`, `{ads}`).
  - Fixed loose `any` type on `queryParams`.
- **`ApiListingRepositorySavedAds.spec.ts`**: Added unit tests for `getListings` covering canonical DTO extraction, array fallback, and `search -> q` parameter mapping.

## Verification
- Monorepo Type Check: `npm run type-check` (passed, 0 errors)
- Monorepo Production Build: `npm run build` (passed, exit code 0)
- Mobile Unit Tests: 20 passed suites, 73 passed tests
- Pre-push architectural guards: 100% green
