### PR TITLE
fix(catalog): catalog cache invalidation & idempotency hardening

### DIFF
--- a/apps/admin/src/hooks/useAdminCategories.ts
+++ b/apps/admin/src/hooks/useAdminCategories.ts
@@ -101,12 +101,23 @@ export function useAdminCategories(options: UseAdminCategoriesOptions = {}) {
             const response = await deleteCategory(id);
             if (response.success) {
                 setCategories(prev => prev.filter(cat => cat.id !== id));
-                showAdminPopup({ type: "success", title: "Success", message: "Category deleted successfully" });
+                showAdminPopup({ 
+                    type: "success", 
+                    title: "Success", 
+                    message: response.message || "Category deleted successfully" 
+                });
+                void fetchCategories();
             } else {
                 showAdminPopup({ type: "error", title: "Error", message: response.message || "Failed to delete category" });
             }
         } catch (err: unknown) {
             const anyErr = err as { status?: number; payload?: { dependencies?: Record<string, number> } };
+            if (anyErr?.status === 404) {
+                setCategories(prev => prev.filter(cat => cat.id !== id));
+                showAdminPopup({ type: "info", title: "Notice", message: "Category was already deleted" });
+                void fetchCategories();
+                return;
+            }
             if (anyErr?.status === 409 && anyErr?.payload?.dependencies) {
                 const deps = anyErr.payload.dependencies;
                 const details = [

--- a/backend/api/src/controllers/admin/catalog/catalogCategoryController.ts
+++ b/backend/api/src/controllers/admin/catalog/catalogCategoryController.ts
@@ -270,9 +270,14 @@ export const deleteCategory = async (req: Request, res: Response) => {
     const categoryId = req.params.id as string;
 
     try {
-        await CatalogOrchestrator.deleteCategoryOrchestrated(categoryId);
+        const result = await CatalogOrchestrator.deleteCategoryOrchestrated(categoryId);
         clearCategoryCanonicalCache();
-        sendSuccessResponse(res, null, 'Category and all dependent brands/models soft-deleted successfully');
+        void logAdminAction(req, 'CATEGORY_DELETE', 'Category', categoryId, { alreadyDeleted: result.alreadyDeleted });
+        sendSuccessResponse(
+            res,
+            result,
+            result.alreadyDeleted ? 'Category was already deleted' : 'Category and all dependent brands/models soft-deleted successfully'
+        );
     } catch (e: unknown) {
         const err = e instanceof AppError ? e : null;
         if (err?.code === 'FORBIDDEN') {

--- a/backend/api/src/controllers/admin/catalog/shared.ts
+++ b/backend/api/src/controllers/admin/catalog/shared.ts
@@ -366,6 +366,11 @@ export async function handleCatalogDelete<T extends Document>(
 
         const item = await model.findByIdAndUpdate(id, softDeleteUpdate, { new: true });
         if (!item) {
+            const alreadyDeletedDoc = await model.findById(id).setOptions({ withDeleted: true }).exec();
+            if (alreadyDeletedDoc && (alreadyDeletedDoc as T & { isDeleted?: boolean }).isDeleted) {
+                if (options.postOp) void options.postOp(alreadyDeletedDoc);
+                return sendSuccessResponse(res, { alreadyDeleted: true }, `${model.modelName} was already deleted`);
+            }
             return sendContractErrorResponse(req, res, 404, `${model.modelName} not found`);
         }
 
@@ -437,6 +442,7 @@ export async function handleCatalogReview<T extends Document>(
 }
 
 import CatalogOrchestrator from '@esparex/core/domains/catalog/application/services/CatalogOrchestrator';
+import { clearCategoryCanonicalCache } from '@esparex/core/domains/catalog/application/services/CatalogCategoryService';
 
 export interface CatalogCacheInvalidationItem {
     categoryIds?: Array<string | Types.ObjectId>;
@@ -444,7 +450,12 @@ export interface CatalogCacheInvalidationItem {
     brandId?: string | Types.ObjectId;
 }
 
-export const invalidateItemCatalogCache = (item: CatalogCacheInvalidationItem) => void CatalogOrchestrator.invalidateCatalogCache({
-    categoryIds: (item.categoryIds as string[] | undefined) || (item.categoryId ? [String(item.categoryId)] : []),
-    brandIds: item.brandId ? [String(item.brandId)] : []
-});
+export const invalidateItemCatalogCache = (item: CatalogCacheInvalidationItem) => {
+    const categoryIds = (item.categoryIds as string[] | undefined) || (item.categoryId ? [String(item.categoryId)] : []);
+    const brandIds = item.brandId ? [String(item.brandId)] : [];
+    clearCategoryCanonicalCache();
+    void CatalogOrchestrator.invalidateCatalogCache({
+        categoryIds,
+        brandIds
+    });
+};

--- a/core/src/__tests__/services/catalogOrchestrator.categoryDelete.spec.ts
+++ b/core/src/__tests__/services/catalogOrchestrator.categoryDelete.spec.ts
@@ -1,0 +1,146 @@
+import { CatalogOrchestratorImpl } from '../../domains/catalog/application/services/CatalogOrchestrator';
+import { AppError } from '../../utils/AppError';
+import { LISTING_TYPE, CATALOG_APPROVAL_STATUS } from '@esparex/contracts';
+import {
+    CatalogUnitOfWorkPort,
+    CatalogCachePort,
+    CategoryRepositoryPort,
+    BrandRepositoryPort,
+    ModelRepositoryPort,
+    SparePartRepositoryPort,
+    ScreenSizeRepositoryPort,
+    Category
+} from '../../domains/catalog';
+
+describe('CatalogOrchestrator - Category Delete Idempotency & Cache Invalidation', () => {
+    let orchestrator: CatalogOrchestratorImpl;
+    let mockUnitOfWork: any;
+    let mockCacheService: any;
+    let mockCategoryRepo: any;
+    let mockBrandRepo: any;
+    let mockModelRepo: any;
+    let mockSparePartRepo: any;
+    let mockScreenSizeRepo: any;
+
+    const sampleCategory: Category = {
+        id: '65fa29c9d2c1f2e165fa29c1',
+        _id: '65fa29c9d2c1f2e165fa29c1',
+        name: 'Mobiles',
+        displayName: 'Mobiles',
+        canonicalName: 'mobiles',
+        slug: 'mobiles',
+        isActive: true,
+        isDeleted: false,
+        configuration: {
+            listingTypes: [LISTING_TYPE.AD],
+            serviceSelectionMode: 'multi',
+            approvalStatus: CATALOG_APPROVAL_STATUS.APPROVED,
+            hasScreenSizes: true
+        }
+    };
+
+    beforeEach(() => {
+        mockUnitOfWork = {
+            executeTransaction: jest.fn().mockImplementation(async (work) => work({}))
+        };
+
+        mockCacheService = {
+            invalidateCatalogCache: jest.fn().mockResolvedValue(undefined)
+        };
+
+        mockCategoryRepo = {
+            findById: jest.fn(),
+            findBySlug: jest.fn(),
+            exists: jest.fn(),
+            resolveActiveCategoryIds: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            softDelete: jest.fn().mockResolvedValue(true),
+            findActive: jest.fn()
+        };
+
+        mockBrandRepo = {
+            findById: jest.fn(),
+            findByNameAndCategory: jest.fn(),
+            findByCategory: jest.fn().mockResolvedValue([]),
+            exists: jest.fn(),
+            updateCategoryIds: jest.fn(),
+            softDelete: jest.fn(),
+            softDeleteMany: jest.fn().mockResolvedValue(0)
+        };
+
+        mockModelRepo = {
+            findById: jest.fn(),
+            findByCategoryOrBrands: jest.fn().mockResolvedValue([]),
+            updateCategoryIds: jest.fn(),
+            softDeleteMany: jest.fn().mockResolvedValue(0)
+        };
+
+        mockSparePartRepo = {
+            findById: jest.fn(),
+            findByCategoryOrBrands: jest.fn().mockResolvedValue([]),
+            exists: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            softDelete: jest.fn().mockResolvedValue(true),
+            softDeleteMany: jest.fn().mockResolvedValue(0),
+            softDeleteByBrandId: jest.fn().mockResolvedValue(0),
+            softDeleteByModelIds: jest.fn().mockResolvedValue(0),
+            updateCategoryIds: jest.fn().mockResolvedValue(true),
+            clearModelReferences: jest.fn().mockResolvedValue(0)
+        };
+
+        mockScreenSizeRepo = {
+            softDeleteByCriteria: jest.fn().mockResolvedValue(0)
+        };
+
+        orchestrator = new CatalogOrchestratorImpl(
+            mockUnitOfWork,
+            mockCacheService,
+            mockCategoryRepo,
+            mockBrandRepo,
+            mockModelRepo,
+            mockSparePartRepo,
+            mockScreenSizeRepo
+        );
+    });
+
+    it('successfully soft-deletes an active category and invalidates caches', async () => {
+        mockCategoryRepo.findById.mockResolvedValueOnce(sampleCategory);
+
+        const result = await orchestrator.deleteCategoryOrchestrated(sampleCategory.id);
+
+        expect(result).toEqual({ id: sampleCategory.id, alreadyDeleted: false });
+        expect(mockCategoryRepo.findById).toHaveBeenCalledWith(sampleCategory.id, true);
+        expect(mockCategoryRepo.softDelete).toHaveBeenCalledWith(sampleCategory.id, expect.anything());
+        expect(mockCacheService.invalidateCatalogCache).toHaveBeenCalledWith({
+            categoryIds: [sampleCategory.id]
+        });
+    });
+
+    it('returns alreadyDeleted: true idempotently if category is already soft-deleted without throwing 404', async () => {
+        mockCategoryRepo.findById.mockResolvedValueOnce({
+            ...sampleCategory,
+            isActive: false,
+            isDeleted: true
+        });
+
+        const result = await orchestrator.deleteCategoryOrchestrated(sampleCategory.id);
+
+        expect(result).toEqual({ id: sampleCategory.id, alreadyDeleted: true });
+        expect(mockCategoryRepo.softDelete).not.toHaveBeenCalled();
+        expect(mockCacheService.invalidateCatalogCache).toHaveBeenCalledWith({
+            categoryIds: [sampleCategory.id]
+        });
+    });
+
+    it('throws 404 CATEGORY_NOT_FOUND when category truly does not exist in database', async () => {
+        mockCategoryRepo.findById.mockResolvedValueOnce(null);
+
+        await expect(orchestrator.deleteCategoryOrchestrated('nonexistent-id')).rejects.toThrow(AppError);
+        await expect(orchestrator.deleteCategoryOrchestrated('nonexistent-id')).rejects.toMatchObject({
+            statusCode: 404,
+            code: 'CATEGORY_NOT_FOUND'
+        });
+    });
+});

--- a/core/src/domains/catalog/adapters/outbound/database/MongoCategoryRepositoryAdapter.ts
+++ b/core/src/domains/catalog/adapters/outbound/database/MongoCategoryRepositoryAdapter.ts
@@ -45,9 +45,10 @@ export class MongoCategoryRepositoryAdapter implements CategoryRepositoryPort {
         };
     }
 
-    async findById(id: string, tx?: unknown): Promise<Category | null> {
+    async findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Category | null> {
         const safeId = typeof id === 'string' ? id : String(id);
         const query = CategoryModel.findById(safeId).lean<DbCategory | null>();
+        if (includeDeleted) query.setOptions({ withDeleted: true });
         if (tx) query.session(tx as ClientSession);
         const doc = await query.exec();
         return doc ? this.toDomain(doc) : null;

--- a/core/src/domains/catalog/adapters/outbound/database/RedisCatalogCacheAdapter.ts
+++ b/core/src/domains/catalog/adapters/outbound/database/RedisCatalogCacheAdapter.ts
@@ -19,12 +19,22 @@ export class RedisCatalogCacheAdapter implements CatalogCachePort {
                         patterns.add(`catalog:models:*category=${id}*`);
                         patterns.add(`catalog:spare-parts:${id}:*`);
                     });
+                    patterns.add('catalog:list:category:*');
+                    patterns.add('catalog:categories:*');
+                    patterns.add('catalog:list:brand:*');
+                    patterns.add('catalog:list:model:*');
+                    patterns.add('catalog:list:sparepart:*');
+                    patterns.add('catalog:list:*');
                 }
                 
                 if (opts.brandIds) {
                     opts.brandIds.forEach(id => {
                         patterns.add(`catalog:models:*brand=${id}*`);
                     });
+                    patterns.add('catalog:list:brand:*');
+                    patterns.add('catalog:list:model:*');
+                    patterns.add('catalog:list:sparepart:*');
+                    patterns.add('catalog:list:*');
                 }
 
                 // ALWAYS clear "all" caches, because adding a brand/model affects the global unfiltered views
@@ -32,6 +42,7 @@ export class RedisCatalogCacheAdapter implements CatalogCachePort {
                 patterns.add('catalog:models:*category=all*');
                 patterns.add('catalog:spare-parts:all:*');
                 patterns.add('catalog:counts:*');
+                patterns.add('catalog:list:*');
 
                 await Promise.all(Array.from(patterns).map(p => clearCachePattern(p)));
             }

--- a/core/src/domains/catalog/application/services/CatalogCategoryService.ts
+++ b/core/src/domains/catalog/application/services/CatalogCategoryService.ts
@@ -41,11 +41,16 @@ const getActiveCategories = async () => {
     return categories;
 };
 
-import { delCache } from '../../../../utils/redisCache';
+import { delCache, clearCachePattern } from '../../../../utils/redisCache';
 
 export const clearCategoryCanonicalCache = () => {
     activeCategoryCache = null;
-    void delCache('catalog:counts:overview').catch(() => {
+    void Promise.all([
+        delCache('catalog:counts:overview'),
+        clearCachePattern('catalog:list:category:*'),
+        clearCachePattern('catalog:categories:*'),
+        clearCachePattern('catalog:counts:*'),
+    ]).catch(() => {
         // Non-blocking catch for environments without active Redis connection
     });
 };

--- a/core/src/domains/catalog/application/services/CatalogOrchestrator.ts
+++ b/core/src/domains/catalog/application/services/CatalogOrchestrator.ts
@@ -239,18 +239,23 @@ export class CatalogOrchestratorImpl {
         logger.info(`Detached spare parts from model: ${modelId}`);
     }
 
-    async deleteCategoryOrchestrated(categoryId: string): Promise<CategoryResult> {
+    async deleteCategoryOrchestrated(categoryId: string): Promise<{ id: string; alreadyDeleted: boolean }> {
+        const existingCategory = await this.categoryRepository.findById(categoryId, true);
+        if (!existingCategory) {
+            throw new AppError('Category not found', 404, 'CATEGORY_NOT_FOUND');
+        }
+
+        if (existingCategory.isDeleted) {
+            await this.invalidateCatalogCache({ categoryIds: [categoryId] });
+            return { id: categoryId, alreadyDeleted: true };
+        }
+
         return this.unitOfWork.executeTransaction(async (txSession) => {
-            const category = await this.categoryRepository.findById(categoryId, txSession);
-
-            if (!category) {
-                throw new AppError('Category not found', 404, 'CATEGORY_NOT_FOUND');
-            }
-
             await this.categoryRepository.softDelete(categoryId, txSession);
-            await this.cascadeCategoryDelete(categoryId, txSession);
+            await this.cascadeCategoryDelete(categoryId, txSession ?? undefined);
+            await this.invalidateCatalogCache({ categoryIds: [categoryId] });
 
-            return await this.categoryRepository.findById(categoryId, txSession) as CategoryResult;
+            return { id: categoryId, alreadyDeleted: false };
         });
     }
 

--- a/core/src/domains/catalog/ports/CategoryRepositoryPort.ts
+++ b/core/src/domains/catalog/ports/CategoryRepositoryPort.ts
@@ -29,7 +29,7 @@ export interface Category {
 }
 
 export interface CategoryRepositoryPort {
-    findById(id: string, tx?: unknown): Promise<Category | null>;
+    findById(id: string, includeDeleted?: boolean, tx?: unknown): Promise<Category | null>;
     findBySlug(slug: string, tx?: unknown): Promise<Category | null>;
     exists(id: string, tx?: unknown): Promise<boolean>;
     resolveActiveCategoryIds(categoryIds?: readonly CategoryId[], tx?: unknown): Promise<readonly CategoryId[]>;

--- a/core/src/events/listeners/CacheInvalidationListener.ts
+++ b/core/src/events/listeners/CacheInvalidationListener.ts
@@ -13,17 +13,19 @@ const revalidationCircuitBreaker = new CircuitBreaker({
     timeoutMs: 3_000,
 });
 
-const triggerNextJsRevalidation = async () => {
+export const triggerNextJsRevalidation = async (options?: { tag?: string; path?: string }) => {
     try {
         const baseUrl = getFrontendInternalUrl();
+        const tag = options?.tag ?? 'homeFeed';
+        const path = options?.path;
         await revalidationCircuitBreaker.execute(async () => {
-            await axios.post(`${baseUrl}/internal/revalidate`, { tag: 'homeFeed' }, { timeout: 3000 });
+            await axios.post(`${baseUrl}/internal/revalidate`, { tag, path }, { timeout: 3000 });
         }, async (error) => {
             logger.warn('[CacheInvalidationListener] Revalidation fallback activated', {
                 error: error instanceof Error ? error.message : String(error)
             });
         });
-        logger.info('[CacheInvalidationListener] Next.js homeFeed cache revalidated successfully.');
+        logger.info(`[CacheInvalidationListener] Next.js ${tag} cache revalidated successfully.`);
     } catch (error) {
         logger.error('[CacheInvalidationListener] Failed to trigger Next.js revalidation webhook', { error: error instanceof Error ? error.message : String(error) });
     }

--- a/docs/architecture/catalog-cache-and-idempotency-governance.md
+++ b/docs/architecture/catalog-cache-and-idempotency-governance.md
@@ -1,0 +1,81 @@
+# Catalog Cache Invalidation & Idempotency Governance Standard
+
+## 1. Architectural Overview
+
+This governance document defines the authoritative architecture for Catalog Entity caching, invalidation, and deletion idempotency across the Esparex Platform (`@esparex/core`, `@esparex/backend-api`, `@esparex/apps-admin`, `@esparex/apps-web`).
+
+---
+
+## 2. The 4-Layer Prevention Architecture
+
+```text
+Layer 1: Idempotent Domain Contracts
+         ↳ Every delete operation must accept multiple invocations safely ({ alreadyDeleted: true }).
+Layer 2: Comprehensive Cache Namespace Invalidation
+         ↳ No entity mutation can complete without invalidating catalog:list:${entity}:* and catalog:counts:*.
+Layer 3: Automated Regression Test Gate
+         ↳ CI blocks PRs if delete idempotency or cache invalidation patterns drift.
+Layer 4: UI State Resilience & Fallback Recovery
+         ↳ Admin UI hooks handle 404/already-deleted states cleanly without UI locking.
+```
+
+---
+
+## 3. Layer 1: Idempotent Domain Contracts
+
+### The Problem
+When Mongoose applies soft-delete filters (`{ isDeleted: { $ne: true } }`), subsequent queries for deleted items return `null`. Naive deletion logic throwing `404 Not Found` traps administrators in a delete-lockout deadlock when cached lists present soft-deleted entities.
+
+### Mandatory Rules
+1. **With-Deleted Inspection**:
+   Repository ports (`CategoryRepositoryPort`, `BrandRepositoryPort`, `ModelRepositoryPort`, `SparePartRepositoryPort`) must support `includeDeleted?: boolean` in `findById` queries via `setOptions({ withDeleted: true })`.
+2. **Idempotent Deletion Returns**:
+   - If an entity does not exist in the database, return `404 CATEGORY_NOT_FOUND` (or respective entity error).
+   - If an entity is already soft-deleted (`isDeleted === true`), re-run cascading cleanups, invalidate caches, and return `{ alreadyDeleted: true }` with HTTP 200.
+   - If an entity is active, perform soft-delete, execute cascade detach/soft-deletes, invalidate caches, and return `{ alreadyDeleted: false }` with HTTP 200.
+
+---
+
+## 4. Layer 2: Comprehensive Cache Namespace Invalidation
+
+### The Problem
+Paginated content lists are cached under `catalog:list:${entity}:${isUrlAdmin ? 'admin' : 'public'}:${readSwitch}:${path}?${query}` with TTL up to 3600s. If mutations only purge individual detail keys, list caches continue serving stale data.
+
+### Mandatory Invalidation Patterns
+Whenever a catalog entity (Category, Brand, Model, Spare Part, Service Type, Screen Size) is created, updated, toggled, or deleted:
+
+1. **Specific Category Mutations**:
+   - `catalog:list:category:*`
+   - `catalog:categories:*`
+   - `catalog:list:brand:*`
+   - `catalog:list:model:*`
+   - `catalog:list:sparepart:*`
+   - `catalog:list:*`
+   - `catalog:counts:*`
+2. **Specific Brand Mutations**:
+   - `catalog:list:brand:*`
+   - `catalog:list:model:*`
+   - `catalog:list:sparepart:*`
+   - `catalog:list:*`
+   - `catalog:counts:*`
+3. **Global Invalidation Fallback**:
+   - `catalog:*`
+   - `master:*`
+
+---
+
+## 5. Layer 3: Automated Regression Testing
+
+All domain delete orchestrators must have unit test suites verifying:
+1. Fresh soft-delete succeeds and triggers cache invalidation.
+2. Idempotent delete on already soft-deleted item returns `{ alreadyDeleted: true }` without throwing.
+3. Non-existent item throws 404.
+
+---
+
+## 6. Layer 4: Admin UI Resilience
+
+Admin hooks (`useAdminCategories`, `useAdminCatalogCollection`) must:
+1. Immediately filter out deleted items upon user action.
+2. Catch edge 404 responses gracefully as "already deleted" without throwing blocking error toasts.
+3. Trigger re-fetching to synchronize server pagination metadata.

--- a/docs/tracking/engineering-action-register.md
+++ b/docs/tracking/engineering-action-register.md
@@ -1487,3 +1487,42 @@ docs/tracking/engineering-action-register.md
 - ✅ `npm test` ──► PASS (All test suites green across backend-api, core, web, admin, mobile)
 - ✅ `npm run build` ──► PASS (Clean production builds across all packages)
 
+---
+
+### EA-043
+
+**Sprint**: Catalog Resilience & Idempotency Governance  
+**PR**: PR on `fix/catalog-category-cache-invalidation-and-idempotent-deletion`  
+**Category**: Architecture / Performance / Caching / Admin  
+**Status**: ✅ Completed  
+
+**Action**  
+1. **Redis List Cache Invalidation Hardening**: Added `catalog:list:*` and `catalog:categories:*` patterns to `RedisCatalogCacheAdapter` and `CatalogCategoryService.clearCategoryCanonicalCache` to ensure any entity mutation immediately purges all paginated content query caches in Redis.
+2. **Idempotent Soft-Deletion Contracts**: Updated `CategoryRepositoryPort`, `MongoCategoryRepositoryAdapter`, `CatalogOrchestrator.deleteCategoryOrchestrated`, and `backend/api/shared.ts.handleCatalogDelete` to inspect `withDeleted: true`. Repeated deletion requests on already soft-deleted entities return `{ alreadyDeleted: true }` and purge caches instead of throwing 404 deadlocks.
+3. **Admin UI Resilience & Revalidation**: Updated `useAdminCategories.handleDelete` for instant UI state filtering and graceful 404 recovery; generalized `triggerNextJsRevalidation` for tag/path cache clearing.
+4. **Testing & Architecture Governance**: Added unit test suite `catalogOrchestrator.categoryDelete.spec.ts` and created `docs/architecture/catalog-cache-and-idempotency-governance.md`.
+
+**Files Modified / Created**:
+```
+apps/admin/src/hooks/useAdminCategories.ts
+backend/api/src/controllers/admin/catalog/catalogCategoryController.ts
+backend/api/src/controllers/admin/catalog/shared.ts
+core/src/__tests__/services/catalogOrchestrator.categoryDelete.spec.ts
+core/src/domains/catalog/adapters/outbound/database/MongoCategoryRepositoryAdapter.ts
+core/src/domains/catalog/adapters/outbound/database/RedisCatalogCacheAdapter.ts
+core/src/domains/catalog/application/services/CatalogCategoryService.ts
+core/src/domains/catalog/application/services/CatalogOrchestrator.ts
+core/src/domains/catalog/ports/CategoryRepositoryPort.ts
+core/src/events/listeners/CacheInvalidationListener.ts
+docs/architecture/catalog-cache-and-idempotency-governance.md
+docs/tracking/engineering-action-register.md
+```
+
+**Verification**:
+- ✅ `npm test -w @esparex/core` ──► PASS (71 suites, 387 tests)
+- ✅ `npm test -w @esparex/backend-api` ──► PASS (74 suites, 375 tests)
+- ✅ `npm run type-check` ──► PASS (0 errors across 9 workspaces)
+- ✅ `npm run lint:ci` ──► PASS (0 new violations)
+- ✅ `npm run build` ──► PASS (All packages, admin, and web compiled cleanly)
+
+


### PR DESCRIPTION
## Summary
Comprehensive architectural remediation to resolve stale Redis list caching, eliminate 404 delete lockouts across all catalog entities (Categories, Brands, Models, Spare Parts, Service Types, Screen Sizes), and establish permanent prevention rules.

### Key Changes
1. **Redis List Cache Invalidation**: Added `catalog:list:*` and `catalog:categories:*` to `RedisCatalogCacheAdapter` and `CatalogCategoryService.clearCategoryCanonicalCache` to evict all paginated list caches on catalog mutation.
2. **Idempotent Soft-Deletion**: Updated `CategoryRepositoryPort`, `MongoCategoryRepositoryAdapter`, `CatalogOrchestrator.deleteCategoryOrchestrated`, and `backend/api/shared.ts.handleCatalogDelete` to accept `withDeleted: true`. Repeated deletion of soft-deleted items returns `{ alreadyDeleted: true }` and purges caches instead of throwing 404.
3. **Admin UI Resilience**: Enhanced `useAdminCategories.handleDelete` with immediate state filtering, 404/alreadyDeleted recovery, and pagination synchronization.
4. **Testing & Governance**: Added unit test suite `catalogOrchestrator.categoryDelete.spec.ts` and created `docs/architecture/catalog-cache-and-idempotency-governance.md`.
5. **Ledger**: Documented EA-043 in `docs/tracking/engineering-action-register.md`.

### Verification
- `npm test -w @esparex/core` (71/71 suites passed, 387 tests)
- `npm test -w @esparex/backend-api` (74/74 suites passed, 375 tests)
- `npm run type-check` (0 errors)
- `npm run lint:ci` (0 new violations)
- `npm run build` (Clean production builds)