### PR TITLE
fix: harden SEO indexing and auth placeholder security

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -39,6 +39,19 @@ const nextConfig = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex, nofollow, noarchive',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default analyze ? withBundleAnalyzer()(nextConfig) : nextConfig;

--- a/apps/admin/src/app/(protected)/(system)/admin-users/page.tsx
+++ b/apps/admin/src/app/(protected)/(system)/admin-users/page.tsx
@@ -111,7 +111,7 @@ export default function AdminUsersPage() {
                                 <input
                                     className="flex-1 rounded-lg border border-slate-300 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-300"
                                     value={permissionsDraft}
-                                    placeholder="users:read, ads:write, ..."
+                                    placeholder="e.g. users:read, listings:write"
                                     onChange={(e) => setPermissionsDraft(e.target.value)}
                                 />
                                 <button
@@ -283,7 +283,7 @@ export default function AdminUsersPage() {
                         submitIcon={UserPlus}
                         secondaryIcon={XCircle}
                         isSubmitting={isMutating}
-                        permissionsPlaceholder="Permissions, comma separated (example: users:read, ads:write)"
+                        permissionsPlaceholder="Comma-separated permission scopes (e.g. users:read, listings:write)"
                         onSubmit={onCreate}
                         onSecondary={() => setShowCreateForm(false)}
                     />

--- a/apps/admin/src/app/(protected)/(system)/settings/components/monetization/CampaignEditModal.tsx
+++ b/apps/admin/src/app/(protected)/(system)/settings/components/monetization/CampaignEditModal.tsx
@@ -141,7 +141,7 @@ export function CampaignEditModal({
                     providerConfig: { ...campaign.providerConfig, googleSlotId: e.target.value },
                   })
                 }
-                placeholder="e.g. 1234567890"
+                placeholder="Google AdSense slot ID"
                 className="w-full h-9 px-3 rounded-xl border border-border bg-card text-caption text-foreground"
               />
             </div>
@@ -173,7 +173,7 @@ export function CampaignEditModal({
                       providerConfig: { ...campaign.providerConfig, bannerTargetUrl: e.target.value },
                     })
                   }
-                  placeholder="https://partner.com"
+                  placeholder="https://advertiser.example.com"
                   className="w-full h-9 px-3 rounded-xl border border-border bg-card text-caption text-foreground"
                 />
               </div>

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -7,7 +7,12 @@ export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Esparex Admin",
-  description: "Admin control plane for Esparex"
+  description: "Admin control plane for Esparex",
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+  },
 };
 
 const geist = Geist({

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -188,7 +188,7 @@ function LoginForm() {
                           <Mail size={18} />
                         </InputPrefix>
                         <Input
-                          placeholder="admin@esparex.com"
+                          placeholder="Your admin email address"
                           type="email"
                           autoComplete="username"
                           className="pl-10"
@@ -252,7 +252,7 @@ function LoginForm() {
                       <FieldControl animateOnError>
                         <InputGroup>
                           <Input
-                            placeholder="000000"
+                            placeholder="6-digit code"
                             inputMode="numeric"
                             autoComplete="one-time-code"
                             disabled={submitting}

--- a/apps/admin/src/app/robots.ts
+++ b/apps/admin/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: '/',
+    },
+  };
+}

--- a/apps/admin/src/components/system/adminUsers/AdminUserFormCard.tsx
+++ b/apps/admin/src/components/system/adminUsers/AdminUserFormCard.tsx
@@ -168,8 +168,9 @@ export function AdminUserFormCard(props: AdminUserFormCardProps) {
                         <input
                             {...register("email")}
                             className={inputClassName}
-                            placeholder="Email"
+                            placeholder="Admin email address"
                             type="email"
+                            autoComplete="email"
                             autoCapitalize="none"
                             autoCorrect="off"
                         />
@@ -181,8 +182,9 @@ export function AdminUserFormCard(props: AdminUserFormCardProps) {
                             <input
                                 {...register("password")}
                                 className={inputClassName}
-                                placeholder="Password"
+                                placeholder="Set initial password"
                                 type="password"
+                                autoComplete="new-password"
                             />
                             <FieldError message={"password" in errors ? errors.password?.message : undefined} />
                         </div>

--- a/apps/admin/src/schemas/admin.schemas.ts
+++ b/apps/admin/src/schemas/admin.schemas.ts
@@ -74,7 +74,7 @@ const permissionsTextSchema = z
                 .map((item) => item.trim())
                 .filter(Boolean)
                 .every((item) => /^[a-z0-9:_-]+$/i.test(item)),
-        'Permissions must be comma-separated values like users:read or ads:write',
+        'Permissions must be comma-separated values like users:read or listings:write',
     );
 
 const adminUserBaseFormSchema = z.object({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint .",
     "lint:image-domains": "node scripts/validate-image-domains.cjs",
     "ci:image-domains": "node scripts/validate-image-domains.cjs",
+    "ci:seo": "node scripts/validate-sitemap.cjs",
     "type-check": "tsc --noEmit",
     "seed:locations:full": "echo \"Moved to backend ops; run from backend package.\" && exit 1",
     "test": "vitest",

--- a/apps/web/scripts/validate-sitemap.cjs
+++ b/apps/web/scripts/validate-sitemap.cjs
@@ -68,7 +68,7 @@ function auditUrlList(urls) {
     let parsed;
     try {
       parsed = new URL(urlStr);
-    } catch (e) {
+    } catch {
       violations.push({ type: 'MALFORMED_URL', url: urlStr, detail: 'Failed to parse URL' });
       continue;
     }
@@ -207,12 +207,12 @@ async function main() {
       const urls = parseUrlsFromXml(response.data);
       console.log(`📊 Found ${urls.length} URLs in sitemap`);
 
-      const { violations, warnings, uniqueUrls } = auditUrlList(urls);
+      const { violations, uniqueUrls } = auditUrlList(urls);
       console.log(`📈 Unique URLs: ${uniqueUrls}`);
 
       if (violations.length > 0) {
         console.error(`\n❌ Found ${violations.length} Critical SEO Violations in Sitemap:`);
-        violations.forEach((v, idx) => {
+        violations.forEach((v) => {
           console.error(`  [${v.type}] ${v.url}: ${v.detail}`);
         });
         process.exit(1);

--- a/apps/web/scripts/validate-sitemap.cjs
+++ b/apps/web/scripts/validate-sitemap.cjs
@@ -1,0 +1,241 @@
+/**
+ * Esparex SEO & Sitemap Automated Validation Tool
+ * Validates canonical URL structure, hostnames, redirects, and indexing exclusion rules.
+ * 
+ * Usage:
+ *   node scripts/validate-sitemap.cjs
+ *   SITEMAP_URL=https://esparex.in/sitemap.xml node scripts/validate-sitemap.cjs
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+
+const projectRoot = path.resolve(__dirname, '..');
+const SITEMAP_TARGET = process.env.SITEMAP_URL || 'https://esparex.in/sitemap.xml';
+
+// Exclusion patterns: paths that must NEVER appear in public sitemap
+const FORBIDDEN_PATTERNS = [
+  /\/account\//i,
+  /\/chat(\/|$)/i,
+  /\/post-(ad|service|spare-part-listing)/i,
+  /\/edit-(ad|service|spare-part)\//i,
+  /\/business\/edit/i,
+  /\/internal\//i,
+  /\/api\//i,
+  /\/search\?/i,
+  /\/browse-(services|spare-parts)/i,
+  /\/spare-parts\//i,
+  /\/category\/mobile-phones/i, // Must use canonical /category/mobiles
+];
+
+// Disallowed hostnames that must NEVER appear in public sitemap
+const FORBIDDEN_HOSTNAMES = [
+  'localhost',
+  'admin.esparex.in',
+  '127.0.0.1',
+  'preview',
+  'staging',
+];
+
+function parseUrlsFromXml(xml) {
+  const urls = [];
+  const locRegex = /<loc>(.*?)<\/loc>/g;
+  let match;
+  while ((match = locRegex.exec(xml)) !== null) {
+    if (match[1]) {
+      urls.push(match[1].trim());
+    }
+  }
+  return urls;
+}
+
+function auditUrlList(urls) {
+  const violations = [];
+  const warnings = [];
+  const seen = new Set();
+  const duplicates = [];
+
+  for (const urlStr of urls) {
+    // 1. Check duplicate
+    if (seen.has(urlStr)) {
+      duplicates.push(urlStr);
+    }
+    seen.add(urlStr);
+
+    // 2. Parse URL
+    let parsed;
+    try {
+      parsed = new URL(urlStr);
+    } catch (e) {
+      violations.push({ type: 'MALFORMED_URL', url: urlStr, detail: 'Failed to parse URL' });
+      continue;
+    }
+
+    // 3. Protocol & Host check
+    if (parsed.protocol !== 'https:') {
+      violations.push({ type: 'INSECURE_PROTOCOL', url: urlStr, detail: `Protocol is ${parsed.protocol}, must be https:` });
+    }
+
+    for (const forbiddenHost of FORBIDDEN_HOSTNAMES) {
+      if (parsed.hostname.includes(forbiddenHost)) {
+        violations.push({ type: 'UNEXPECTED_HOSTNAME', url: urlStr, detail: `Host '${parsed.hostname}' contains forbidden term '${forbiddenHost}'` });
+      }
+    }
+
+    // 4. Query params check
+    if (parsed.search) {
+      violations.push({ type: 'QUERY_STRING_IN_SITEMAP', url: urlStr, detail: `Sitemap entries must not contain query parameters: ${parsed.search}` });
+    }
+
+    // 5. Forbidden private / redirect / internal paths
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      if (pattern.test(parsed.pathname)) {
+        violations.push({ type: 'NON_INDEXABLE_ROUTE', url: urlStr, detail: `Matched forbidden pattern: ${pattern.toString()}` });
+      }
+    }
+
+    // 6. Spare-part-listing slug-id format check
+    if (parsed.pathname.startsWith('/spare-part-listings/')) {
+      const slugParam = parsed.pathname.replace('/spare-part-listings/', '');
+      if (!/-[a-z0-9]+$/i.test(slugParam)) {
+        violations.push({ type: 'SPARE_PART_MISSING_ID', url: urlStr, detail: `Spare part URL '${slugParam}' lacks canonical -{id} suffix` });
+      }
+    }
+  }
+
+  if (duplicates.length > 0) {
+    violations.push({ type: 'DUPLICATE_URLS', url: duplicates.join(', '), detail: `Found ${duplicates.length} duplicate URL(s)` });
+  }
+
+  return { violations, warnings, totalUrls: urls.length, uniqueUrls: seen.size };
+}
+
+function fetchUrl(targetUrl, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const client = targetUrl.startsWith('https') ? https : http;
+    const req = client.get(targetUrl, { headers: { 'User-Agent': 'Esparex-SEO-Auditor/1.0' } }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode, data, headers: res.headers });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      reject(new Error(`Timeout fetching ${targetUrl}`));
+    });
+  });
+}
+
+async function auditLocalSourceFiles() {
+  const issues = [];
+  console.log('🔍 Auditing local static SEO configurations...');
+
+  // 1. Check sitemap.ts
+  const sitemapFile = path.join(projectRoot, 'src/app/sitemap.ts');
+  const sitemapContent = fs.readFileSync(sitemapFile, 'utf8');
+
+  if (sitemapContent.includes('catalog/spare-parts')) {
+    issues.push('sitemap.ts references catalog/spare-parts instead of user listings endpoint');
+  }
+  if (sitemapContent.includes('!part.slug.match')) {
+    issues.push('sitemap.ts contains inverted spare-part regex filter logic');
+  }
+  if (sitemapContent.includes('?limit=1000&page=1') && sitemapContent.includes('${url}?')) {
+    issues.push('sitemap.ts contains possible double ? concatenation');
+  }
+
+  // 2. Check web robots.ts
+  const robotsFile = path.join(projectRoot, 'src/app/robots.ts');
+  const robotsContent = fs.readFileSync(robotsFile, 'utf8');
+  for (const requiredDisallow of ['/account/', '/chat', '/post-spare-part-listing', '/internal/', '/api/']) {
+    if (!robotsContent.includes(requiredDisallow)) {
+      issues.push(`robots.ts missing disallow for ${requiredDisallow}`);
+    }
+  }
+
+  // 3. Check admin indexing protection
+  const adminRobotsFile = path.resolve(projectRoot, '../admin/src/app/robots.ts');
+  if (!fs.existsSync(adminRobotsFile)) {
+    issues.push('apps/admin missing src/app/robots.ts');
+  } else {
+    const adminRobots = fs.readFileSync(adminRobotsFile, 'utf8');
+    if (!adminRobots.includes("disallow: '/'") && !adminRobots.includes('disallow: "/"')) {
+      issues.push("apps/admin robots.ts does not disallow '/'");
+    }
+  }
+
+  const adminConfigFile = path.resolve(projectRoot, '../admin/next.config.mjs');
+  const adminConfig = fs.readFileSync(adminConfigFile, 'utf8');
+  if (!adminConfig.includes('X-Robots-Tag')) {
+    issues.push('apps/admin next.config.mjs missing X-Robots-Tag header');
+  }
+
+  // 4. Check web layout.tsx metadataBase fallback
+  const layoutFile = path.join(projectRoot, 'src/app/layout.tsx');
+  const layoutContent = fs.readFileSync(layoutFile, 'utf8');
+  if (layoutContent.includes("new URL('http://localhost:3000')") || layoutContent.includes('new URL("http://localhost:3000")')) {
+    issues.push('apps/web layout.tsx uses http://localhost:3000 as fallback metadataBase');
+  }
+
+  return issues;
+}
+
+async function main() {
+  console.log('====================================================');
+  console.log('🚀 Esparex SEO & Sitemap Hardening Audit Tool');
+  console.log('====================================================');
+
+  const sourceIssues = await auditLocalSourceFiles();
+  if (sourceIssues.length > 0) {
+    console.error('\n❌ Static Source Audit Violations Found:');
+    sourceIssues.forEach((issue, idx) => {
+      console.error(`  ${idx + 1}. ${issue}`);
+    });
+  } else {
+    console.log('✅ Static Source SEO rules audit: PASSED');
+  }
+
+  console.log(`\n🌐 Attempting live/staged sitemap verification: ${SITEMAP_TARGET}`);
+  try {
+    const response = await fetchUrl(SITEMAP_TARGET, 3000);
+    if (response.statusCode === 200) {
+      console.log(`✅ Sitemap fetched successfully (HTTP 200, length: ${response.data.length} bytes)`);
+      const urls = parseUrlsFromXml(response.data);
+      console.log(`📊 Found ${urls.length} URLs in sitemap`);
+
+      const { violations, warnings, uniqueUrls } = auditUrlList(urls);
+      console.log(`📈 Unique URLs: ${uniqueUrls}`);
+
+      if (violations.length > 0) {
+        console.error(`\n❌ Found ${violations.length} Critical SEO Violations in Sitemap:`);
+        violations.forEach((v, idx) => {
+          console.error(`  [${v.type}] ${v.url}: ${v.detail}`);
+        });
+        process.exit(1);
+      }
+
+      console.log('✅ Live sitemap validation: PASSED with 0 violations!');
+    } else {
+      console.log(`ℹ️  Sitemap endpoint returned status ${response.statusCode} (remote environment may be inactive in offline CI).`);
+    }
+  } catch (err) {
+    console.log(`ℹ️  Live sitemap fetch skipped (${err.message}). Offline source audit was used.`);
+  }
+
+  if (sourceIssues.length > 0) {
+    process.exit(1);
+  }
+
+  console.log('\n====================================================');
+  console.log('🎉 SEO Validation Completed Successfully!');
+  console.log('====================================================\n');
+}
+
+main().catch((err) => {
+  console.error('Fatal SEO Auditor Error:', err);
+  process.exit(1);
+});

--- a/apps/web/scripts/validate-sitemap.cjs
+++ b/apps/web/scripts/validate-sitemap.cjs
@@ -1,7 +1,7 @@
 /**
  * Esparex SEO & Sitemap Automated Validation Tool
  * Validates canonical URL structure, hostnames, redirects, and indexing exclusion rules.
- * 
+ *
  * Usage:
  *   node scripts/validate-sitemap.cjs
  *   SITEMAP_URL=https://esparex.in/sitemap.xml node scripts/validate-sitemap.cjs

--- a/apps/web/src/__tests__/seo-sitemap.spec.ts
+++ b/apps/web/src/__tests__/seo-sitemap.spec.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import sitemap, {
+    sanitiseSlug,
+    buildSitemapApiUrl,
+    formatSitemapDate,
+} from "@/app/sitemap";
+import robots from "@/app/robots";
+
+describe("SEO & Sitemap Hardening Regression Suite", () => {
+    describe("1. sanitiseSlug", () => {
+        it("strips parentheses and characters invalid in RFC 3986 URL paths", () => {
+            expect(sanitiseSlug("iPhone 13 (Pro) Max")).toBe("iphone-13-pro-max");
+            expect(sanitiseSlug("Samsung Galaxy S22+ (Ultra)")).toBe("samsung-galaxy-s22-ultra");
+            expect(sanitiseSlug("Screen & Battery (Original)")).toBe("screen-battery-original");
+        });
+
+        it("collapses multiple dashes and strips leading/trailing dashes", () => {
+            expect(sanitiseSlug("--bad---slug--")).toBe("bad-slug");
+            expect(sanitiseSlug("")).toBe("");
+        });
+    });
+
+    describe("2. buildSitemapApiUrl & Query Parameter Safety (BUG-1)", () => {
+        it("constructs API URLs with proper query params and never produces double '?'", () => {
+            const url = buildSitemapApiUrl("https://api.esparex.in/api/v1", "listings", {
+                listingType: "ad",
+                status: "live",
+            });
+
+            expect(url).not.toContain("??");
+            expect(url).not.toContain("?listingType=ad?limit");
+            expect(url.split("?").length).toBe(2);
+
+            const parsed = new URL(url);
+            expect(parsed.searchParams.get("listingType")).toBe("ad");
+            expect(parsed.searchParams.get("status")).toBe("live");
+            expect(parsed.searchParams.get("limit")).toBe("1000");
+            expect(parsed.searchParams.get("page")).toBe("1");
+        });
+
+        it("handles trailing and leading slashes safely", () => {
+            const url = buildSitemapApiUrl("https://api.esparex.in/api/v1/", "/businesses", {});
+            expect(url).toContain("https://api.esparex.in/api/v1/businesses?");
+            expect(url).not.toContain("v1//businesses");
+        });
+    });
+
+    describe("3. formatSitemapDate", () => {
+        it("formats date to W3C format without milliseconds", () => {
+            const formatted = formatSitemapDate("2026-09-04T10:20:30.123Z");
+            expect(formatted).toBe("2026-09-04T10:20:30Z");
+            expect(formatted).not.toMatch(/\.\d{3}Z$/);
+        });
+    });
+
+    describe("4. Sitemap Generation & Policy Validation", () => {
+        const originalFetch = global.fetch;
+
+        beforeEach(() => {
+            // Mock fetch to simulate API returning live listings
+            global.fetch = vi.fn().mockImplementation(async (url: string) => {
+                if (url.includes("listingType=ad")) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            data: [
+                                { id: "ad-1", seoSlug: "iphone-13", updatedAt: "2026-09-01T00:00:00.000Z" },
+                                { id: "ad-2", seoSlug: "samsung-s21", updatedAt: "2026-09-02T00:00:00.000Z" },
+                            ],
+                        }),
+                    };
+                }
+                if (url.includes("listingType=service")) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            data: [
+                                { id: "srv-1", slug: "screen-repair", updatedAt: "2026-09-01T00:00:00.000Z" },
+                            ],
+                        }),
+                    };
+                }
+                if (url.includes("listingType=spare_part")) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            data: [
+                                { id: "part-1", slug: "oled-display", updatedAt: "2026-09-01T00:00:00.000Z" },
+                                { id: "part-2", slug: "battery-5000mah", updatedAt: "2026-09-02T00:00:00.000Z" },
+                            ],
+                        }),
+                    };
+                }
+                if (url.includes("businesses")) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            data: [
+                                { id: "biz-1", slug: "apex-repairs", updatedAt: "2026-09-01T00:00:00.000Z" },
+                            ],
+                        }),
+                    };
+                }
+                return { ok: false, status: 404 };
+            });
+        });
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+        });
+
+        it("contains all static canonical routes with https://esparex.in base", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            const expectedStatic = [
+                "https://esparex.in",
+                "https://esparex.in/about",
+                "https://esparex.in/contact",
+                "https://esparex.in/faq",
+                "https://esparex.in/how-it-works",
+                "https://esparex.in/privacy",
+                "https://esparex.in/safety-tips",
+                "https://esparex.in/site-map",
+                "https://esparex.in/terms",
+            ];
+
+            for (const expected of expectedStatic) {
+                expect(urls).toContain(expected);
+            }
+        });
+
+        it("excludes redirect-only routes and parameter query search pages", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            expect(urls.some((u) => u.includes("/browse-services"))).toBe(false);
+            expect(urls.some((u) => u.includes("/browse-spare-parts"))).toBe(false);
+            expect(urls.some((u) => u.includes("/spare-parts/"))).toBe(false);
+            expect(urls.some((u) => u.includes("/search?"))).toBe(false);
+        });
+
+        it("excludes private, account, and internal routes", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            expect(urls.some((u) => u.includes("/account"))).toBe(false);
+            expect(urls.some((u) => u.includes("/chat"))).toBe(false);
+            expect(urls.some((u) => u.includes("/post-"))).toBe(false);
+            expect(urls.some((u) => u.includes("/edit-"))).toBe(false);
+            expect(urls.some((u) => u.includes("/internal/"))).toBe(false);
+            expect(urls.some((u) => u.includes("/api/"))).toBe(false);
+        });
+
+        it("never includes admin, staging, preview, or localhost hosts", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            for (const url of urls) {
+                expect(url).not.toContain("localhost");
+                expect(url).not.toContain("admin.esparex.in");
+                expect(url).not.toContain("preview");
+                expect(url).not.toContain("staging");
+                expect(url.startsWith("https://esparex.in")).toBe(true);
+            }
+        });
+
+        it("includes spare-part listings with canonical slug-id format (BUG-2, BUG-6, BUG-8)", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            const sparePartUrls = urls.filter((u) => u.includes("/spare-part-listings/"));
+            expect(sparePartUrls.length).toBeGreaterThan(0);
+            expect(sparePartUrls).toContain("https://esparex.in/spare-part-listings/oled-display-part-1");
+            expect(sparePartUrls).toContain("https://esparex.in/spare-part-listings/battery-5000mah-part-2");
+        });
+
+        it("uses canonical category slugs and avoids redirect aliases", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+
+            // Must use canonical 'mobiles', NOT 'mobile-phones' which issues 301
+            expect(urls).toContain("https://esparex.in/category/mobiles");
+            expect(urls).not.toContain("https://esparex.in/category/mobile-phones");
+            expect(urls).toContain("https://esparex.in/category/tablets");
+            expect(urls).toContain("https://esparex.in/category/laptops");
+            expect(urls).toContain("https://esparex.in/category/spare-parts");
+        });
+
+        it("contains zero duplicate URLs", async () => {
+            const entries = await sitemap();
+            const urls = entries.map((e) => e.url);
+            const uniqueUrls = new Set(urls);
+            expect(urls.length).toBe(uniqueUrls.size);
+        });
+    });
+
+    describe("5. Web Robots Policy", () => {
+        it("explicitly disallows all sensitive and private routes", () => {
+            const result = robots();
+            const rules = result.rules;
+            const disallow = Array.isArray(rules) ? rules[0]?.disallow : rules?.disallow;
+            const disallowList = Array.isArray(disallow) ? disallow : [disallow || ""];
+
+            expect(disallowList).toContain("/account/");
+            expect(disallowList).toContain("/chat");
+            expect(disallowList).toContain("/chat/");
+            expect(disallowList).toContain("/post-ad");
+            expect(disallowList).toContain("/post-service");
+            expect(disallowList).toContain("/post-spare-part-listing");
+            expect(disallowList).toContain("/edit-ad/");
+            expect(disallowList).toContain("/edit-service/");
+            expect(disallowList).toContain("/edit-spare-part/");
+            expect(disallowList).toContain("/business/edit");
+            expect(disallowList).toContain("/internal/");
+            expect(disallowList).toContain("/api/");
+            expect(disallowList).toContain("/admin/");
+
+            expect(result.sitemap).toBe("https://esparex.in/sitemap.xml");
+        });
+    });
+
+    describe("6. Sensitive Form Placeholders Security Verification", () => {
+        const repoRoot = path.resolve(__dirname, "../../../..");
+
+        it("admin login page contains no company email or default OTP placeholders", () => {
+            const loginPath = path.join(repoRoot, "apps/admin/src/app/login/page.tsx");
+            const content = fs.readFileSync(loginPath, "utf8");
+
+            expect(content).not.toContain('placeholder="admin@esparex.com"');
+            expect(content).not.toContain('placeholder="000000"');
+            expect(content).toContain('placeholder="Your admin email address"');
+            expect(content).toContain('placeholder="6-digit code"');
+        });
+
+        it("AdminUserFormCard enforces autoComplete and non-label placeholders", () => {
+            const cardPath = path.join(repoRoot, "apps/admin/src/components/system/adminUsers/AdminUserFormCard.tsx");
+            const content = fs.readFileSync(cardPath, "utf8");
+
+            expect(content).not.toMatch(/placeholder="Password"/);
+            expect(content).toContain('placeholder="Set initial password"');
+            expect(content).toContain('autoComplete="new-password"');
+            expect(content).toContain('placeholder="Admin email address"');
+            expect(content).toContain('autoComplete="email"');
+        });
+
+        it("admin users page and schemas use canonical listings:write instead of ads:write in examples", () => {
+            const pagePath = path.join(repoRoot, "apps/admin/src/app/(protected)/(system)/admin-users/page.tsx");
+            const content = fs.readFileSync(pagePath, "utf8");
+
+            expect(content).not.toContain('placeholder="users:read, ads:write, ..."');
+            expect(content).toContain('placeholder="e.g. users:read, listings:write"');
+        });
+
+        it("campaign settings modal uses safe example.com domain", () => {
+            const modalPath = path.join(repoRoot, "apps/admin/src/app/(protected)/(system)/settings/components/monetization/CampaignEditModal.tsx");
+            const content = fs.readFileSync(modalPath, "utf8");
+
+            expect(content).not.toContain('placeholder="https://partner.com"');
+            expect(content).toContain('placeholder="https://advertiser.example.com"');
+            expect(content).toContain('placeholder="Google AdSense slot ID"');
+        });
+
+        it("user profile email placeholder uses personal generic email", () => {
+            const emailSectionPath = path.join(repoRoot, "apps/web/src/components/user/profile/tabs/PersonalProfileEmailSection.tsx");
+            const content = fs.readFileSync(emailSectionPath, "utf8");
+
+            expect(content).not.toContain('placeholder="name@company.com"');
+            expect(content).toContain('placeholder="your@email.com"');
+        });
+    });
+});

--- a/apps/web/src/__tests__/seo-sitemap.spec.ts
+++ b/apps/web/src/__tests__/seo-sitemap.spec.ts
@@ -163,7 +163,9 @@ describe("SEO & Sitemap Hardening Regression Suite", () => {
                 expect(url).not.toContain("admin.esparex.in");
                 expect(url).not.toContain("preview");
                 expect(url).not.toContain("staging");
-                expect(url.startsWith("https://esparex.in")).toBe(true);
+                const parsedUrl = new URL(url);
+                expect(parsedUrl.protocol).toBe("https:");
+                expect(parsedUrl.hostname).toBe("esparex.in");
             }
         });
 

--- a/apps/web/src/app/(public)/business/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/business/[slug]/page.tsx
@@ -69,6 +69,7 @@ export async function generateMetadata(
     return {
       title: "Business Not Found | Esparex",
       description: "The requested business profile could not be found.",
+      robots: { index: false, follow: false },
     };
   }
 

--- a/apps/web/src/app/(public)/search/page.tsx
+++ b/apps/web/src/app/(public)/search/page.tsx
@@ -39,11 +39,15 @@ export async function generateMetadata(
     };
     const titleDefault = 'Buy Used Electronics & Spare Parts Online India | Esparex';
 
+    const canonicalUrl = searchParams.type
+        ? `https://esparex.in${buildPublicBrowseRoute({ type: parsed.type })}`
+        : 'https://esparex.in/search';
+
     return {
         title: titleMap[parsed.type] ?? titleDefault,
         description: 'Browse thousands of mobile spare parts, used phones, laptops and repair services across India on Esparex.',
         alternates: {
-            canonical: `https://esparex.in${buildPublicBrowseRoute({ type: parsed.type })}`,
+            canonical: canonicalUrl,
         },
         robots: hasFilters ? { index: false, follow: true } : { index: true, follow: true },
     };

--- a/apps/web/src/app/(public)/seller/[id]/page.tsx
+++ b/apps/web/src/app/(public)/seller/[id]/page.tsx
@@ -38,6 +38,7 @@ export async function generateMetadata({
     return {
       title: "Seller Profile | Esparex",
       description: "View verified seller profile and active listings on Esparex.",
+      robots: { index: false, follow: false },
     };
   }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -16,13 +16,22 @@ const metadataBase = (() => {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
     if (appUrl) {
         try {
-            return new URL(appUrl);
+            const parsed = new URL(appUrl);
+            const hostname = parsed.hostname.toLowerCase();
+            if (
+                hostname !== 'admin.esparex.in' &&
+                !hostname.includes('preview') &&
+                !hostname.includes('staging') &&
+                (process.env.NODE_ENV !== 'production' || hostname === 'esparex.in')
+            ) {
+                return parsed;
+            }
         } catch {
-            // Fall through to local default.
+            // Fall through to canonical default.
         }
     }
 
-    return new URL('http://localhost:3000');
+    return new URL('https://esparex.in');
 })();
 
 export const viewport: Viewport = {

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -6,8 +6,19 @@ export default function robots(): MetadataRoute.Robots {
             userAgent: '*',
             allow: '/',
             disallow: [
-                // Account namespace
+                // Account namespace & Messaging
                 '/account/',
+                '/chat',
+                '/chat/',
+                // Actions
+                '/post-ad',
+                '/post-service',
+                '/post-spare-part-listing',
+                '/edit-ad/',
+                '/edit-service/',
+                '/edit-spare-part/',
+                '/business/edit',
+                '/notifications',
                 // Legacy private routes (all have 301 redirects)
                 '/profile/',
                 '/my-ads',
@@ -17,15 +28,10 @@ export default function robots(): MetadataRoute.Robots {
                 '/purchases',
                 '/business/my-business',
                 '/business/register',
-                '/business/edit',
-                // Actions
-                '/post-ad',
-                '/post-service',
-                '/edit-ad/',
-                '/notifications',
-                // System
+                // System & Internal
                 '/api/',
                 '/admin/',
+                '/internal/',
             ],
         },
         sitemap: 'https://esparex.in/sitemap.xml',

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -5,62 +5,109 @@ import {
     API_V1_BASE_PATH,
     DEFAULT_LOCAL_API_ORIGIN,
 } from "@/lib/api/routes";
+import { getCanonicalCategorySlug } from "@/lib/seo/canonicalSlugs";
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 3600; // Cache for 1 hour to reduce latency
 
-const BASE_url = process.env.NEXT_PUBLIC_APP_URL || 'https://esparex.in';
+export const BASE_URL = (() => {
+    const raw = process.env.NEXT_PUBLIC_APP_URL?.trim();
+    if (raw) {
+        try {
+            const parsed = new URL(raw);
+            const hostname = parsed.hostname.toLowerCase();
+            if (
+                hostname !== 'admin.esparex.in' &&
+                !hostname.includes('preview') &&
+                !hostname.includes('staging') &&
+                (process.env.NODE_ENV !== 'production' || hostname === 'esparex.in')
+            ) {
+                return parsed.origin;
+            }
+        } catch {
+            // fall through
+        }
+    }
+    return 'https://esparex.in';
+})();
+
 // Use internal backend URL for faster server-side fetches if available
 const API_URL = process.env.BACKEND_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || `${DEFAULT_LOCAL_API_ORIGIN}${API_V1_BASE_PATH}`;
 
-type SitemapItem = {
+export type SitemapItem = {
     id: string | number;
     slug?: string;
     updatedAt?: string;
 };
 
 /**
- * Sanitises a spare-part/category slug for use in a sitemap URL.
- * Strips parentheses and other characters invalid in RFC 3986 paths.
+ * Sanitises a slug for use in a sitemap URL.
+ * Strips parentheses and characters invalid in RFC 3986 paths.
  */
-function sanitiseSlug(raw: string): string {
+export function sanitiseSlug(raw: string): string {
+    if (!raw) return '';
     return raw
         .toLowerCase()
         .replace(/[()]/g, '')
-        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/[^a-z0-9-]+/g, '-')
         .replace(/-{2,}/g, '-')
         .replace(/^-|-$/g, '');
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === 'object' && value !== undefined;
+    typeof value === 'object' && value !== null;
 
 /**
  * Formats date to W3C format without milliseconds for strict XML parsers (Google standard)
  */
-const formatSitemapDate = (date: string | Date | undefined): string => {
+export const formatSitemapDate = (date: string | Date | undefined): string => {
     const d = date ? new Date(date) : new Date();
-    // Return ISO string without milliseconds: YYYY-MM-DDThh:mm:ssZ
     return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
 };
 
-async function fetchDynamicIds(endpoint: string, key = 'id', slugKey?: string): Promise<SitemapItem[]> {
+/**
+ * Safely constructs URL with query parameters avoiding double-? or malformed query strings
+ */
+export function buildSitemapApiUrl(
+    baseUrl: string,
+    endpoint: string,
+    params: Record<string, string> = {}
+): string {
+    const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+    const urlObj = new URL(cleanEndpoint, base);
+    
+    // Set default pagination parameters
+    urlObj.searchParams.set('limit', '1000');
+    urlObj.searchParams.set('page', '1');
+    
+    for (const [key, value] of Object.entries(params)) {
+        urlObj.searchParams.set(key, value);
+    }
+    return urlObj.toString();
+}
+
+export async function fetchDynamicIds(
+    endpoint: string,
+    params: Record<string, string> = {},
+    key = 'id',
+    slugKey?: string
+): Promise<SitemapItem[]> {
     try {
-        const url = `${API_URL}/${endpoint}`.replace(/([^:]\/)\/+/g, "$1");
-        // Fetch up to 1000 items for sitemap with 10s timeout
-        const res = await fetch(`${url}?limit=1000&page=1`, { 
+        const fullUrl = buildSitemapApiUrl(API_URL, endpoint, params);
+        const res = await fetch(fullUrl, {
             next: { revalidate: 3600 },
             headers: {
                 'Accept': 'application/json',
                 'X-App-Source': 'sitemap-generator'
             }
         });
-        
+
         if (!res.ok) {
             logger.warn(`Sitemap fetch failed for ${endpoint}: ${res.status}`);
             return [];
         }
-        
+
         const data = await res.json();
         // Handle various response formats:
         // 1. { data: [...] } (Standard Paginated)
@@ -74,7 +121,7 @@ async function fetchDynamicIds(endpoint: string, key = 'id', slugKey?: string): 
             if (!isRecord(item)) {
                 return { id: '', updatedAt: new Date().toISOString() };
             }
-            const idValue = item[key] ?? item.id ?? '';
+            const idValue = item[key] ?? item.id ?? item._id ?? '';
             const slugValue = slugKey ? item[slugKey] : undefined;
             const updatedAt = typeof item.updatedAt === 'string' ? item.updatedAt : new Date().toISOString();
             return {
@@ -82,7 +129,7 @@ async function fetchDynamicIds(endpoint: string, key = 'id', slugKey?: string): 
                 slug: typeof slugValue === 'string' ? slugValue : undefined,
                 updatedAt
             };
-        }).filter((item) => item.id !== '');
+        }).filter((item) => String(item.id).trim() !== '');
     } catch (e) {
         logger.error(`Sitemap fetch error for ${endpoint}:`, e);
         return [];
@@ -90,20 +137,18 @@ async function fetchDynamicIds(endpoint: string, key = 'id', slugKey?: string): 
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    // 1. Parallel Fetch all dynamic data
+    // 1. Parallel Fetch all dynamic live listings
     const [ads, businesses, services, spareParts] = await Promise.all([
-        fetchDynamicIds(`${API_ROUTES.USER.LISTINGS}?listingType=ad`, 'id', 'seoSlug'),
-        fetchDynamicIds(API_ROUTES.USER.BUSINESSES_PUBLIC, 'id', 'slug'),
-        fetchDynamicIds(`${API_ROUTES.USER.LISTINGS}?listingType=service`, 'id', 'slug'),
-        fetchDynamicIds('catalog/spare-parts', 'id', 'slug')
+        fetchDynamicIds(API_ROUTES.USER.LISTINGS, { listingType: 'ad', status: 'live' }, 'id', 'seoSlug'),
+        fetchDynamicIds(API_ROUTES.USER.BUSINESSES_PUBLIC, {}, 'id', 'slug'),
+        fetchDynamicIds(API_ROUTES.USER.LISTINGS, { listingType: 'service', status: 'live' }, 'id', 'slug'),
+        fetchDynamicIds(API_ROUTES.USER.LISTINGS, { listingType: 'spare_part', status: 'live' }, 'id', 'slug'),
     ]);
 
-    // 2. Static Routes
+    // 2. Static Public Canonical Routes
     const staticRoutes: MetadataRoute.Sitemap = [
         '',
         '/about',
-        // NOTE: /search?type=* removed — query-param URLs waste crawl budget.
-    // /browse-spare-parts and /browse-services redirect to /search; omit them.
         '/contact',
         '/faq',
         '/how-it-works',
@@ -112,64 +157,90 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         '/site-map',
         '/terms',
     ].map((route) => ({
-        url: `${BASE_url}${route}`,
+        url: `${BASE_URL}${route}`,
         lastModified: new Date(),
         changeFrequency: 'daily' as const,
         priority: route === '' ? 1.0 : 0.8,
     }));
 
-    // 3. Dynamic Ads
-    const adRoutes: MetadataRoute.Sitemap = ads.map((ad) => ({
-        url: `${BASE_url}/ads/${ad.slug || ad.id}-${ad.id}`,
-        lastModified: formatSitemapDate(ad.updatedAt),
-        changeFrequency: 'daily' as const,
-        priority: 0.9,
-    }));
+    // 3. Dynamic Live Ads
+    const adRoutes: MetadataRoute.Sitemap = ads
+        .filter((ad) => Boolean(ad.id))
+        .map((ad) => {
+            const slug = sanitiseSlug(String(ad.slug || ad.id));
+            return {
+                url: `${BASE_URL}/ads/${slug}-${ad.id}`,
+                lastModified: formatSitemapDate(ad.updatedAt),
+                changeFrequency: 'daily' as const,
+                priority: 0.9,
+            };
+        });
 
-    // 4. Dynamic Businesses
-    const businessRoutes: MetadataRoute.Sitemap = businesses.map((business) => ({
-        url: `${BASE_url}/business/${business.slug || business.id}-${business.id}`,
-        lastModified: formatSitemapDate(business.updatedAt),
-        changeFrequency: 'weekly' as const,
-        priority: 0.9,
-    }));
+    // 4. Dynamic Live Businesses
+    const businessRoutes: MetadataRoute.Sitemap = businesses
+        .filter((business) => Boolean(business.id))
+        .map((business) => {
+            const slug = sanitiseSlug(String(business.slug || business.id));
+            return {
+                url: `${BASE_URL}/business/${slug}-${business.id}`,
+                lastModified: formatSitemapDate(business.updatedAt),
+                changeFrequency: 'weekly' as const,
+                priority: 0.9,
+            };
+        });
 
-    // 5. Dynamic Services
-    const serviceRoutes: MetadataRoute.Sitemap = services.map((service) => ({
-        url: `${BASE_url}/services/${service.slug || service.id}-${service.id}`,
-        lastModified: formatSitemapDate(service.updatedAt),
-        changeFrequency: 'daily' as const,
-        priority: 0.9,
-    }));
+    // 5. Dynamic Live Services
+    const serviceRoutes: MetadataRoute.Sitemap = services
+        .filter((service) => Boolean(service.id))
+        .map((service) => {
+            const slug = sanitiseSlug(String(service.slug || service.id));
+            return {
+                url: `${BASE_URL}/services/${slug}-${service.id}`,
+                lastModified: formatSitemapDate(service.updatedAt),
+                changeFrequency: 'daily' as const,
+                priority: 0.9,
+            };
+        });
 
-    // 6. Categories (Semi-static)
-    const categories = ['Mobile Phones', 'Tablets', 'Laptops', 'Spare Parts', 'Accessories', 'Wearables'];
-    const categoryRoutes: MetadataRoute.Sitemap = categories.map((cat) => ({
-        url: `${BASE_url}/category/${cat.toLowerCase().replace(/ /g, '-')}`,
+    // 6. Canonical Categories (Always map to canonical slug to prevent 301 redirects)
+    const rawCategories = ['mobiles', 'tablets', 'laptops', 'spare-parts', 'accessories', 'wearables', 'led-tvs'];
+    const canonicalCategories = Array.from(new Set(rawCategories.map((cat) => getCanonicalCategorySlug(cat))));
+    const categoryRoutes: MetadataRoute.Sitemap = canonicalCategories.map((cat) => ({
+        url: `${BASE_URL}/category/${cat}`,
         lastModified: new Date(),
         changeFrequency: 'weekly' as const,
         priority: 0.8,
     }));
- 
-    // 7. Individual Spare Part Listing Pages (with proper slug-id format)
-    // NOTE: Catalog aggregator pages (e.g. /spare-part-listings/battery) are omitted
-    // because they 404 on the current route — a dedicated aggregator page is required.
-    const sparePartRoutes: MetadataRoute.Sitemap = spareParts
-        .filter((part) => part.slug && !part.slug.match(/^[a-z0-9-]+$/) === false)
-        .map((part) => ({
-            url: `${BASE_url}/spare-part-listings/${sanitiseSlug(String(part.slug || part.id))}`,
-            lastModified: formatSitemapDate(part.updatedAt),
-            changeFrequency: 'weekly' as const,
-            priority: 0.8,
-        }));
 
-    return [
+    // 7. Individual Spare Part Listing Pages (canonical slug-id format)
+    const sparePartRoutes: MetadataRoute.Sitemap = spareParts
+        .filter((part) => Boolean(part.id && (!part.slug || /^[a-z0-9-]+$/.test(part.slug))))
+        .map((part) => {
+            const slug = sanitiseSlug(String(part.slug || part.id));
+            return {
+                url: `${BASE_URL}/spare-part-listings/${slug}-${part.id}`,
+                lastModified: formatSitemapDate(part.updatedAt),
+                changeFrequency: 'weekly' as const,
+                priority: 0.8,
+            };
+        });
+
+    // 8. Deduplicate and collect all valid routes
+    const seenUrls = new Set<string>();
+    const allRoutes: MetadataRoute.Sitemap = [];
+    for (const route of [
         ...staticRoutes,
         ...adRoutes,
         ...businessRoutes,
         ...categoryRoutes,
         ...serviceRoutes,
-        ...sparePartRoutes
-    ];
-}
+        ...sparePartRoutes,
+    ]) {
+        if (!seenUrls.has(route.url)) {
+            seenUrls.add(route.url);
+            allRoutes.push(route);
+        }
+    }
 
+    return allRoutes;
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -76,11 +76,11 @@ export function buildSitemapApiUrl(
     const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
     const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
     const urlObj = new URL(cleanEndpoint, base);
-    
+
     // Set default pagination parameters
     urlObj.searchParams.set('limit', '1000');
     urlObj.searchParams.set('page', '1');
-    
+
     for (const [key, value] of Object.entries(params)) {
         urlObj.searchParams.set(key, value);
     }

--- a/apps/web/src/components/catalog/CatalogSlugPage.tsx
+++ b/apps/web/src/components/catalog/CatalogSlugPage.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from "next";
 import { AdCardGrid } from "@/components/user/ad-card";
 import { Button } from "@esparex/ui";
 import type { ListingPageResult } from "@/lib/api/user/listings";
+import { generateAdSlug } from "@/lib/slug";
 
 export type CatalogSlugEntity = "brand" | "model";
 
@@ -55,9 +56,15 @@ export function buildCatalogSlugMetadata(
   record: CatalogSlugRecord
 ): Metadata {
   const config = ENTITY_CONFIG[entity];
+  const canonicalSlug = record.slug || generateAdSlug(record.name);
+  const canonicalParam = `${canonicalSlug}-${record.id}`;
+  const basePath = entity === "brand" ? "brands" : "models";
   return {
     title: config.metadataTitle(record.name),
     description: config.metadataDescription(record.name, record.contextLabel),
+    alternates: {
+      canonical: `https://esparex.in/${basePath}/${canonicalParam}`,
+    },
   };
 }
 

--- a/apps/web/src/components/catalog/CatalogSlugRoutes.tsx
+++ b/apps/web/src/components/catalog/CatalogSlugRoutes.tsx
@@ -119,7 +119,10 @@ function createCatalogSlugMetadata(entity: CatalogSlugEntity) {
   }: CatalogSlugRouteProps): Promise<Metadata> {
     const { slug } = await params;
     if (!slug) {
-      return { title: "Catalog Page | Esparex" };
+      return {
+        title: "Catalog Page | Esparex",
+        robots: { index: false, follow: false },
+      };
     }
 
     const parsed = parseOptionalSlugId(slug);
@@ -131,7 +134,10 @@ function createCatalogSlugMetadata(entity: CatalogSlugEntity) {
 
     return record
       ? buildCatalogSlugMetadata(entity, record)
-      : { title: "Catalog Page Not Found | Esparex" };
+      : {
+          title: "Catalog Page Not Found | Esparex",
+          robots: { index: false, follow: false },
+        };
   };
 }
 

--- a/apps/web/src/components/ui/SafeImage.tsx
+++ b/apps/web/src/components/ui/SafeImage.tsx
@@ -40,7 +40,7 @@ export function SafeImage({
     if (typeof currentSrc !== "string") return false;
     try {
       if (currentSrc.startsWith("http://") || currentSrc.startsWith("https://")) {
-        const base = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+        const base = typeof window !== "undefined" ? window.location.origin : "https://esparex.in";
         const url = new URL(currentSrc, base);
         // Local relative assets or same-origin paths do not need unoptimized flag
         if (typeof window !== "undefined" && url.origin === window.location.origin) {

--- a/apps/web/src/components/user/business-registration/StepBasicDetails.tsx
+++ b/apps/web/src/components/user/business-registration/StepBasicDetails.tsx
@@ -47,9 +47,10 @@ export function StepBasicDetails({
                     <Input
                         id="reg-email"
                         type="email"
+                        autoComplete="email"
                         value={formData.email}
                         onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                        placeholder="contact@yourbusiness.com"
+                        placeholder="business@example.com"
                         className="h-10 text-body-lg md:text-body"
                         aria-invalid={Boolean(formData.errors?.email)}
                     />

--- a/apps/web/src/components/user/profile/tabs/PersonalProfileEmailSection.tsx
+++ b/apps/web/src/components/user/profile/tabs/PersonalProfileEmailSection.tsx
@@ -23,7 +23,7 @@ export function PersonalProfileEmailSection({
             <Input
                 id="profile-email"
                 type="email"
-                placeholder="name@company.com"
+                placeholder="your@email.com"
                 {...register("email")}
                 className={`h-10 rounded-xl bg-card border-border px-3.5 text-caption sm:text-body font-medium ${emailError ? "border-destructive" : ""}`}
                 aria-invalid={!!emailError}

--- a/apps/web/src/lib/listings/listingDetailPage.tsx
+++ b/apps/web/src/lib/listings/listingDetailPage.tsx
@@ -78,7 +78,8 @@ export async function buildListingMetadata({
     const listingTitle = `${listing.title}${locationSuffix}` || missingTitle;
     
     const canonicalSlug = listing.seoSlug || generateAdSlug(listing.title || "");
-    const canonicalUrl = `${canonicalBasePath}/${canonicalSlug}-${listing.id}`;
+    const canonicalPath = `${canonicalBasePath}/${canonicalSlug}-${listing.id}`;
+    const canonicalUrl = `https://esparex.in${canonicalPath}`;
     const previousImages = (await parent).openGraph?.images || [];
     const mainImage = listing.images?.[0];
 

--- a/docs/audits/SEO_HARDENING_VERIFICATION_REPORT.md
+++ b/docs/audits/SEO_HARDENING_VERIFICATION_REPORT.md
@@ -1,0 +1,77 @@
+# SEO Indexing, Canonicalization & Placeholder Hardening Verification Report
+
+- **Date**: 2026-09-04
+- **Branch**: `fix/seo-indexing-auth-hardening`
+- **Target Environments**: Web (`https://esparex.in`), Admin (`https://admin.esparex.in`)
+
+---
+
+## 1. Summary of Changes & Root Causes Addressed
+
+| Issue / Category | Root Cause | Solution Implemented | Verification Status |
+|---|---|---|---|
+| **BUG-1: Sitemap Query Parameter Double-Separator** | `${url}?limit=1000&page=1` appended to `listings?listingType=ad` created `...ad?limit=1000&page=1` | Added `buildSitemapApiUrl` using `URL` and `URLSearchParams` to safely set query parameters | ✅ Verified (18/18 vitest tests pass) |
+| **BUG-2: Spare Parts Sitemap Filter Inversion** | `!part.slug.match(...) === false` evaluated boolean comparison incorrectly, excluding 100% of spare parts | Replaced with `Boolean(part.id && (!part.slug \|\| /^[a-z0-9-]+$/.test(part.slug)))` | ✅ Verified in vitest suite |
+| **BUG-3: Admin Indexation Exposure** | Admin application had no `robots.ts`, no `noindex` metadata, and no `X-Robots-Tag` | 1. Created `apps/admin/src/app/robots.ts` (`Disallow: /`)<br>2. Added `robots: { index: false, follow: false, nocache: true }` in `layout.tsx`<br>3. Configured `X-Robots-Tag: noindex, nofollow, noarchive` in `next.config.mjs` | ✅ Verified (`/robots.txt` built, config compiled) |
+| **BUG-4: Localhost Fallback in MetadataBase** | `metadataBase` in `apps/web/src/app/layout.tsx` defaulted to `http://localhost:3000` | Fallback set to canonical `https://esparex.in` and validated against admin/staging/preview/localhost leaks | ✅ Verified |
+| **BUG-5: Incomplete Private Disallows in robots.txt** | Missing disallows for `/chat/`, `/post-spare-part-listing`, `/edit-service/`, `/edit-spare-part/`, `/internal/` | Added comprehensive disallow list covering all authenticated and internal routes | ✅ Verified in vitest & robots check |
+| **BUG-6, BUG-7, BUG-8: Spare Part Endpoint & Canonical Format** | Sitemap fetched catalog parts rather than listings and emitted bare slug instead of `${slug}-${id}` | Fetched `listings?listingType=spare_part&status=live` and generated `${slug}-${id}` canonical URLs | ✅ Verified in vitest suite |
+| **Category Alias 301 Redirects in Sitemap** | Sitemap emitted `/category/mobile-phones` which redirects to `/category/mobiles` | Passed all category tokens through `getCanonicalCategorySlug` to ensure zero redirect entries in sitemap | ✅ Verified in vitest suite |
+| **P1–P7: Sensitive Form Placeholders** | Login exposed `admin@esparex.com`, `000000`, missing `autoComplete`, and external domains like `partner.com` | Replaced all instances with generic, RFC-compliant text and added missing `autoComplete` attributes | ✅ Verified |
+
+---
+
+## 2. Automated Test Results
+
+### 2.1 Unit & Regression Suite (`apps/web/src/__tests__/seo-sitemap.spec.ts`)
+- **Suite Result**: 18 / 18 tests passed
+- **Coverage**:
+  - `sanitiseSlug`: special characters, parentheses, multi-dash stripping
+  - `buildSitemapApiUrl`: query parameter safety, no double `?`, boundary slashes
+  - `formatSitemapDate`: W3C ISO date formatting without milliseconds
+  - Sitemap static route inventory (only canonical public URLs)
+  - Sitemap exclusion of redirect routes (`/browse-services`, `/browse-spare-parts`, `/spare-parts/`)
+  - Sitemap exclusion of private routes (`/account/`, `/chat`, `/post-`, `/edit-`, `/internal/`, `/api/`)
+  - Verification of zero admin, localhost, or preview hostnames
+  - Spare part listing format `${slug}-${id}` and filter preservation
+  - Canonical category slugs (no redirect aliases)
+  - Zero duplicate URLs
+  - Web `robots.txt` policy verification
+  - Sensitive placeholder security assertions
+
+### 2.2 Monorepo Type Check
+- **Command**: `npm run type-check`
+- **Workspaces Audited**:
+  - `@esparex/design-tokens`
+  - `@esparex/contracts`
+  - `@esparex/shared`
+  - `@esparex/core`
+  - `@esparex/backend-api`
+  - `@esparex/apps-admin`
+  - `@esparex/apps-web`
+  - `@esparex/mobile-ui`
+  - `@esparex/apps-mobile`
+- **Result**: Exit code 0, 0 errors across all 9 packages.
+
+### 2.3 Production Builds
+- `npm run build -w apps/admin`: Compiled and optimized successfully (Exit code 0)
+- `npm run build -w apps/web`: 41 routes static & dynamic optimized successfully (Exit code 0)
+
+### 2.4 Automated SEO Tooling (`apps/web/scripts/validate-sitemap.cjs`)
+- **Command**: `npm run ci:seo -w apps/web`
+- **Result**: Static source SEO rules audit: PASSED with 0 violations.
+
+### 2.5 Monorepo Architecture & Route Guards
+- `npm run guard:mobile-architecture`: Passed
+- `node scripts/enforce-route-collision-guard.js`: Passed
+- `node scripts/guard-route-shadowing.js`: Passed
+- `node scripts/enforce-shared-ssot.js`: Passed
+- `node scripts/enforce-design-token-adoption.js`: Passed (0 violations)
+
+---
+
+## 3. Pre-PR Git Hygiene & Clean Status
+
+- `git diff origin/develop...HEAD --check`: Clean (0 whitespace/conflict errors)
+- `git status`: Working tree clean
+- Sequential clean commit history on single branch `fix/seo-indexing-auth-hardening`.

--- a/docs/audits/SEO_INDEXING_AUTH_HARDENING_AUDIT.md
+++ b/docs/audits/SEO_INDEXING_AUTH_HARDENING_AUDIT.md
@@ -1,0 +1,110 @@
+# SEO Indexing, Canonicalization & Sensitive Placeholder Hardening Audit
+
+## Executive Summary
+
+- **Audit Date**: 2026-09-04
+- **Branch**: `fix/seo-indexing-auth-hardening`
+- **Target Apps**: `apps/web` (Next.js 15, `https://esparex.in`), `apps/admin` (Next.js 15, `https://admin.esparex.in`)
+- **Scope**: SEO, indexing, canonicalization, robots.txt, sitemap.xml, sensitive placeholder text, form credentials.
+
+---
+
+## 1. Google Search Console & Route Inventory Baseline
+
+### 1.1 GSC Baseline Profile (Current State)
+- **Total Discovered URLs**: ~109 URLs
+- **Indexed**: 23 URLs
+- **Not Indexed**: 86 URLs across 7 reason categories
+- **Objective**: Ensure ONLY genuine, public, unique, canonical, indexable pages on `https://esparex.in` are indexed. Explicitly prevent indexing for admin, private, internal, redirect-only, filter-parameterized, and non-live pages.
+
+### 1.2 Route Audit & Classification
+
+| Route Pattern | Classification | Current Indexability | Target Indexability | Action Required |
+|---|---|---|---|---|
+| `/` | Static Public | Indexable | Indexable | Canonical verification |
+| `/about`, `/contact`, `/faq`, `/how-it-works`, `/privacy`, `/safety-tips`, `/site-map`, `/terms` | Static Public | Indexable | Indexable | Retain in sitemap |
+| `/search` (bare) | Search Public | Indexable | Indexable | Canonical verification |
+| `/search?*` (with filters) | Search Query | `noindex` | `noindex` | Retain `hasFilters` -> `noindex` |
+| `/ads/[slug]` | Dynamic Listing | Indexable if live | Indexable if live | Fix sitemap endpoint & query param bug |
+| `/services/[slug]` | Dynamic Listing | Indexable if live | Indexable if live | Fix sitemap endpoint & query param bug |
+| `/spare-part-listings/[slug]` | Dynamic Listing | Indexable if live | Indexable if live | Fix sitemap filter bug, URL format (`slug-id`), and endpoint |
+| `/business/[slug]` | Dynamic Business | Indexable | Indexable | Retain in sitemap |
+| `/seller/[id]` | Dynamic Seller | Indexable | Indexable | Validate canonical format |
+| `/category/[category]` | Dynamic Taxonomy | Indexable | Indexable | Retain canonical category slugs |
+| `/brands/[slug]`, `/models/[slug]` | Dynamic Taxonomy | Indexable | Indexable if content exists | Verify canonical metadata |
+| `/browse-services`, `/browse-spare-parts` | Legacy Redirect | 301 Redirect | 301 (Do NOT Index) | Exclude from sitemap |
+| `/spare-parts/[slug]` | Legacy Redirect | 301 Redirect | 301 (Do NOT Index) | Exclude from sitemap |
+| `/account/*` | Private Auth | `noindex` | `noindex` | Verify robots.txt disallow |
+| `/chat/*` | Private Auth | `noindex` (layout) | `noindex` | **Add to robots.txt disallow** |
+| `/post-ad`, `/post-service`, `/post-spare-part-listing` | Private Auth | `noindex` (layout) | `noindex` | Verify robots.txt disallow |
+| `/edit-ad/*`, `/edit-service/*`, `/edit-spare-part/*` | Private Auth | `noindex` (layout) | `noindex` | **Add to robots.txt disallow** |
+| `/business/edit` | Private Auth | `noindex` (layout) | `noindex` | **Add to robots.txt disallow** |
+| `/internal/*` | System/API | Accessible | `noindex` | **Add to robots.txt disallow** |
+| `admin.esparex.in/*` | Admin Subdomain | **Publicly indexable** | **NOINDEX ALL** | **Add admin robots.ts, layout metadata, and X-Robots-Tag header** |
+
+---
+
+## 2. Root Cause Analysis of Identified Bugs
+
+### BUG-1: Sitemap Query Parameter Double-Separator (CRITICAL)
+- **Location**: `apps/web/src/app/sitemap.ts` (lines 51, 95, 97)
+- **Root Cause**: `fetchDynamicIds` takes `endpoint` (passed as `"listings?listingType=ad"`) and string-interpolates `${url}?limit=1000&page=1`, creating `.../listings?listingType=ad?limit=1000&page=1` (double `?`).
+- **Consequence**: Backend fails to parse `listingType` or treats it as malformed, mixing or failing dynamic listing retrieval.
+- **Fix**: Use `URL` or `URLSearchParams` to safely append query parameters without string concatenation collisions.
+
+### BUG-2: Spare Parts Filter Inversion (CRITICAL)
+- **Location**: `apps/web/src/app/sitemap.ts` (line 158)
+- **Root Cause**: `.filter((part) => part.slug && !part.slug.match(/^[a-z0-9-]+$/) === false)`. Precedence causes `!part.slug.match(...)` to evaluate to boolean, which is never strictly equal to `false` when match succeeds.
+- **Consequence**: Exactly 0 spare part listing URLs are output in sitemap.xml.
+- **Fix**: Use regex test: `.filter((part) => Boolean(part.slug && /^[a-z0-9-]+$/.test(part.slug)))`.
+
+### BUG-3: Admin Application Indexing Vulnerability (HIGH)
+- **Location**: `apps/admin/src/app/` (all routes, `layout.tsx`, `next.config.mjs`)
+- **Root Cause**: No `robots.ts`, no `robots: { index: false, follow: false }` metadata in root layout, and no `X-Robots-Tag: noindex, nofollow, noarchive` HTTP response headers configured.
+- **Consequence**: `admin.esparex.in/login` and administrative routes risk indexation in Google Search Console.
+- **Fix**: Implement defense-in-depth:
+  1. `apps/admin/src/app/robots.ts` with `Disallow: /`.
+  2. Root layout metadata `robots: { index: false, follow: false, nocache: true }`.
+  3. `X-Robots-Tag: noindex, nofollow, noarchive` HTTP header in `apps/admin/next.config.mjs`.
+
+### BUG-4: Dangerous `localhost:3000` MetadataBase Fallback (HIGH)
+- **Location**: `apps/web/src/app/layout.tsx` (lines 15–26)
+- **Root Cause**: Fallback URL is `http://localhost:3000` if `process.env.NEXT_PUBLIC_APP_URL` is undefined.
+- **Consequence**: Any relative canonical or OpenGraph image path resolves to `http://localhost:3000/...` in production, causing search crawler confusion and canonical rejection.
+- **Fix**: Set fallback to canonical production origin `https://esparex.in`.
+
+### BUG-5: Incomplete Private Disallow Rules in `robots.ts` (MEDIUM)
+- **Location**: `apps/web/src/app/robots.ts`
+- **Root Cause**: Missing disallows for `/chat/`, `/edit-service/`, `/edit-spare-part/`, `/post-spare-part-listing`, `/business/edit`, `/internal/`.
+- **Consequence**: Crawlers attempt crawling private interactive pages before hitting layout tags or auth gates.
+- **Fix**: Expand disallow paths in `robots.ts`.
+
+### BUG-6 & BUG-7: Spare Parts Endpoint & Canonical Route Mismatch (MEDIUM)
+- **Location**: `apps/web/src/app/sitemap.ts`
+- **Root Cause**: Sitemap fetches `catalog/spare-parts` (catalog taxonomy) instead of user-posted listings `listings?listingType=spare_part`, and outputs `/spare-part-listings/${slug}` instead of the canonical `${slug}-${id}` format.
+- **Consequence**: Sitemap entries do not match live detail page canonicals, triggering redirect errors in GSC.
+- **Fix**: Query `listings?listingType=spare_part` and format URLs with `${slug}-${id}`.
+
+---
+
+## 3. Sensitive Placeholder Audit Baseline
+
+| Issue | File | Current Placeholder / Text | Security / UX Concern | Target Replacement |
+|---|---|---|---|---|
+| ISSUE-P1 | `apps/admin/src/app/login/page.tsx:191` | `placeholder="admin@esparex.com"` | Exposes corporate email domain pattern; enumeration hint | `placeholder="Your admin email address"` |
+| ISSUE-P2 | `apps/admin/src/app/login/page.tsx:255` | `placeholder="000000"` | Mimics default OTP / credential | `placeholder="6-digit code"` |
+| ISSUE-P3 | `AdminUserFormCard.tsx:184` | `placeholder="Password"` | Duplicates label, lacks `autoComplete` | `placeholder="Set initial password"`, `autoComplete="new-password"` |
+| ISSUE-P4 | `AdminUserFormCard.tsx:171` | `placeholder="Email"` | Duplicates label, lacks `autoComplete` | `placeholder="Admin email address"`, `autoComplete="email"` |
+| ISSUE-P5 | `admin-users/page.tsx:114,286` | `ads:write`, `Permissions... (example: users:read, ads:write)` | Exposes internal scope vocabulary; uses deprecated non-canonical `ads` term | `e.g. users:read, listings:write` |
+| ISSUE-P6 | `CampaignEditModal.tsx:144,176` | `e.g. 1234567890`, `https://partner.com` | Real external domain `partner.com`; unguided slot ID | `Google AdSense slot ID`, `https://advertiser.example.com` |
+| ISSUE-P7 | `PersonalProfileEmailSection.tsx:26` | `placeholder="name@company.com"` | Implies corporate email on personal account profile | `placeholder="your@email.com"` |
+
+---
+
+## 4. Verification Baseline
+
+Before applying fixes, the following checks will be executed across all phases:
+1. `npm run type-check` (Monorepo type check)
+2. `npm run build -w apps/web`
+3. `npm run build -w apps/admin`
+4. Automated unit and regression tests for sitemap and canonical generation.

--- a/docs/governance/SEO_AND_AUTH_PLACEHOLDER_GOVERNANCE.md
+++ b/docs/governance/SEO_AND_AUTH_PLACEHOLDER_GOVERNANCE.md
@@ -1,0 +1,76 @@
+# SEO, Indexing & Sensitive Placeholder Governance
+
+> **Status:** Enforced · **Owner:** SEO & Application Security Governance · **Scope:** All web and admin applications across Esparex monorepo.
+
+---
+
+## 1. SEO & Indexing Prevention Rules
+
+To ensure search engines crawl and index only canonical, valuable, and public pages on `https://esparex.in`:
+
+1. **Deterministic Canonical URLs**:
+   - All public canonical URLs MUST resolve to `https://esparex.in`.
+   - Never generate canonical URLs pointing to `localhost`, `admin.esparex.in`, or preview/staging environments.
+   - Dynamic canonical generation must match the canonical route format defined in the application (e.g., `${slug}-${id}` for listings).
+
+2. **Absolute Admin and Private Route Protection**:
+   - The entire `admin.esparex.in` application MUST be non-indexable.
+   - Enforcement MUST follow defense-in-depth:
+     - `robots.ts` with `Disallow: /`
+     - Root layout metadata: `robots: { index: false, follow: false, nocache: true }`
+     - HTTP Header: `X-Robots-Tag: noindex, nofollow, noarchive`
+   - Private and authenticated web routes (`/account/*`, `/chat/*`, `/post-*`, `/edit-*`, `/business/edit`) must never be indexable.
+   - Internal API/revalidation endpoints (`/api/*`, `/internal/*`) must be blocked in `robots.ts`.
+
+3. **Sitemap Integrity**:
+   - Sitemap URLs MUST exactly match canonical routes.
+   - Redirect-only routes (such as `/browse-services`, `/browse-spare-parts`, `/spare-parts/[slug]`) MUST NEVER be included in `sitemap.ts`.
+   - Non-live, drafted, rejected, or expired listings MUST NOT be included in `sitemap.ts`.
+   - Dynamic query strings must be constructed safely using `URL` or `URLSearchParams`; never manually concatenate queries with string interpolation (`?` vs `&`).
+   - All slug filters must use sound boolean logic (e.g. `Boolean(slug && regex.test(slug))`).
+
+4. **Production MetadataBase Security**:
+   - `metadataBase` fallbacks must never default to `http://localhost:3000` in production-facing layouts.
+   - The fallback must default to `new URL('https://esparex.in')`.
+
+---
+
+## 2. Authentication & Form Placeholder Prevention Rules
+
+To prevent sensitive information exposure, user confusion, and credential enumeration:
+
+1. **No Production or Real Email Domain Patterns**:
+   - Placeholders on public and admin authentication forms must NEVER use real company or administrative domains (e.g., avoid `admin@esparex.com`).
+   - Use generic, actionable prompt text such as `"Your admin email address"` or `"your@email.com"`.
+
+2. **No Default-Looking Credentials or OTPs**:
+   - Authentication fields must never use realistic numbers like `"000000"` or `"123456"`.
+   - Use explanatory hints such as `"6-digit code"`.
+
+3. **Safe Example Domains**:
+   - When URL examples are required in documentation, inputs, or placeholders, use RFC 2606 reserved domains (`example.com`, `example.org`, `advertiser.example.com`).
+   - Never use real commercial partner domains (e.g. avoid `partner.com`).
+
+4. **Credential Autocomplete Attributes**:
+   - Password creation fields MUST have `autoComplete="new-password"`.
+   - Email inputs MUST have `autoComplete="email"`.
+   - Password login fields MUST have `autoComplete="current-password"`.
+
+5. **No Internal Scope Vocabulary Exposure**:
+   - Do not leak internal RBAC terminology or obsolete entity names (e.g., do not use `ads:write`; use unified canonical terminology `listings:write`).
+   - Placeholders should inform without duplicating label text verbatim.
+
+---
+
+## 3. Code Quality and Monorepo Hygiene Rules
+
+1. **Contracts as Single Source of Truth**:
+   - All API DTOs and routes must reference `@esparex/contracts` and `@esparex/shared`.
+   - Do not redefine parallel DTOs, listing types, or query params locally.
+
+2. **Zero TypeScript Escape Hatches**:
+   - `as any`, `as never`, `as unknown as`, `@ts-ignore`, and `@ts-expect-error` are strictly prohibited in production code.
+
+3. **Zero Dead Code & Orphans**:
+   - Remove unused imports, dead variables, deprecated route handlers, and temporary implementation comments.
+   - Maintain strict accessibility (WCAG 2.2 AA) and prevent regressions.


### PR DESCRIPTION
## Summary

Comprehensive audit and permanent hardening of SEO indexing, canonicalization, sitemap generation, admin indexing protection, and sensitive form placeholder cleanup across `apps/web` and `apps/admin`.

---

### Root Causes Identified

1. **BUG-1 (Critical Sitemap Concatenation Bug)**: `sitemap.ts` passed `listings?listingType=ad` into `fetchDynamicIds`, which then string-interpolated `${url}?limit=1000&page=1`, creating malformed URLs with double `?` separators (`.../listings?listingType=ad?limit=1000&page=1`).
2. **BUG-2 (Critical Spare Parts Exclusion)**: `!part.slug.match(/^[a-z0-9-]+$/) === false` had operator precedence flaws that evaluated boolean inverted comparison, eliminating 100% of spare part listings from the sitemap.
3. **BUG-3 (Admin Public Indexation Exposure)**: The admin application on `admin.esparex.in` had zero `robots.ts`, missing root metadata `robots` directive, and no HTTP `X-Robots-Tag`, allowing admin login and administrative routes to be indexed.
4. **BUG-4 (Dangerous MetadataBase Fallback)**: `metadataBase` in `apps/web/src/app/layout.tsx` defaulted to `http://localhost:3000` when `NEXT_PUBLIC_APP_URL` was unset, risking relative canonical and OG image resolution to localhost.
5. **BUG-5 (Incomplete Web Private Disallow Rules)**: `robots.ts` lacked disallows for authenticated and internal endpoints (`/chat/`, `/post-spare-part-listing`, `/edit-service/`, `/edit-spare-part/`, `/internal/`).
6. **BUG-6/7/8 (Spare Part Endpoint & Format Mismatch)**: Sitemap fetched catalog definitions instead of active listing records and omitted the canonical `-{id}` suffix.
7. **Category Alias 301 Redirects in Sitemap**: Hardcoded category names like "Mobile Phones" emitted `/category/mobile-phones`, which issued 301 redirects to `/category/mobiles` (accounting for "Page with redirect" in GSC).
8. **Sensitive Form Placeholders (P1–P7)**: Admin login exposed real internal email conventions (`admin@esparex.com`), realistic OTP values (`000000`), missing `autoComplete` attributes, and external partner domains (`partner.com`).

---

### Permanent Fixes Implemented

1. **Sitemap Safe API Construction**:
   - Implemented `buildSitemapApiUrl` using standard `URL` and `URLSearchParams` to guarantee zero double-`?` query parameters.
   - Added `status: 'live'` filter to ensure only live listings are queried.
   - Fixed spare-part filter logic using `Boolean(part.id && (!part.slug || /^[a-z0-9-]+$/.test(part.slug)))`.
   - Formatted spare-part URLs using canonical `${slug}-${id}` format.
   - Deduplicated all generated sitemap entries.
2. **Category Canonicalization in Sitemap**:
   - Passed all category tokens through `getCanonicalCategorySlug` to guarantee only canonical categories (`mobiles`, `tablets`, etc.) are output in `sitemap.xml`.
3. **Admin Indexing Protection (Defense-in-Depth)**:
   - Added `apps/admin/src/app/robots.ts` with `Disallow: /`.
   - Added `robots: { index: false, follow: false, nocache: true }` in `apps/admin/src/app/layout.tsx`.
   - Configured `X-Robots-Tag: noindex, nofollow, noarchive` on all routes in `apps/admin/next.config.mjs`.
4. **Production MetadataBase Security**:
   - Updated `apps/web/src/app/layout.tsx` to safely fallback to `https://esparex.in`.
   - Guarded against admin, staging, preview, and localhost hostname leaks.
   - Set listing detail canonical URLs and OG URLs explicitly to absolute `https://esparex.in/...`.
   - Added canonical URL metadata to catalog brand and model landing routes in `CatalogSlugRoutes.tsx` and `CatalogSlugPage.tsx`.
   - Added `robots: { index: false, follow: false }` for missing/not-found business, seller, and catalog entities.
   - Cleaned search page metadata so bare `/search` canonicalizes to `https://esparex.in/search`.
5. **Web Robots Hardening**:
   - Expanded `apps/web/src/app/robots.ts` disallows to cover `/account/`, `/chat`, `/chat/`, `/post-spare-part-listing`, `/edit-service/`, `/edit-spare-part/`, `/business/edit`, `/internal/`, and `/api/`.
6. **Form Placeholder & Security Cleanup**:
   - `apps/admin/src/app/login/page.tsx`: Replaced `admin@esparex.com` with `Your admin email address` and `000000` with `6-digit code`.
   - `apps/admin/src/components/system/adminUsers/AdminUserFormCard.tsx`: Added `placeholder="Admin email address"`, `autoComplete="email"`, `placeholder="Set initial password"`, and `autoComplete="new-password"`.
   - `apps/admin/src/app/(protected)/(system)/admin-users/page.tsx` & `admin.schemas.ts`: Replaced deprecated `ads:write` examples with canonical `listings:write`.
   - `CampaignEditModal.tsx`: Replaced `https://partner.com` with RFC-reserved `https://advertiser.example.com` and `e.g. 1234567890` with `Google AdSense slot ID`.
   - `PersonalProfileEmailSection.tsx`: Replaced `name@company.com` with `your@email.com`.
   - `StepBasicDetails.tsx`: Replaced `contact@yourbusiness.com` with `business@example.com` and added `autoComplete="email"`.

---

### Prevention Rules Introduced

- Created `docs/governance/SEO_AND_AUTH_PLACEHOLDER_GOVERNANCE.md`:
  - Mandatory absolute `https://esparex.in` canonical resolution.
  - Three-tier admin indexing protection gate.
  - Prohibition of redirect-only and private routes from `sitemap.ts`.
  - Ban on production/admin email formats and fake OTP values in form placeholders.
  - Enforcement of RFC 2606 reserved domains (`example.com`).

---

### Automated Tests & Verification

- **Automated Regression Suite (`apps/web/src/__tests__/seo-sitemap.spec.ts`)**: 18 / 18 tests passing.
- **Automated Sitemap Audit CLI (`apps/web/scripts/validate-sitemap.cjs`)**:
  - Added npm script `npm run ci:seo -w apps/web`.
  - Audits static source files, rules, query handling, and online/offline sitemap payloads.
- **Monorepo Type Check (`npm run type-check`)**: Passed with exit code 0 across all 9 packages.
- **Production Builds**:
  - `npm run build -w apps/admin`: Compiled and static-generated with exit code 0.
  - `npm run build -w apps/web`: All 41 routes compiled and static/dynamic optimized with exit code 0.
- **Architecture Guards**:
  - `npm run guard:mobile-architecture`: Passed.
  - `node scripts/enforce-route-collision-guard.js`: Passed.
  - `node scripts/guard-route-shadowing.js`: Passed.
  - `node scripts/enforce-shared-ssot.js`: Passed.
  - `node scripts/enforce-design-token-adoption.js`: Passed (0 violations).
- **Git Hygiene**:
  - `git diff origin/develop...HEAD --check`: 0 errors.

---

### External GSC Actions Recommended

1. Submit updated `https://esparex.in/sitemap.xml` in Google Search Console.
2. Under "Page indexing", request validation of:
   - "Page with redirect" (resolved by eliminating non-canonical category aliases from sitemap).
   - "Discovered — currently not crawled" (resolved by fixing double `?` URL query and spare part logic).
3. If `admin.esparex.in` was added as a property, verify that `Disallow: /` and `X-Robots-Tag: noindex` de-index any crawled admin login pages.
